### PR TITLE
BUG: NetCDF files close to prevent SegFault

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -279,6 +279,7 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
     if radar_calibration == {}:
         radar_calibration = None
 
+    ncobj.close()
     return Radar(
         time, _range, fields, metadata, scan_type,
         latitude, longitude, altitude,


### PR DESCRIPTION
Opening the same NetCDF files without closing the Dataset object
causes a segmentation fault on some systems.  This explicitly closes the netCDF4
Dataset object when the read_cfradial function is done extracting data from the
object.