### PR TITLE
ENH: Region based Doppler velocity dealiasing

### DIFF
--- a/doc/source/dev_reference/correct.rst
+++ b/doc/source/dev_reference/correct.rst
@@ -8,7 +8,9 @@ Radar Moment correction routines.
 .. automodule:: pyart.correct.dealias
 .. automodule:: pyart.correct.filters
 .. automodule:: pyart.correct.phase_proc
+.. automodule:: pyart.correct.region_dealias
 .. automodule:: pyart.correct.unwrap
+.. automodule:: pyart.correct._common_dealias
 .. automodule:: pyart.correct._fourdd_interface
 .. automodule:: pyart.correct._unwrap_1d
 .. automodule:: pyart.correct._unwrap_2d

--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -29,5 +29,6 @@ from .attenuation import calculate_attenuation
 from .phase_proc import phase_proc_lp
 from .filters import GateFilter, moment_based_gate_filter
 from .unwrap import dealias_unwrap_phase
+from .region_dealias import dealias_region_based
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -13,6 +13,7 @@ moments and data.
 
     dealias_fourdd
     dealias_unwrap_phase
+    dealias_region_based
     calculate_attenuation
     phase_proc_lp
     GateFilter

--- a/pyart/correct/_common_dealias.py
+++ b/pyart/correct/_common_dealias.py
@@ -1,0 +1,62 @@
+"""
+pyart.correct._common_dealias
+=============================
+
+Routines used by multiple dealiasing functions.
+
+.. autosummary::
+    :toctree: generated/
+
+    _parse_fields
+    _parse_nyquist_vel
+    _parse_gatefilter
+    _parse_rays_wrap_around
+
+"""
+
+from ..config import get_field_name
+from .filters import moment_based_gate_filter, GateFilter
+
+
+def _parse_fields(vel_field, corr_vel_field):
+    """ Parse and return the radar fields for dealiasing. """
+    if vel_field is None:
+        vel_field = get_field_name('velocity')
+    if corr_vel_field is None:
+        corr_vel_field = get_field_name('corrected_velocity')
+    return vel_field, corr_vel_field
+
+
+def _parse_nyquist_vel(nyquist_vel, radar):
+    """ Parse the nyquist_vel parameter, extract from the radar if needed. """
+    if nyquist_vel is None:
+        if (radar.instrument_parameters is None) or (
+                'nyquist_velocity' not in radar.instrument_parameters):
+            message = ('Nyquist velocity not specified in radar object, '
+                       'provide this value explicitly in the function call.')
+            raise ValueError(message)
+        nyquist_vel = radar.instrument_parameters[
+            'nyquist_velocity']['data'][0]
+    return nyquist_vel
+
+
+def _parse_gatefilter(gatefilter, radar, **kwargs):
+    """ Parse the gatefilter, return a valid GateFilter object. """
+    # parse the gatefilter parameter
+    if gatefilter is None:  # create a moment based filter
+        gatefilter = moment_based_gate_filter(radar, **kwargs)
+    elif gatefilter is False:
+        gatefilter = GateFilter(radar)
+    else:
+        gatefilter = gatefilter.copy()
+    return gatefilter
+
+
+def _parse_rays_wrap_around(rays_wrap_around, radar):
+    """ Parse the rays_wrap_around parameter. """
+    if rays_wrap_around is None:
+        if radar.scan_type == 'ppi':
+            rays_wrap_around = True
+        else:
+            rays_wrap_around = False
+    return rays_wrap_around

--- a/pyart/correct/region_dealias.py
+++ b/pyart/correct/region_dealias.py
@@ -27,10 +27,8 @@ import scipy.ndimage as ndimage
 import scipy.sparse as sparse
 
 from ..config import get_metadata
-
-# XXX move these to a _common_dealias module
-from .unwrap import _parse_fields, _parse_gatefilter, _parse_rays_wrap_around
-from .unwrap import _parse_nyquist_vel
+from ._common_dealias import _parse_fields, _parse_gatefilter
+from ._common_dealias import _parse_rays_wrap_around, _parse_nyquist_vel
 
 
 # Possible future improvements to the region based dealiasing algorithm:

--- a/pyart/correct/region_dealias.py
+++ b/pyart/correct/region_dealias.py
@@ -1,0 +1,426 @@
+"""
+pyart.correct.region_dealias
+============================
+
+Region based dealiasing using a dynamic network reduction for region joining.
+
+.. autosummary::
+    :toctree: generated/
+
+    dealias_region_based
+
+
+"""
+
+import numpy as np
+import scipy.ndimage as ndimage
+import scipy.sparse as sparse
+
+
+# TODO
+# * have dealias_region_based function behave like other dealias functions
+# * non-hard coded segmentation with parameter based number of splits
+# * deal with filtered (masked) gates
+# * optimize
+# * refactor
+# * document
+# * unit tests
+# * merge into Py-ART
+
+
+def dealias_region_based(radar):
+    """
+    Dealias Doppler velocities using a region based algorithm.
+
+    Parameters
+    ----------
+    radar : Radar
+        Radar object containing Doppler velocities to dealias.
+    nyquist_velocity : float, optional
+        Nyquist velocity in unit identical to those stored in the radar's
+        velocity field.  None will attempt to determine this value from the
+        instrument_parameters attribute.
+    gatefilter : GateFilter, None or False, optional.
+        A GateFilter instance which specified which gates should be
+        ignored when performing de-aliasing.  A value of None, the default,
+        created this filter from the radar moments using any additional
+        arguments by passing them to :py:func:`moment_based_gate_filter`.
+        False disables filtering including all gates in the dealiasing.
+    rays_wrap_around : bool or None, optional
+        True when the rays at the beginning of the sweep and end of the sweep
+        should be interpreted as connected when de-aliasing (PPI scans).
+        False if they edges should not be interpreted as connected (other scan
+        types).  None will determine the correct value from the radar
+        scan type.
+    keep_original : bool, optional
+        True to retain the original Doppler velocity values at gates
+        where the dealiasing procedure fails or was not applied. False
+        does not replacement and these gates will be masked in the corrected
+        velocity field.
+    vel_field : str, optional
+        Field in radar to use as the Doppler velocities during dealiasing.
+        None will use the default field name from the Py-ART configuration
+        file.
+    corr_vel_field : str, optional
+        Name to use for the dealiased Doppler velocity field metadata.  None
+        will use the default field name from the Py-ART configuration file.
+
+    Returns
+    -------
+
+    """
+    original_data = radar.fields['velocity']['data'].copy()
+    nyquist = radar.instrument_parameters['nyquist_velocity']['data'][0]
+
+    # find regions/segments in original data
+    labels, nfeatures = find_segments(original_data)
+    segment_sizes = _segment_sizes(labels, nfeatures)
+    edge_sum, edge_count = edge_sum_and_count(
+        labels, nfeatures, original_data)
+
+    # find unwrap number for these regions
+    region_tracker = RegionTracker(segment_sizes)
+    edge_tracker = EdgeTracker(edge_sum, edge_count, nyquist)
+    for i in range(80000):
+        # print "------------------------"
+        # print "step:", i
+        if combine_segments(region_tracker, edge_tracker):
+            break
+
+    # dealias the data using the unwrap numbers
+    dealias_data = original_data.copy()
+    for i in range(nfeatures+1):
+        nwrap = region_tracker.unwrap_number[i]
+        dealias_data[labels == i] += nwrap * nyquist
+    return dealias_data
+
+
+def combine_segments(region_tracker, edge_tracker):
+    """ Returns True when done. """
+    # Edge parameter from edge with largest weight
+    status, extra = edge_tracker.pop_edge()
+    if status:
+        return True
+    node1, node2, weight, diff, edge_number = extra
+    rdiff = np.round(diff)
+
+    # node sizes of nodes to be merged
+    node1_size = region_tracker.get_node_size(node1)
+    node2_size = region_tracker.get_node_size(node2)
+
+    # determine which nodes should be merged
+    if node1_size > node2_size:
+        base_node, merge_node = node1, node2
+    else:
+        base_node, merge_node = node2, node1
+        rdiff = -rdiff
+
+    # unwrap merge_node
+    if rdiff != 0:
+        region_tracker.unwrap_node(merge_node, rdiff)
+        edge_tracker.unwrap_node(merge_node, rdiff)
+
+    # merge nodes
+    region_tracker.merge_nodes(base_node, merge_node)
+    edge_tracker.merge_nodes(base_node, merge_node, edge_number)
+
+    return False
+
+
+def edge_sum_and_count(labels, nfeatures, data):
+
+    total_nodes = np.prod(labels.shape)
+    l_index = np.zeros(total_nodes * 4, dtype=np.int32)
+    n_index = np.zeros(total_nodes * 4, dtype=np.int32)
+    e_sum = np.zeros(total_nodes * 4, dtype=np.float64)
+    right, bottom = [i-1 for i in labels.shape]
+
+    idx = 0
+    for index, label in np.ndenumerate(labels):
+        x, y = index
+        vel = data[x, y]
+
+        # left
+        if x != 0:
+            neighbor = labels[x-1, y]
+            if neighbor != label:
+                l_index[idx] = label
+                n_index[idx] = neighbor
+                e_sum[idx] = vel
+                idx += 1
+
+        # right
+        if x != right:
+            neighbor = labels[x+1, y]
+            if neighbor != label:
+                l_index[idx] = label
+                n_index[idx] = neighbor
+                e_sum[idx] = vel
+                idx += 1
+
+        # top
+        if y != 0:
+            neighbor = labels[x, y-1]
+            if neighbor != label:
+                l_index[idx] = label
+                n_index[idx] = neighbor
+                e_sum[idx] = vel
+                idx += 1
+
+        # bottom
+        if y != bottom:
+            neighbor = labels[x, y+1]
+            if neighbor != label:
+                l_index[idx] = label
+                n_index[idx] = neighbor
+                e_sum[idx] = vel
+                idx += 1
+
+    l_index = l_index[:idx]
+    n_index = n_index[:idx]
+    e_sum = e_sum[:idx]
+    e_count = np.ones_like(e_sum, dtype=np.int32)
+
+    shape = (nfeatures+1, nfeatures+1)
+    edge_sum = sparse.coo_matrix((e_sum, (l_index, n_index)), shape=shape)
+    edge_count = sparse.coo_matrix((e_count, (l_index, n_index)), shape=shape)
+
+    return edge_sum.tocsr(), edge_count.tocsr()
+    # return edge_sum.todense(), edge_count.todense()
+
+
+def find_segments(vel):
+    """ Find segments """
+    nyquist = 16.524679
+
+    label, nfeatures = ndimage.label(vel > nyquist * 1/3.)
+
+    labels2, nfeatures2 = ndimage.label(vel < -nyquist * 1/3.)
+    labels2[np.nonzero(labels2)] += nfeatures
+
+    middle = np.logical_and(vel <= nyquist * 1/3.,
+                            vel >= -nyquist * 1/3.)
+    labels3, nfeatures3 = ndimage.label(middle)
+    labels3[np.nonzero(labels3)] += nfeatures + nfeatures2
+
+    return label + labels2 + labels3, nfeatures + nfeatures2 + nfeatures3
+
+
+def _segment_sizes(labels, nfeatures):
+    return np.bincount(labels.ravel())[1:]
+
+
+class RegionTracker(object):
+    """
+    Tracks the location of radar volume regions contained in each node
+    as the network is reduced.
+    """
+
+    def __init__(self, region_sizes):
+        """ initalize. """
+        # number of gates in each node
+        nregions = len(region_sizes) + 1
+        self.node_size = np.zeros(nregions, dtype='int32')
+        self.node_size[1:] = region_sizes[:]
+
+        # array of lists containing the regions in each node
+        self.regions_in_node = np.zeros(nregions, dtype='object')
+        for i in range(nregions):
+            self.regions_in_node[i] = [i]
+
+        # number of unwrappings to apply to dealias each region
+        self.unwrap_number = np.zeros(nregions, dtype='int32')
+
+    def merge_nodes(self, node_a, node_b):
+        """ Merge node b into node a. """
+
+        # move all regions from node_b to node_a
+        regions_to_merge = self.regions_in_node[node_b]
+        self.regions_in_node[node_a].extend(regions_to_merge)
+        self.regions_in_node[node_b] = []
+
+        # update node sizes
+        self.node_size[node_a] += self.node_size[node_b]
+        self.node_size[node_b] = 0
+        return
+
+    def unwrap_node(self, node, nwrap):
+        """ Unwrap all gates contained a node. """
+        if nwrap == 0:
+            return
+        # for each region in node add nwrap
+        regions_to_unwrap = self.regions_in_node[node]
+        self.unwrap_number[regions_to_unwrap] += nwrap
+        return
+
+    def get_node_size(self, node):
+        """ Return the number of gates in a node. """
+        return self.node_size[node]
+
+
+class EdgeTracker(object):
+
+    def __init__(self, edge_sum, edge_count, nyquist):
+        """ initialize """
+
+        nedges = int(edge_count.nnz / 2)
+        nnodes = edge_count.shape[0]
+
+        # node number and different in sum for each edge
+        self.node_alpha = np.zeros(nedges, dtype=np.int32)
+        self.node_beta = np.zeros(nedges, dtype=np.int32)
+        self.sum_diff = np.zeros(nedges, dtype=np.float32)
+
+        # number of connections between the regions
+        self.weight = np.zeros(nedges, dtype=np.int32)
+
+        # fast finding
+        self._common_finder = np.zeros(nnodes, dtype=np.bool)
+        self._common_index = np.zeros(nnodes, dtype=np.int32)
+        self._last_base_node = -1
+
+        # array of linked lists pointing to each segment
+        self.edges_in_node = np.zeros(nnodes, dtype='object')
+        for i in range(nnodes):
+            self.edges_in_node[i] = []
+
+        # fill out data from edge_count and edge_sum
+        a, b = edge_count.nonzero()
+        edge = 0
+        for i, j in zip(a, b):
+            if i < j:
+                continue
+
+            self.node_alpha[edge] = i
+            self.node_beta[edge] = j
+            self.sum_diff[edge] = (edge_sum[i, j] - edge_sum[j, i]) / nyquist
+            self.weight[edge] = edge_count[i, j]
+            self.edges_in_node[i].append(edge)
+            self.edges_in_node[j].append(edge)
+
+            edge += 1
+
+        # list which orders edges according to their
+        # weight, highest first
+        self.priority_queue = []
+
+    def merge_nodes(self, base_node, merge_node, foo_edge):
+        """ Merge nodes. """
+
+        # remove edge between base and merge nodes
+        self.weight[foo_edge] = -999
+        self.edges_in_node[merge_node].remove(foo_edge)
+        self.edges_in_node[base_node].remove(foo_edge)
+        self._common_finder[merge_node] = False
+
+        # find all the edges in the two segments
+        edges_in_merge = list(self.edges_in_node[merge_node])
+
+        # loop over base_node edges if last base_node was different
+        if self._last_base_node != base_node:
+            self._common_finder[:] = False
+            edges_in_base = list(self.edges_in_node[base_node])
+            for edge_num in edges_in_base:
+
+                # reverse edge if needed so node_alpha is base_node
+                if self.node_beta[edge_num] == base_node:
+                    self._reverse_edge_direction(edge_num)
+                assert self.node_alpha[edge_num] == base_node
+
+                # find all neighboring nodes to base_node
+                neighbor = self.node_beta[edge_num]
+                self._common_finder[neighbor] = True
+                self._common_index[neighbor] = edge_num
+
+        # loop over edge nodes
+        for edge_num in edges_in_merge:
+
+            # reverse edge so that node alpha is the merge_node
+            if self.node_beta[edge_num] == merge_node:
+                self._reverse_edge_direction(edge_num)
+            assert self.node_alpha[edge_num] == merge_node
+
+            # update all the edges to point to the base node
+            self.node_alpha[edge_num] = base_node
+
+            # if base_node also has an edge with the neighbor combine them
+            neighbor = self.node_beta[edge_num]
+            if self._common_finder[neighbor]:
+                base_edge_num = self._common_index[neighbor]
+                self._combine_edges(base_edge_num, edge_num,
+                                    base_node, merge_node, neighbor)
+            # if not fill in _common_ arrays.
+            else:
+                self._common_finder[neighbor] = True
+                self._common_index[neighbor] = edge_num
+
+        # move all edges from merge_node to base_node
+        edges = self.edges_in_node[merge_node]
+        self.edges_in_node[base_node].extend(edges)
+        self.edges_in_node[merge_node] = []
+        self._last_base_node = int(base_node)
+        return
+
+    def _combine_edges(self, base_edge, merge_edge,
+                       base_node, merge_node, neighbor_node):
+        """ Combine edges into a single edge.  """
+        # Merging nodes MUST be set to alpha prior to calling this function
+
+        # combine edge weights
+        self.weight[base_edge] += self.weight[merge_edge]
+        self.weight[merge_edge] = -999.
+
+        # combine sums
+        self.sum_diff[base_edge] += self.sum_diff[merge_edge]
+
+        # remove merge_edge from both node lists
+        self.edges_in_node[merge_node].remove(merge_edge)
+        self.edges_in_node[neighbor_node].remove(merge_edge)
+
+        # TODO priority queue
+        # remove merge_edge from edge priority queue
+        # self.priority_queue.remove(merge_edge)
+
+        # relocate base_edge in priority queue
+        # self.priority_queue.sort()
+
+    def _reverse_edge_direction(self, edge):
+        """ Reverse an edges direction, change alpha and beta. """
+        # swap nodes
+        a = int(self.node_alpha[edge])
+        b = int(self.node_beta[edge])
+        self.node_alpha[edge] = b
+        self.node_beta[edge] = a
+        # swap sums
+        self.sum_diff[edge] = -1. * self.sum_diff[edge]
+        return
+
+    def unwrap_node(self, node, nwrap):
+        if nwrap == 0:
+            return
+        # add weight * nwrap to each edge in segment
+        for edge in self.edges_in_node[node]:
+            weight = self.weight[edge]
+            if node == self.node_alpha[edge]:
+                self.sum_diff[edge] += weight * nwrap
+            else:
+                assert self.node_beta[edge] == node
+                self.sum_diff[edge] += -weight * nwrap
+        return
+
+    def pop_edge(self):
+        """ Pop edge with largest weight.  Return node numbers and diff """
+
+        # if len(priority_queue) == 0:
+        #     return True, None
+
+        # edge_num = self.priority_queue[0]
+        edge_num = np.argmax(self.weight)
+        node1 = self.node_alpha[edge_num]
+        node2 = self.node_beta[edge_num]
+        weight = self.weight[edge_num]
+        diff = self.sum_diff[edge_num] / (float(weight))
+
+        if weight < 0:
+            return True, None
+        return False, (node1, node2, weight, diff, edge_num)

--- a/pyart/correct/region_dealias.py
+++ b/pyart/correct/region_dealias.py
@@ -29,7 +29,6 @@ from .unwrap import _parse_nyquist_vel
 # * optimize
 # * refactor
 # * document
-# * unit tests
 # * merge into Py-ART
 
 

--- a/pyart/correct/tests/test_region_dealias.py
+++ b/pyart/correct/tests/test_region_dealias.py
@@ -1,0 +1,101 @@
+""" Unit Tests for Py-ART's correct/region_dealias.py module. """
+
+# python test_
+# to recreate a dealias_plot.png file showing the before and after doppler
+# velocities
+
+from __future__ import print_function
+
+import pyart
+import numpy as np
+from numpy.testing import assert_allclose
+
+REF_DATA = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5,
+            12.5, 13.5, 12.5, 11.5, 10.5, 9.5, 8.5, 7.5, 6.5, 5.5, 4.5, 3.5,
+            2.5, 1.5, 0.5]
+
+
+def test_dealias_region_based():
+    radar, dealias_vel = perform_dealias()
+    assert_allclose(dealias_vel['data'][13, :27], REF_DATA)
+    assert np.ma.is_masked(dealias_vel['data'][13]) is False
+
+
+def test_dealias_region_based_masked_wrap_around():
+    radar = pyart.testing.make_velocity_aliased_radar()
+    vdata = radar.fields['velocity']['data']
+    radar.fields['velocity']['data'] = np.ma.masked_array(vdata)
+    radar.fields['velocity']['data'][13, -4:] = [-7.5, 8.5, 0, 0]
+    radar.fields['velocity']['data'][0, 25] = np.ma.masked
+    radar.fields['velocity']['data'][-1, 30] = np.ma.masked
+    radar.fields['velocity']['data'][180, -1] = np.ma.masked
+    radar.fields['velocity']['data'][180, 0] = np.ma.masked
+    dealias_vel = pyart.correct.dealias_region_based(
+        radar, rays_wrap_around=True)
+    assert_allclose(dealias_vel['data'][13, :27], REF_DATA)
+    assert np.ma.is_masked(dealias_vel['data'][13]) is False
+    assert np.ma.is_masked(dealias_vel['data'][0, 25])
+    assert not np.ma.is_masked(dealias_vel['data'][0, 24])
+    assert np.ma.is_masked(dealias_vel['data'][-1, 30])
+    assert not np.ma.is_masked(dealias_vel['data'][-1, 29])
+    assert np.ma.is_masked(dealias_vel['data'][180, -1])
+    assert not np.ma.is_masked(dealias_vel['data'][180, -2])
+    assert np.ma.is_masked(dealias_vel['data'][180, 0])
+    assert not np.ma.is_masked(dealias_vel['data'][180, 1])
+
+
+def test_dealias_region_based_no_wrap_around():
+    radar = pyart.testing.make_velocity_aliased_radar()
+    vdata = radar.fields['velocity']['data']
+    radar.fields['velocity']['data'] = np.ma.masked_array(vdata)
+    radar.fields['velocity']['data'][13, -4:] = [-7.5, 8.5, 0, 0]
+    radar.fields['velocity']['data'][0, 25] = np.ma.masked
+    radar.fields['velocity']['data'][0, 25] = np.ma.masked
+    radar.fields['velocity']['data'][-1, 30] = np.ma.masked
+    dealias_vel = pyart.correct.dealias_region_based(
+        radar, rays_wrap_around=False)
+    assert_allclose(dealias_vel['data'][13, :27], REF_DATA)
+    assert np.ma.is_masked(dealias_vel['data'][13]) is False
+    assert np.ma.is_masked(dealias_vel['data'][0, 25])
+    assert not np.ma.is_masked(dealias_vel['data'][0, 24])
+    assert np.ma.is_masked(dealias_vel['data'][-1, 30])
+    assert not np.ma.is_masked(dealias_vel['data'][-1, 29])
+
+
+def perform_dealias(**kwargs):
+    """ Perform velocity dealiasing on reference data. """
+    radar = pyart.testing.make_velocity_aliased_radar()
+    # speckling that will not be not be dealiased.
+    radar.fields['velocity']['data'][13, -4:] = [-7.5, 8.5, 0, 0]
+    dealias_vel = pyart.correct.dealias_region_based(
+        radar, **kwargs)
+    return radar, dealias_vel
+
+
+def main():
+
+    radar, dealias_vel = perform_dealias()
+    radar.fields['dealiased_velocity'] = dealias_vel
+
+    # print out results
+    print("ray 13 velocitites before dealias:")
+    print(radar.fields['velocity']['data'][13])
+    print("ray 13 velocities after dealias:")
+    print(radar.fields['dealiased_velocity']['data'][13])
+
+    # create plot
+    import matplotlib.pyplot as plt
+    fig = plt.figure(figsize=[5, 10])
+    ax1 = fig.add_subplot(2, 1, 1)
+    ax2 = fig.add_subplot(2, 1, 2)
+    rd = pyart.graph.RadarDisplay(radar)
+    rd.plot_ppi('velocity', 0, ax=ax1, colorbar_flag=False,
+                title='', vmin=-10, vmax=10)
+    rd.plot_ppi('dealiased_velocity', 0, ax=ax2, colorbar_flag=False,
+                title='', vmin=-10, vmax=20)
+    plt.show()
+    fig.savefig('dealias_plot.png')
+
+
+if __name__ == "__main__":
+    main()

--- a/pyart/correct/unwrap.py
+++ b/pyart/correct/unwrap.py
@@ -8,10 +8,6 @@ Dealias using multidimensional phase unwrapping algorithms.
     :toctree: generated/
 
     dealias_unwrap_phase
-    _parse_fields
-    _parse_nyquist_vel
-    _parse_gatefilter
-    _parse_rays_wrap_around
     _dealias_unwrap_3d
     _dealias_unwrap_2d
     _dealias_unwrap_1d
@@ -27,8 +23,9 @@ from __future__ import print_function
 
 import numpy as np
 
-from ..config import get_field_name, get_metadata
-from .filters import moment_based_gate_filter, GateFilter
+from ..config import get_metadata
+from ._common_dealias import _parse_fields, _parse_gatefilter
+from ._common_dealias import _parse_rays_wrap_around, _parse_nyquist_vel
 
 from ._unwrap_1d import unwrap_1d
 from ._unwrap_2d import unwrap_2d
@@ -142,50 +139,6 @@ def dealias_unwrap_phase(
     corr_vel = get_metadata(corr_vel_field)
     corr_vel['data'] = data
     return corr_vel
-
-
-def _parse_fields(vel_field, corr_vel_field):
-    """ Parse and return the radar fields for dealiasing. """
-    if vel_field is None:
-        vel_field = get_field_name('velocity')
-    if corr_vel_field is None:
-        corr_vel_field = get_field_name('corrected_velocity')
-    return vel_field, corr_vel_field
-
-
-def _parse_nyquist_vel(nyquist_vel, radar):
-    """ Parse the nyquist_vel parameter, extract from the radar if needed. """
-    if nyquist_vel is None:
-        if (radar.instrument_parameters is None) or (
-                'nyquist_velocity' not in radar.instrument_parameters):
-            message = ('Nyquist velocity not specified in radar object, '
-                       'provide this value explicitly in the function call.')
-            raise ValueError(message)
-        nyquist_vel = radar.instrument_parameters[
-            'nyquist_velocity']['data'][0]
-    return nyquist_vel
-
-
-def _parse_gatefilter(gatefilter, radar, **kwargs):
-    """ Parse the gatefilter, return a valid GateFilter object. """
-    # parse the gatefilter parameter
-    if gatefilter is None:  # create a moment based filter
-        gatefilter = moment_based_gate_filter(radar, **kwargs)
-    elif gatefilter is False:
-        gatefilter = GateFilter(radar)
-    else:
-        gatefilter = gatefilter.copy()
-    return gatefilter
-
-
-def _parse_rays_wrap_around(rays_wrap_around, radar):
-    """ Parse the rays_wrap_around parameter. """
-    if rays_wrap_around is None:
-        if radar.scan_type == 'ppi':
-            rays_wrap_around = True
-        else:
-            rays_wrap_around = False
-    return rays_wrap_around
 
 
 def _dealias_unwrap_3d(radar, vdata, nyquist_vel, gfilter, rays_wrap_around):


### PR DESCRIPTION
Add the **dealias_region_based** function to the pyart.correct namespace which performs Doppler velocity dealiasing by finding regions of similar velocities and unfolding and merging pairs of regions until all regions are unfolded.  Unfolding and merging regions is accomplished by modeling the problem as a dynamic network reduction.