### PR TITLE
MAINT: Added fallback ppi scan type for CfRadial files

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -184,6 +184,8 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         scan_type = 'sector'
     elif 'rhi' in mode:
         scan_type = 'rhi'
+    elif 'ppi' in mode:
+        scan_type = 'ppi'
     else:
         scan_type = 'other'
 


### PR DESCRIPTION
The scan_type of a radar will be set to ppi if the string 'ppi' appears in
the first sweep_mode string when reading CfRadial files.