### PR TITLE
Latlon for points in grid

### DIFF
--- a/pyart/io/__init__.py
+++ b/pyart/io/__init__.py
@@ -22,6 +22,7 @@ from and write data to a number of file formats.
     write_cfradial
     read_grid
     write_grid
+    add_2d_latlon_axis
 
 """
 
@@ -38,5 +39,6 @@ from .nexrad_archive import read_nexrad_archive
 from .nexrad_cdm import read_nexrad_cdm
 from .grid_io import read_grid, write_grid
 from .auto_read import read
+from .common import add_2d_latlon_axis
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -123,18 +123,18 @@ def make_time_unit_str(dtobj):
 def add_2d_latlon_axis(grid,**kwargs):
     """
     Add to Grid (in place) a 2-dimensional axes for latitude and longitude 
-    of every point in the y,x plane. If available conversion is done using Basemap,
-    extra arguments in **kwargs are passed to that function. If not available
-    internal implementation is used
+    of every point in the y,x plane. If available conversion is done using 
+    basemap.pyproj, extra arguments in **kwargs are passed to pyproj.Proj
+    function. If not available internal implementation is used
 
     Parameters
     ----------
     grid: grid object
         Cartesian grid object containing the 1d axes "x_disp","y_disp" and 
         scalar axes 'lat','lon'.
-    **kwargs: Basemap options
-        Options to be passed to Basemap. If projection is not specified here it
-        uses projection='aeqd' (azimuthal equidistant)
+    **kwargs: Pyproj options
+        Options to be passed to Proj. If projection is not specified here it
+        uses proj='aeqd' (azimuthal equidistant)
 
     Returns
     -------
@@ -169,21 +169,11 @@ def add_2d_latlon_axis(grid,**kwargs):
     """
     import sys
     try:
-        #XXX my version of Basemap (debian wheezy) seem to have some bug, it results in impossible values 1.e+30 etc.
-        #XXX this commented lines should work however
-        #XXX function description above is done supposing a working Basemap
-        #from mpl_toolkits.basemap import Basemap
-        #if 'projection' not in kwargs:
-        #    kwargs['projection']='aeqd'
-        #x,y=np.meshgrid(grid.axes["x_disp"]['data'],grid.axes["y_disp"]['data'])
-        #b = Basemap(lat_0=grid.axes["lat"]['data'],lon_0=grid.axes["lon"]['data'],**kwargs)
-        #lon, lat = b(x, y, inverse=True)
-        #XXX pyproj version
-        import pyproj
+        from mpl_toolkits.basemap import pyproj
         if 'proj' not in kwargs:
             kwargs['proj']='aeqd'
         x,y=np.meshgrid(grid.axes["x_disp"]['data'],grid.axes["y_disp"]['data'])
-        b = pyproj.Proj(lat_0=grid.axes["lat"]['data'],lon_0=grid.axes["lon"]['data'],**kwargs)
+        b = pyproj.Proj(lat_0=grid.axes["lat"]['data'][0],lon_0=grid.axes["lon"]['data'][0],**kwargs)
         lon, lat = b(x, y, inverse=True)
     except ImportError:
         import warnings
@@ -200,7 +190,7 @@ def add_2d_latlon_axis(grid,**kwargs):
         lat = np.arcsin(np.cos(c)*np.sin(phi_0)+np.sin(azi)*np.sin(c)*np.cos(phi_0))*180/np.pi
         lon=np.arctan2(np.cos(azi)*np.sin(c),np.cos(c)*np.cos(phi_0)-np.sin(azi)*np.sin(c)*np.sin(phi_0))*180/np.pi+grid.axes["lon"]['data']
         lon=np.fmod(lon+180,360)-180;
-
+    
     lat_axis = {'data':  lat,
              'long_name': 'Latitude for points in Cartesian system',
              'axis': 'YX',

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -125,13 +125,13 @@ def add_2d_latlon_axis(grid, **kwargs):
     Add to Grid (in place) a 2-dimensional axes for latitude and longitude
     of every point in the y,x plane. If available conversion is done using
     basemap.pyproj, extra arguments in **kwargs are passed to pyproj.Proj
-    function. If not available internal implementation is used
+    function. If not available internal implementation is used.
 
     Parameters
     ----------
     grid: grid object
-        Cartesian grid object containing the 1d axes "x_disp","y_disp" and
-        scalar axes 'lat','lon'.
+        Cartesian grid object containing the 1d axes "x_disp", "y_disp" and
+        scalar axes 'lat', 'lon'.
     **kwargs: Pyproj options
         Options to be passed to Proj. If projection is not specified here it
         uses proj='aeqd' (azimuthal equidistant)
@@ -139,7 +139,7 @@ def add_2d_latlon_axis(grid, **kwargs):
     Returns
     -------
     grid: grid object
-        Cartesian grid with new axes "longitude","latitude"
+        Cartesian grid with new axes "longitude", "latitude"
 
     Notes
     -----
@@ -152,14 +152,14 @@ def add_2d_latlon_axis(grid, **kwargs):
 
         c = \\sqrt(x^2 + y^2)/R
 
-        azi = \\atan2(y,x) #from east to north
+        azi = \\arctan2(y,x) \\text{  # from east to north}
 
-        lat = \\asin(\\cos(c)*\\sin(lat0)+\\sin(azi)*\\sin(c)*\\cos(lat0))
+        lat = \\arcsin(\\cos(c)*\\sin(lat0)+\\sin(azi)*\\sin(c)*\\cos(lat0))
 
-        lon = \\atan2(\\cos(azi)*\\sin(c),\\cos(c)*\\cos(lat0)-\\sin(azi)*\\sin(c)*\\sin(lat0)) + lon0
+        lon = \\arctan2(\\cos(azi)*\\sin(c),\\cos(c)*\\cos(lat0)-\\sin(azi)*\\sin(c)*\\sin(lat0)) + lon0
 
-    Where x,y are the cartesian position from the center of projection;
-    lat,lon the corresponding latitude and longitude; lat0,lon0 the latitude
+    Where x, y are the cartesian position from the center of projection;
+    lat, lon the corresponding latitude and longitude; lat0, lon0 the latitude
     and longitude of the center of the projection; R the mean radius of the
     earth (6371 km)
 

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -120,17 +120,17 @@ def make_time_unit_str(dtobj):
     return "seconds since " + dtobj.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def add_2d_latlon_axis(grid,**kwargs):
+def add_2d_latlon_axis(grid, **kwargs):
     """
-    Add to Grid (in place) a 2-dimensional axes for latitude and longitude 
-    of every point in the y,x plane. If available conversion is done using 
+    Add to Grid (in place) a 2-dimensional axes for latitude and longitude
+    of every point in the y,x plane. If available conversion is done using
     basemap.pyproj, extra arguments in **kwargs are passed to pyproj.Proj
     function. If not available internal implementation is used
 
     Parameters
     ----------
     grid: grid object
-        Cartesian grid object containing the 1d axes "x_disp","y_disp" and 
+        Cartesian grid object containing the 1d axes "x_disp","y_disp" and
         scalar axes 'lat','lon'.
     **kwargs: Pyproj options
         Options to be passed to Proj. If projection is not specified here it
@@ -143,8 +143,9 @@ def add_2d_latlon_axis(grid,**kwargs):
 
     Notes
     -----
-    If Basemap is not available calculation of latitude, longitude is done 
-    by converting spherical azimuthal equidistant projection to latlon projection [1].
+    If Basemap is not available calculation of latitude, longitude is done
+    by converting spherical azimuthal equidistant projection to latlon
+    projection [1].
     It uses the mean radius of earth (6371 km)
 
     .. math::
@@ -157,9 +158,9 @@ def add_2d_latlon_axis(grid,**kwargs):
 
         lon = \\atan2(\\cos(azi)*\\sin(c),\\cos(c)*\\cos(lat0)-\\sin(azi)*\\sin(c)*\\sin(lat0)) + lon0
 
-    Where x,y are the cartesian position from the center of projection; 
-    lat,lon the corresponding latitude and longitude; lat0,lon0 the latitude 
-    and longitude of the center of the projection; R the mean radius of the 
+    Where x,y are the cartesian position from the center of projection;
+    lat,lon the corresponding latitude and longitude; lat0,lon0 the latitude
+    and longitude of the center of the projection; R the mean radius of the
     earth (6371 km)
 
     References
@@ -171,39 +172,45 @@ def add_2d_latlon_axis(grid,**kwargs):
     try:
         from mpl_toolkits.basemap import pyproj
         if 'proj' not in kwargs:
-            kwargs['proj']='aeqd'
+            kwargs['proj'] = 'aeqd'
         x,y=np.meshgrid(grid.axes["x_disp"]['data'],grid.axes["y_disp"]['data'])
-        b = pyproj.Proj(lat_0=grid.axes["lat"]['data'][0],lon_0=grid.axes["lon"]['data'][0],**kwargs)
+        b = pyproj.Proj(lat_0=grid.axes["lat"]['data'][0], 
+                        lon_0=grid.axes["lon"]['data'][0], **kwargs)
         lon, lat = b(x, y, inverse=True)
     except ImportError:
         import warnings
-        warnings.warn('No basemap found, using internal implementation for converting azimuthal equidistant to latlon')
+        warnings.warn('No basemap found, using internal implementation '
+                      'for converting azimuthal equidistant to latlon')
         #azimutal equidistant projetion to latlon
         R = 6371.0 * 1000.0     # radius of earth in meters.
-        
-        x,y=np.meshgrid(grid.axes["x_disp"]['data'],grid.axes["y_disp"]['data'])
-        
-        c=np.sqrt(x*x+y*y)/R;
-        phi_0=grid.axes["lat"]['data']*np.pi/180
-        azi=np.arctan2(y,x); #from east to north
-        
-        lat = np.arcsin(np.cos(c)*np.sin(phi_0)+np.sin(azi)*np.sin(c)*np.cos(phi_0))*180/np.pi
-        lon=np.arctan2(np.cos(azi)*np.sin(c),np.cos(c)*np.cos(phi_0)-np.sin(azi)*np.sin(c)*np.sin(phi_0))*180/np.pi+grid.axes["lon"]['data']
-        lon=np.fmod(lon+180,360)-180;
-    
+
+        x,y = np.meshgrid(grid.axes["x_disp"]['data'],
+                          grid.axes["y_disp"]['data'])
+
+        c = np.sqrt(x*x + y*y) / R
+        phi_0 = grid.axes["lat"]['data'] * np.pi / 180
+        azi = np.arctan2(y,x)  # from east to north
+
+        lat = np.arcsin(np.cos(c) * np.sin(phi_0) + 
+                        np.sin(azi) * np.sin(c) * np.cos(phi_0)) * 180 / np.pi
+        lon = (np.arctan2(np.cos(azi) * np.sin(c), np.cos(c) * np.cos(phi_0)
+                         - np.sin(azi) * np.sin(c) * np.sin(phi_0))
+               * 180 / np.pi+grid.axes["lon"]['data'])
+        lon = np.fmod(lon + 180, 360) - 180
+
     lat_axis = {'data':  lat,
              'long_name': 'Latitude for points in Cartesian system',
              'axis': 'YX',
              'units': 'degree_N',
              'standard_name': 'latitude',
              }
-    
+
     lon_axis = {'data': lon,
              'long_name': 'Longitude for points in Cartesian system',
              'axis': 'YX',
              'units': 'degree_E',
              'standard_name': 'longitude',
              }
-    
-    grid.axes["latitude"]=lat_axis
-    grid.axes["longitude"]=lon_axis
+
+    grid.axes["latitude"] = lat_axis
+    grid.axes["longitude"] = lon_axis

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -11,6 +11,7 @@ Input/output routines common to many file formats.
     stringarray_to_chararray
     radar_coords_to_cart
     make_time_unit_str
+    add_2d_latlon_axis
 
 """
 
@@ -121,12 +122,47 @@ def make_time_unit_str(dtobj):
 
 def add_2d_latlon_axis(grid):
     """
-    
-    Function description here
-    
-    verify and explaine math
-    http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html
+    Add to Grid (in place) a 2-dimensional axes for latitude and longitude 
+    of every point in the y,x plane
+
+    Parameters
+    ----------
+    grid: grid object
+        Cartesian grid object containing the 1d axes "x_disp","y_disp" and 
+        scalar axes 'lat','lon'.
+
+    Returns
+    -------
+    grid: grid object
+        Cartesian grid with new axes "longitude","latitude"
+
+    Notes
+    -----
+    The calculation of latitude, longitude is done by converting spherical 
+    azimuthal equidistant projection to latlon projection [1]. It uses the 
+    mean radius of earth (6371 km)
+
+    .. math::
+
+        c = \\sqrt(x^2 + y^2)/R
+
+        azi = \\atan2(y,x)
+
+        lat = \\asin(\\cos(c)*\\sin(lat0)+\\sin(azi)*\\sin(c)*\\cos(lat0))
+
+        lon = \\atan2(\\cos(azi)*\\sin(c),\\cos(c)*\\cos(lat0)-\\sin(azi)*\\sin(c)*\\sin(lat0)) + lon0
+
+    Where x,y are the cartesian position from the center of projection; 
+    lat,lon the corresponding latitude and longitude; lat0,lon0 the latitude 
+    and longitude of the center of the projection; R the mean radius of the 
+    earth (6371 km)
+
+    References
+    ----------
+    .. [1] Snyder, J. P. Map Projections--A Working Manual. U. S. Geological
+        Survey Professional Paper 1395, 1987, pp. 191-202.
     """
+    
     #azimutal equidistant projetion to latlon
     R = 6371.0 * 1000.0     # radius of earth in meters.
     

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -117,3 +117,43 @@ def radar_coords_to_cart(rng, az, ele, debug=False):
 def make_time_unit_str(dtobj):
     """ Return a time unit string from a datetime object. """
     return "seconds since " + dtobj.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def add_2d_latlon_axis(grid):
+    """
+    
+    Function description here
+    
+    verify and explaine math
+    http://mathworld.wolfram.com/AzimuthalEquidistantProjection.html
+    """
+    #azimutal equidistant projetion to latlon
+    R = 6371.0 * 1000.0     # radius of earth in meters.
+    
+    x,y=np.meshgrid(grid.axes["x_disp"]['data'],grid.axes["y_disp"]['data'])
+    
+    c=np.sqrt(x*x+y*y)/R;
+    phi_0=grid.axes["lat"]['data']*np.pi/180
+    azi=np.arctan2(y,x);
+    
+    lat = np.arcsin(np.cos(c)*np.sin(phi_0)+np.sin(azi)*np.sin(c)*np.cos(phi_0))*180/np.pi
+    lon=np.arctan2(np.cos(azi)*np.sin(c),np.cos(c)*np.cos(phi_0)-np.sin(azi)*np.sin(c)*np.sin(phi_0))*180/np.pi+grid.axes["lon"]['data']
+    lon=np.fmod(lon+180,360)-180;
+        
+    
+    lat_axis = {'data':  lat,
+             'long_name': 'Latitude for points in Cartesian system',
+             'axis': 'YX',
+             'units': 'degree_N',
+             'standard_name': 'latitude',
+             }
+    
+    lon_axis = {'data': lon,
+             'long_name': 'Longitude for points in Cartesian system',
+             'axis': 'YX',
+             'units': 'degree_E',
+             'standard_name': 'longitude',
+             }
+    
+    grid.axes["latitude"]=lat_axis
+    grid.axes["longitude"]=lon_axis


### PR DESCRIPTION
add a function to create in grid object from the axes x_disp,y_disp,lat and lon, 2-d axes for the latitude or longitude of every point the the xy plane. The math is "simple" azimuthal equidistant projetion to latlon. I map it into pyart so I can call as a user, but one should decide how to implement, if as method in grid or something else
