### PR TITLE
BUG: relative import in odim_h5 module.

### DIFF
--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -11,14 +11,14 @@ Routines for reading ODIM_H5 files.
 
 """
 
-import numpy as np
-import h5py
 import datetime
 
-from pyart.config import FileMetadata, get_fillvalue
-from pyart.io.radar import Radar
-from pyart.io.common import make_time_unit_str
-from pyart.io.common import radar_coords_to_cart
+import numpy as np
+import h5py
+
+from ..config import FileMetadata, get_fillvalue
+from ..io.common import make_time_unit_str, radar_coords_to_cart
+from ..core.radar import Radar
 
 
 ODIM_H5_FIELD_NAMES = {


### PR DESCRIPTION
Corrected bug with invalid import of Radar object by replacing
absolute imports with relative imports.
