### PR TITLE
BUG: python-netcdf4 version 1.1.0 supported.

### DIFF
--- a/pyart/graph/plot_cfradial.py
+++ b/pyart/graph/plot_cfradial.py
@@ -95,8 +95,8 @@ class CFRadialDisplay(RadarDisplay):
         self.y = self.y + self.shift[1]
 
         # radar location in latitude and longitude
-        lon = dataset.variables['longitude'][0]
-        lat = dataset.variables['latitude'][0]
+        lon = dataset.variables['longitude'][:]
+        lat = dataset.variables['latitude'][:]
         self.loc = [lat, lon]
 
         # datetime object describing first sweep time

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -260,6 +260,11 @@ def _ncvar_to_dict(ncvar):
     """ Convert a NetCDF Dataset variable to a dictionary. """
     d = dict((k, getattr(ncvar, k)) for k in ncvar.ncattrs())
     d['data'] = ncvar[:]
+    if np.isscalar(d['data']):
+        # netCDF4 1.1.0+ returns a scalar for 0-dim array, we always want
+        # 1-dim+ arrays with a valid shape.
+        d['data'] = np.array(d['data'])
+        d['data'].shape = (1, )
     return d
 
 

--- a/pyart/io/tests/test_cfradial.py
+++ b/pyart/io/tests/test_cfradial.py
@@ -295,7 +295,7 @@ def test_write_ppi_arm_time_vars():
     assert 'time_offset' in dset.variables
 
     base_time = dset.variables['base_time']
-    assert base_time[0] == 1305888856
+    assert base_time[:] == 1305888856
     assert base_time.string == '20-May-2011,10:54:16 GMT'
 
     time_offset = dset.variables['time_offset']


### PR DESCRIPTION
With version 1.0.9 of netcdf4-python, the method of accessing data in 0-dimensional arrays changed to be more like NumPy.  This required minor changes to Py-ART.  For additional details on the change see [issue 220](https://github.com/Unidata/netcdf4-python/pull/220) of the netcdf4-python repository.
