### PR TITLE
Added module to core to allow the import of enumerated echo classes 

### DIFF
--- a/pyart/core/__init__.py
+++ b/pyart/core/__init__.py
@@ -19,6 +19,6 @@ Core Py-ART classes and function for interacting with weather radar data.
 
 from .radar import Radar, is_vpt, to_vpt
 from .grid import Grid
-from .echo_classes import *
+import echo_classes
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/core/__init__.py
+++ b/pyart/core/__init__.py
@@ -19,5 +19,6 @@ Core Py-ART classes and function for interacting with weather radar data.
 
 from .radar import Radar, is_vpt, to_vpt
 from .grid import Grid
+from .echo_classes import *
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/core/echo_classes.py
+++ b/pyart/core/echo_classes.py
@@ -19,10 +19,17 @@ CLASS_MULTITRIP = 3
 CLASS_LIQUID = 4
 CLASS_ICE = 5
 CLASS_MIXEDPHASE = 6
+CLASS_HAIL = 7
 
 
 #This string will be helpful when saving files etc.
 CLASS_METADATA = """Numerical classifications for dominant scatterer at gate:
 0: Returs for which there is no significant scattering
 1: Stationary persistant clutter.
-2: Non-stationary but non-weather related, eg birds/bragg etc"""
+2: Non-stationary but non-weather related, eg birds/bragg etc
+3: Multi-trip echoes beyond the MUR
+4: Liquid precipitation
+5: Solid (ice) precipitation
+6: Mixed ice and liquiq
+7: Dominant hail (ie hail contaminated)
+"""

--- a/pyart/core/echo_classes.py
+++ b/pyart/core/echo_classes.py
@@ -1,0 +1,28 @@
+"""
+pyart.core.echo_classes
+===============
+
+A Module where enumerated echo classifications are held
+
+.. autosummary::
+    :toctree: generated/
+    :template: dev_template.rst
+
+    echo_classes
+
+"""
+
+CLASS_NOISE = 0 #returs for which there is no significant scattering
+CLASS_CLUTTER = 1 #Stationary persistant clutter.
+CLASS_NONMETEO = 2 # Non-stationary but non-weather related, eg birds/bragg etc
+CLASS_MULTITRIP = 3
+CLASS_LIQUID = 4
+CLASS_ICE = 5
+CLASS_MIXEDPHASE = 6
+
+
+#This string will be helpful when saving files etc.
+CLASS_METADATA = """Numerical classifications for dominant scatterer at gate:
+0: Returs for which there is no significant scattering
+1: Stationary persistant clutter.
+2: Non-stationary but non-weather related, eg birds/bragg etc"""


### PR DESCRIPTION
in any module use: from pyart.core.echo_classes import * (or relative import)
This will populate namespace with CLASS_DESCRIPTOR
and CLASS_METADATA
CLASS_METADATA contains verbose descriptors intended for use in things like field['notes'] etc.. 

This module is added with the intent to grow as users/contributors add more classes.. But of course module developers do not need to use ALL classes.. eg a classification algorithm may only use classes 1,2 and 10 (eg clutter, non-meteo and a yet to be named class, let us call it "ships") 

Use of this module will unify enumerated classes.. it is expected future PRs will add to this.. The metadata string can be trimmed to use using searches between \n 

