### PR TITLE
Add Grid datetime routine

### DIFF
--- a/pyart/util/datetime_utils.py
+++ b/pyart/util/datetime_utils.py
@@ -1,25 +1,31 @@
 """ Functions for converting date and time between various forms """
 
-import netCDF4
+from netCDF4 import num2date
 
 
 def datetime_from_radar(radar):
     """ Return a datetime for the first ray in a Radar. """
-    return netCDF4.num2date(radar.time['data'][0], radar.time['units'])
+    return num2date(radar.time['data'][0], radar.time['units'])
 
 
 def datetimes_from_radar(radar):
     """ Return an array of datetimes for the rays in a Radar. """
-    return netCDF4.num2date(radar.time['data'][:], radar.time['units'])
+    return num2date(radar.time['data'][:], radar.time['units'])
 
 
 def datetime_from_dataset(dataset):
     """ Return a datetime for the first time in a netCDF Dataset. """
-    return netCDF4.num2date(dataset.variables['time'][0],
-                            dataset.variables['time'].units)
+    return num2date(dataset.variables['time'][0],
+                    dataset.variables['time'].units)
 
 
 def datetimes_from_dataset(dataset):
     """ Return an array of datetimes for the times in a netCDF Dataset. """
-    return netCDF4.num2date(dataset.variables['time'][:],
-                            dataset.variables['time'].units)
+    return num2date(dataset.variables['time'][:],
+                    dataset.variables['time'].units)
+
+
+def datetime_from_grid(grid):
+    """ Return a datetime for the volume start in a Grid. """
+    return num2date(grid.axes['time_start']['data'][0],
+                    grid.axes['time_start']['units'])


### PR DESCRIPTION
I am adding a `datetime_from_grid` function to the `datetime_utils` module. This function should return the Python datetime corresponding to the volume start time of the `Grid`. @jjhelmus, this is a simple PR and it meets PEP 8 standards.
