### PR TITLE
ENH: objective analysis

### DIFF
--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -435,7 +435,7 @@ def map_to_grid(radars, grid_shape, grid_dimensions, grid_origin=None,
     # create arrays to hold the gate locations and indicators if the gate
     # should be included in the interpolation
     gate_locations = np.empty((total_gates, 3), dtype=np.float64)
-    include_gate = np.ones((total_gates, 1), dtype=np.bool)
+    include_gate = np.ones(total_gates, dtype=np.bool)
     
     # offsets from the grid origin in meters for each radar
     offsets = []

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -387,9 +387,9 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
     """
     # check the parameters
     if weighting_function.upper() not in ['CRESSMAN', 'BARNES']:
-        raise ValueError('unknown weighting_function')
+        raise ValueError('Unknown weighting_function')
     if algorithm not in ['kd_tree', 'ball_tree']:
-        raise ValueError('unknow algorithm: %s' % algorithm)
+        raise ValueError('Unknown algorithm: %s' %algorithm)
     badval = get_fillvalue()
 
     # find the grid origin if not given
@@ -554,7 +554,7 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
             roi_func = _gen_roi_func_dist_beam(
                 h_factor, nb, bsp, min_radius, offsets)
         else:
-            raise ValueError('unknown roi_func: %s' % roi_func)
+            raise ValueError('Unknown roi_func: %s' %roi_func)
 
     # create array to hold interpolated grid data and roi if requested
     grid_data = np.ma.empty((nz, ny, nx, nfields), dtype=np.float64)
@@ -598,13 +598,20 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
             _load_nn_field_data(field_data_objs, nfields, npoints, r_nums,
                                 e_nums, nn_field_data)
 
-        # preforms weighting of neighbors.
+        # performs weighting of neighbors
         dist2 = dist * dist
         r2 = r * r
-
+        
+        # the Cressman filter (weight) is a function of the radial distance
+        # separating an analysis point from a data point (r) and the radius
+        # of influence (Rc) parameter
         if weighting_function.upper() == 'CRESSMAN':
             weights = (r2 - dist2) / (r2 + dist2)
             value = np.ma.average(nn_field_data, weights=weights, axis=0)
+            
+        # the Barnes filter (weight) is a function of the radial distance
+        # separating an analysis point from a data point (r) and the
+        # smoothing parameter (k)
         elif weighting_function.upper() == 'BARNES':
             w = np.exp(-dist2 / (2.0 * r2)) + 1e-5
             w /= np.sum(w)


### PR DESCRIPTION
This is my initial attempt at enhancing certain components of the mapping routine. The improvements in this PR targets two areas:

1. A non-uniform grid can now specified, e.g. a grid that has higher resolution in the ABL and thins out aloft. This was an easy fix, and involved removing the `grid_shape` and `grid_limits` variables and allowing a user to input his/her own `grid_dimensions` variable.
2. Changing the Barnes weight to reflect the literature, primarily Trapp and Doswell (2000). The free parameter for a Barnes weight is the smoothing parameter, not the radius of influence like that of the Cressman weight.

As of this PR, only a constant smoothing parameter can be specified for the Barnes weight. This smoothing parameter depends on the non-dimensional smoothing parameter and the data spacing. They argue that "in terms of preservation of the phase and amplitude of the input data, predictability of the resultant smoothing and filtering, and relative insensitivity to input data unsteadiness or spatial characteristics, the isotropic Barnes weight function with constant smoothing parameter appears to be the most desirable of the schemes considered." See Trapp and Doswell (2000) for more information.