### PR TITLE
TST: Removed warnings and unnecessary screen output from tests

### DIFF
--- a/pyart/correct/dealias.py
+++ b/pyart/correct/dealias.py
@@ -143,9 +143,9 @@ def dealias_fourdd(radar, last_radar=None, sounding_heights=None,
     # TODO test with RHI radar scan
 
     # verify that sounding data or last_volume is provided
-    sounding_available = (
-        None not in [sounding_heights, sounding_wind_speeds,
-                     sounding_wind_direction])
+    sounding_available = ((sounding_heights is not None) and
+                          (sounding_wind_speeds is not None) and
+                          (sounding_wind_direction is not None))
     if (not sounding_available) and (last_radar is None):
         raise ValueError('sounding data or last_radar must be provided')
 

--- a/pyart/correct/tests/test_phase_proc.py
+++ b/pyart/correct/tests/test_phase_proc.py
@@ -50,6 +50,8 @@ def test_phase_proc_lp_glpk():
 
 @skipif(not cvxopt_available)
 def test_phase_proc_lp_cvxopt():
+    from cvxopt import solvers
+    solvers.options['LPX_K_MSGLEV'] = 0     # supress screen output
     radar, phidp, kdp = perform_phase_processing('cvxopt')
     ref = np.load(REFERENCE_RAYS_FILE)
     assert _ratio(ref['reference_phidp'], phidp['data']) <= 0.01

--- a/pyart/graph/plot_mdv.py
+++ b/pyart/graph/plot_mdv.py
@@ -111,7 +111,7 @@ class MdvDisplay(RadarDisplay):
             mask_field, mask_value = mask_tuple
             mask_field_num = self.mdvfile.fields.index(mask_field)
             mdata = self.mdvfile.read_a_field(mask_field_num)[sweep]
-            data = np.ma.masked_where(mdata < mask_value, data)
+            data = np.ma.masked_where(np.ma.less(mdata, mask_value), data)
         return data
 
     def _get_x_y(self, field, sweep, edges, filter_transitions):

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -235,8 +235,9 @@ class RadarDisplay:
         # get the data and mask
         data = self._get_ray_data(field, ray, mask_tuple, filter_transitions)
 
-         # mask the data where outside the limits
+        # mask the data where outside the limits
         if mask_outside:
+            data = np.ma.masked_invalid(data)
             data = np.ma.masked_outside(data, ray_min, ray_max)
 
         # plot the data
@@ -329,6 +330,7 @@ class RadarDisplay:
 
         # mask the data where outside the limits
         if mask_outside:
+            data = np.ma.masked_invalid(data)
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the data
@@ -425,6 +427,7 @@ class RadarDisplay:
 
         # mask the data where outside the limits
         if mask_outside:
+            data = np.ma.masked_invalid(data)
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the data
@@ -535,6 +538,7 @@ class RadarDisplay:
 
         # mask the data where outside the limits
         if mask_outside:
+            data = np.ma.masked_invalid(data)
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the data


### PR DESCRIPTION
No output is emitted from Py-ART when running unit tests using standard settings.