### PR TITLE
ENH: pulse_width included when reading Sigmet files.

### DIFF
--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -291,6 +291,12 @@ DEFAULT_METADATA = {
         'meta_group': 'instrument_parameters',
         'long_name': 'Unambiguous range'},
 
+    'pulse_width': {
+        'units': 'seconds',
+        'comments': 'Pulse width',
+        'meta_group': 'instrument_parameters',
+        'long_name': 'Pulse width'},
+
     # Metadata for radar_parameter sub-convention
     'radar_beam_width_h': {
         'units': 'degrees',

--- a/pyart/io/sigmet.py
+++ b/pyart/io/sigmet.py
@@ -237,6 +237,7 @@ def read_sigmet(filename, field_names=None, additional_metadata=None,
     unambiguous_range = filemetadata('unambiguous_range')
     beam_width_h = filemetadata('radar_beam_width_h')
     beam_width_v = filemetadata('radar_beam_width_v')
+    pulse_width = filemetadata('pulse_width')
 
     trays = nsweeps * nrays     # this is correct even with missing rays
     prt_value = 1. / sigmetfile.product_hdr['product_end']['prf']
@@ -258,12 +259,16 @@ def read_sigmet(filename, field_names=None, additional_metadata=None,
     beam_width_v['data'] = np.array([bin4_to_angle(
         task_config['task_misc_info']['vertical_beamwidth'])],
         dtype='float32')
+    pulse_width['data'] = np.array(
+        [task_config['task_dsp_info']['pulse_width'] * 1e-5] *
+        len(time['data']), dtype='float32')
 
     instrument_parameters = {'unambiguous_range': unambiguous_range,
                              'prt_mode': prt_mode, 'prt': prt,
                              'nyquist_velocity': nyquist_velocity,
                              'radar_beam_width_h': beam_width_h,
-                             'radar_beam_width_v': beam_width_v}
+                             'radar_beam_width_v': beam_width_v,
+                             'pulse_width': pulse_width}
 
     return Radar(
         time, _range, fields, metadata, scan_type,

--- a/pyart/io/tests/test_sigmet.py
+++ b/pyart/io/tests/test_sigmet.py
@@ -159,7 +159,8 @@ def test_antenna_transition():
 # instrument_parameters attribute
 def test_instument_parameters():
     # instrument_parameter sub-convention
-    keys = ['prt', 'unambiguous_range', 'prt_mode', 'nyquist_velocity']
+    keys = ['prt', 'unambiguous_range', 'prt_mode', 'nyquist_velocity',
+            'pulse_width']
     for k in keys:
         description = 'instrument_parameters: %s' % k
         check_instrument_parameter.description = description


### PR DESCRIPTION
The radar pulse width is extracted when reading Sigmet files and
included in the instrument_parameters attribute of the returned
Radar object under the 'pulse_width' key.  The 'data' array contains the pulse
width in seconds for each time point, these widths are always the same.
