### PR TITLE
BUG: Treat radar coordinates as gate centers in plots

### DIFF
--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -11,6 +11,10 @@ Common graphing routines.
     radar_coords_to_cart
     corner_to_point
     ax_radius
+    sweep_coords_to_cart
+    _interpolate_range_edges
+    _interpolate_elevation_edges
+    _interpolate_azimuth_edges
 
 """
 
@@ -73,3 +77,75 @@ def ax_radius(lat, units='radians'):
         const = 1.0
     R = Re * np.sin(PI / 2.0 - abs(lat * const))
     return R
+
+
+def sweep_coords_to_cart(ranges, azimuths, elevations, edges=False):
+    """
+    Calculate Cartesian coordinate for the gates in a single radar sweep.
+
+    Calculates the Cartesian coordinates for the gate centers or edges for
+    all gates in a single sweep assuming a standard atmosphere (4/3 Earth's
+    radius model). See :py:func:`pyart.io.common.radar_coords_to_cart` for
+    details.
+
+    Parameters
+    ----------
+    ranges : array, 1D.
+        Distances to the center of the radar gates (bins) in meters.
+    azimuths : array, 1D.
+        Azimuth angles of the sweep in degrees.
+    elevations : array, 1D.
+        Elevation angles of the sweep in degrees.
+    edges : bool, optional
+        True to calculate the coordinates of the gate edges by interpolating
+        between gates and extrapolating at the boundaries.  False to
+        calculate the gate centers.
+
+    Returns
+    -------
+    x, y, z : array, 2D
+        Cartesian coordinates in meters from the center of the radar to the
+        gate centers or edges.
+
+    """
+    if edges:
+        ranges = _interpolate_range_edges(ranges)
+        elevations = _interpolate_elevation_edges(elevations)
+        azimuths = _interpolate_azimuth_edges(azimuths)
+    rg, azg = np.meshgrid(ranges, azimuths)
+    rg, eleg = np.meshgrid(ranges, elevations)
+    return radar_coords_to_cart(rg / 1000., azg, eleg)
+
+
+def _interpolate_range_edges(ranges):
+    """ Interpolate the edges of the range gates from their centers. """
+    edges = np.empty((ranges.shape[0] + 1, ), dtype=ranges.dtype)
+    edges[1:-1] = (ranges[:-1] + ranges[1:]) / 2.
+    edges[0] = ranges[0] - (ranges[1] - ranges[0]) / 2.
+    edges[-1] = ranges[-1] - (ranges[-2] - ranges[-1]) / 2.
+    edges[edges < 0] = 0    # do not allow range to become negative
+    return edges
+
+
+def _interpolate_elevation_edges(elevations):
+    """ Interpolate the edges of the elevation angles from their centers. """
+    edges = np.empty((elevations.shape[0]+1, ), dtype=elevations.dtype)
+    edges[1:-1] = (elevations[:-1] + elevations[1:]) / 2.
+    edges[0] = elevations[0] - (elevations[1] - elevations[0]) / 2.
+    edges[-1] = elevations[-1] - (elevations[-2] - elevations[-1]) / 2.
+    edges[edges > 180] = 180.   # prevent angles from going below horizon
+    edges[edges < 0] = 0.
+    return edges
+
+
+def _interpolate_azimuth_edges(azimuths):
+    """ Interpolate the edges of the azimuth angles from their centers. """
+    edges = np.empty((azimuths.shape[0]+1, ), dtype=azimuths.dtype)
+    # perform interpolation and extrapolation in complex plane to
+    # account for periodic nature of azimuth angle.
+    az = np.exp(1.j*np.deg2rad(azimuths))
+    edges[1:-1] = np.angle((az[1:] + az[:-1]) / 2., deg=True)
+    edges[0] = np.angle(az[0] - (az[1] - az[0]) / 2., deg=True)
+    edges[-1] = np.angle(az[-1] - (az[-2] - az[-1]) / 2., deg=True)
+    edges[edges < 0] += 360     # range from [-180, 180] to [0, 360]
+    return edges

--- a/pyart/graph/plot_cfradial.py
+++ b/pyart/graph/plot_cfradial.py
@@ -152,7 +152,7 @@ class CFRadialDisplay(RadarDisplay):
     def _get_data(self, field, sweep, mask_tuple):
         """ Retrieve and return data from a plot function. """
         start = self.starts[sweep]
-        end = self.ends[sweep]
+        end = self.ends[sweep] + 1
         data = self.dataset.variables[field][start:end]
 
         if mask_tuple is not None:

--- a/pyart/graph/plot_mdv.py
+++ b/pyart/graph/plot_mdv.py
@@ -114,14 +114,16 @@ class MdvDisplay(RadarDisplay):
             data = np.ma.masked_where(mdata < mask_value, data)
         return data
 
-    def _get_x_y(self, field, sweep):
+    def _get_x_y(self, field, sweep, edges):
         """ Retrieve and return x and y coordinate in km. """
+        # TODO perform interpolating if edges is True
         x = self.mdvfile.carts['x'][sweep] / 1000.0  # x coords in km
         y = self.mdvfile.carts['y'][sweep] / 1000.0  # y coords in km
         return x, y
 
-    def _get_x_y_z(self, field, sweep):
+    def _get_x_y_z(self, field, sweep, edges):
         """ Retrieve and return x, y, and z coordinate in km. """
+        # TODO perform interpolating if edges is True
         x = self.mdvfile.carts['x'][sweep] / 1000.0  # x coords in km
         y = self.mdvfile.carts['y'][sweep] / 1000.0  # y coords in km
         z = self.mdvfile.carts['z'][sweep] / 1000.0  # y coords in km

--- a/pyart/graph/plot_rsl.py
+++ b/pyart/graph/plot_rsl.py
@@ -136,13 +136,15 @@ class RslDisplay(RadarDisplay):
             data = np.ma.masked_where(mdata < mask_value, data)
         return data
 
-    def _get_x_y(self, field, sweep):
+    def _get_x_y(self, field, sweep, edges):
         """ Retrieve and return x and y coordinate in km. """
-        x, y, z = self._get_x_y_z(field, sweep)
+        # TODO perform interpolating if edges is True
+        x, y, z = self._get_x_y_z(field, sweep, edges)
         return x, y
 
-    def _get_x_y_z(self, field, sweep):
+    def _get_x_y_z(self, field, sweep, edges):
         """ Retrieve and return x, y, and z coordinate in km. """
+        # TODO perform interpolating if edges is True
         volume_num = rsl.RSLNAME2VOLUMENUM[field]
         sweep = self.rslfile.get_volume(volume_num).get_sweep(sweep)
         ray = sweep.get_ray(0)

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -104,7 +104,7 @@ class RadarMapDisplay(RadarDisplay):
                      projection='lcc', area_thresh=10000,
                      min_lon=None, max_lon=None, min_lat=None, max_lat=None,
                      width=None, height=None, lon_0=None, lat_0=None,
-                     resolution='h', shapefile=None, **kwargs):
+                     resolution='h', shapefile=None, edges=True, **kwargs):
         """
         Plot a PPI volume sweep onto a geographic map.
 
@@ -178,6 +178,13 @@ class RadarMapDisplay(RadarDisplay):
         resolution : 'c', 'l', 'i', 'h', or 'f'.
             Resolution of boundary database to use. See Basemap documentation
             for details.
+        edges : bool
+            True will interpolate and extrapolate the gate edges from the
+            range, azimuth and elevations in the radar, treating these
+            as specifying the center of each gate.  False treats these
+            coordinates themselved as the gate edges, resulting in a plot
+            in which the last gate in each ray and the entire last ray are not
+            not plotted.
 
         """
         # parse parameters
@@ -194,7 +201,7 @@ class RadarMapDisplay(RadarDisplay):
 
         # get data for the plot
         data = self._get_data(field, sweep, mask_tuple)
-        x, y = self._get_x_y(field, sweep)
+        x, y = self._get_x_y(field, sweep, edges)
 
         # mask the data where outside the limits
         if mask_outside:

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -40,8 +40,8 @@ def test_radarmapdisplay_auto_range():
     fig = plt.figure()
     ax = fig.add_subplot(111)
     display.plot_ppi_map('reflectivity_horizontal', resolution='c')
-    assert round(display.basemap.latmax, 2) == 36.84
-    assert round(display.basemap.latmin, 2) == 36.14
+    assert round(display.basemap.latmax, 2) == 36.85
+    assert round(display.basemap.latmin, 2) == 36.13
     assert round(display.basemap.lonmax, 2) == -97.15
     assert round(display.basemap.lonmin, 2) == -98.04
     plt.close()


### PR DESCRIPTION
The range, azimuth, elevation coordinates in radar files typically specify
the center of the gate, when plotting Py-ART uses these coordinates to
interpolate and extrapolate the gates edges which are then used to plot
the data.

Prior to this the centers were used to plot which resulted in the plots
missing the last range gate and the last ray.

This pull request performs the interpolation and extrapolation in the antenna
 coordinate which allow for filtering of nonphysical edges.  Pull Request #178
does this interpolation in Cartesian space which does not offer this filtering.

Thanks to @deeplycloudy for pointing out this bug
