### PR TITLE
Created aux reader submodule, moved gamic_hdf5 to aux reader

### DIFF
--- a/pyart/io/aux_reader/__init__.py
+++ b/pyart/io/aux_reader/__init__.py
@@ -1,0 +1,22 @@
+"""
+==================================
+Input and output (:mod:`pyart.io.aux_reader`)
+==================================
+
+.. currentmodule:: pyart.io.auxreader
+
+Py-ART has modules, classes and functions which are able to read data
+from and write data to a number of file formats.
+
+
+    read_gamic
+
+"""
+
+try:
+    from .gamic_hdf5 import read_gamic
+    _HDF5_AVAILABLE = True
+except:
+    _HDF5_AVAILABLE = False
+
+__all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/io/aux_reader/gamic_hdf5.py
+++ b/pyart/io/aux_reader/gamic_hdf5.py
@@ -1,5 +1,5 @@
 """
-pyart.io.read_gamic
+pyart.io.aux_reader.read_gamic
 =================
 
 Utilities for reading gamic hdf5 files.
@@ -18,9 +18,9 @@ import datetime
 import h5py
 import numpy as np
 
-from ..config import FileMetadata
-from .common import make_time_unit_str
-from .radar import Radar
+from ...config import FileMetadata
+from ..common import make_time_unit_str
+from ..radar import Radar
 
 
 def read_gamic(filename, field_names=None, additional_metadata=None,

--- a/pyart/io/aux_reader/setup.py
+++ b/pyart/io/aux_reader/setup.py
@@ -1,0 +1,11 @@
+
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('aux_reader', parent_package, top_path)
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/pyart/setup.py
+++ b/pyart/setup.py
@@ -10,6 +10,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('retrieve')
     config.add_subpackage('testing')
     config.add_subpackage('util')
+    config.add_subpackage('io/aux_reader')
 
     config.add_data_dir('tests')
     return config


### PR DESCRIPTION
(Second Attempt) This PR creates a submodule in io called pyart.io.aux_reader and moves the gamic_hdf5 reader into this submodule. I did not see any tests for this function so nothing was touched there, and I believe I modified all of the setup.py stuff correctly but please double check it.
