### PR TITLE
BUG: lat, lon incorrect when using grid_origin.

### DIFF
--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -127,8 +127,10 @@ def grid_from_radars(radars, grid_shape, grid_limits, **kwargs):
              'positive': 'up'}
 
     # grid origin location dictionaries
-    if 'origin' in kwargs:
-        lat, lon, alt = kwargs['origin']
+    if 'grid_origin' in kwargs:
+        lat = np.array([kwargs['grid_origin'][0]])
+        lon = np.array([kwargs['grid_origin'][1]])
+        alt = first_radar.altitude['data']
     else:
         lat = first_radar.latitude['data']
         lon = first_radar.longitude['data']

--- a/pyart/map/tests/test_map.py
+++ b/pyart/map/tests/test_map.py
@@ -82,3 +82,13 @@ def test_grid_from_radars():
                        np.linspace(-900, 900, 9).astype('float64'))
     assert_array_equal(grid.axes['z_disp']['data'],
                        np.linspace(-400, 400, 3).astype('float64'))
+
+
+def test_grid_from_radars_grid_origin():
+    radar = pyart.testing.make_target_radar()
+    grid = pyart.map.grid_from_radars((radar,), grid_origin=(36.4, -97.6),
+                                      **COMMON_MAP_TO_GRID_ARGS)
+    print round(grid.axes['lat']['data'][0], 2)
+    print round(grid.axes['lon']['data'][0], 2)
+    assert round(grid.axes['lat']['data'][0], 2) == 36.4
+    assert round(grid.axes['lon']['data'][0], 2) == -97.6


### PR DESCRIPTION
When a grid was created using map_to_grid the lat and lon keys in the
axes attribute did not reflect the correct location of the grid origin.

Created a test to detect this bug and corrected it.
