### PR TITLE
Fail softly when volume number is unknown

### DIFF
--- a/pyart/io/rsl.py
+++ b/pyart/io/rsl.py
@@ -14,12 +14,20 @@ Python wrapper around the RSL library.
 """
 
 # Nothing from this module is imported into pyart.io if RSL is not installed.
+import sys
 import numpy as np
+import logging
 
 from ..config import FileMetadata, get_fillvalue
 from . import _rsl_interface
 from ..core.radar import Radar
 from .common import dms_to_d, make_time_unit_str
+
+logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stderr)
+handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s'))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def read_rsl(filename, field_names=None, additional_metadata=None,
@@ -118,7 +126,10 @@ def read_rsl(filename, field_names=None, additional_metadata=None,
     # transfer only those which are available
     fields = {}
     for volume_num in available_vols:
-
+        # if a volume number is not recognized it is skipped.
+        if volume_num not in VOLUMENUM2RSLNAME:
+            logging.warn("Unknown Volume Number %d" % volume_num)
+            continue
         rsl_field_name = VOLUMENUM2RSLNAME[volume_num]
         field_name = filemetadata.get_field_name(rsl_field_name)
         if field_name is None:

--- a/pyart/io/rsl.py
+++ b/pyart/io/rsl.py
@@ -16,18 +16,12 @@ Python wrapper around the RSL library.
 # Nothing from this module is imported into pyart.io if RSL is not installed.
 import sys
 import numpy as np
-import logging
+import warnings
 
 from ..config import FileMetadata, get_fillvalue
 from . import _rsl_interface
 from ..core.radar import Radar
 from .common import dms_to_d, make_time_unit_str
-
-logger = logging.getLogger()
-handler = logging.StreamHandler(sys.stderr)
-handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s'))
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 
 def read_rsl(filename, field_names=None, additional_metadata=None,
@@ -128,7 +122,7 @@ def read_rsl(filename, field_names=None, additional_metadata=None,
     for volume_num in available_vols:
         # if a volume number is not recognized it is skipped.
         if volume_num not in VOLUMENUM2RSLNAME:
-            logging.warn("Unknown Volume Number %d" % volume_num)
+            warnings.warn("Unknown Volume Number %d" % volume_num)
             continue
         rsl_field_name = VOLUMENUM2RSLNAME[volume_num]
         field_name = filemetadata.get_field_name(rsl_field_name)


### PR DESCRIPTION
While attempting to read in [NPOL DATA](ftp://gpm.nsstc.nasa.gov/gpm_validation/ifloods/NPOL/data) I encountered a bug in which reading the UF file failed because a volume number was not recognized.

```
  File "pyart/pyart/io/rsl.py", line 122, in read_rsl
    rsl_field_name = VOLUMENUM2RSLNAME[volume_num]
KeyError: 46
```

This hints that the VOLUMENUM2RSLNAME dict is out of date.  This change doesn't update the dict, but instead lets reading continue after logging a warning:

```
2015-01-22 10:54:04,253 WARNING root: Unknown Volume Number 46
2015-01-22 10:54:04,253 WARNING root: Unknown Volume Number 46
```