### PR TITLE
BUG: Reading a corrupt sigmet file raises IOError

### DIFF
--- a/pyart/io/sigmet.py
+++ b/pyart/io/sigmet.py
@@ -116,6 +116,9 @@ def read_sigmet(filename, field_names=None, additional_metadata=None,
     sigmetfile.close()
     nsweeps, nrays, nbins = sigmet_data[first_data_type].shape
 
+    if nsweeps == 0:
+        raise IOError('File contains no readable sweep data.')
+
     # parse the extended headers for time
     if full_xhdr and 'XHDR' in sigmet_data:
         # extract the ms timing data and store the full header for later


### PR DESCRIPTION
Reading a Sigmet file which is corrupt before the end of the first sweep
raises a IOError.  Only a warning is issue when the file contains one or more
complete sweeps.

Calling the read_sigmet function with debug=True will provide details of where
the file is corrupt.
