### PR TITLE
BUG: No SegFault when dealiasing sweeps with all gates filtered

### DIFF
--- a/pyart/correct/unwrap_2d_ljmu.c
+++ b/pyart/correct/unwrap_2d_ljmu.c
@@ -708,9 +708,11 @@ unwrap2D(double* wrapped_image, double* UnwrappedImage, unsigned char* input_mas
   horizontalEDGEs(pixel, edge, image_width, image_height, &params);
   verticalEDGEs(pixel, edge, image_width, image_height, &params);
 
-  //sort the EDGEs depending on their reiability. The PIXELs with higher
-  //relibility (small value) first
-  quicker_sort(edge, edge + params.no_of_edges - 1);
+  if (params.no_of_edges != 0) {
+      //sort the EDGEs depending on their reiability. The PIXELs with higher
+      //relibility (small value) first
+      quicker_sort(edge, edge + params.no_of_edges - 1);
+  }
 
   //gather PIXELs into groups
   gatherPIXELs(edge, &params);

--- a/pyart/correct/unwrap_3d_ljmu.c
+++ b/pyart/correct/unwrap_3d_ljmu.c
@@ -1040,8 +1040,10 @@ unwrap3D(double* wrapped_volume, double* unwrapped_volume, unsigned char* input_
   verticalEDGEs(voxel, edge, volume_width, volume_height, volume_depth, &params);
   normalEDGEs(voxel, edge, volume_width, volume_height, volume_depth, &params);
 
-  //sort the EDGEs depending on their reiability. The VOXELs with higher relibility (small value) first
-  quicker_sort(edge, edge + params.no_of_edges - 1);
+  if (params.no_of_edges != 0) {
+      //sort the EDGEs depending on their reiability. The VOXELs with higher relibility (small value) first
+      quicker_sort(edge, edge + params.no_of_edges - 1);
+  }
 
   //gather VOXELs into groups
   gatherVOXELs(edge, &params);


### PR DESCRIPTION
The dealias_unwrap_phase function no longer Segmentation faults when
a sweep in the passed radar object is fully masked or all the gates
are filtered.

Closes #230