### PR TITLE
ENH: inclusive kwarg to filters

### DIFF
--- a/pyart/correct/filters.py
+++ b/pyart/correct/filters.py
@@ -227,8 +227,8 @@ class GateFilter(object):
             Name of field compared against the value.
         value : float
             Gates with a value below this value in the specified field will
-            be maked for exclusion in the filter.
-        filter_masked : bool, optional
+            be marked for exclusion in the filter.
+        exclude_masked : bool, optional
             True to filter masked values in the specified field if the data is
             a masked array, False to include any masked values.
         op : {'and', 'or', 'new'}
@@ -245,6 +245,8 @@ class GateFilter(object):
             conditions.  Note that the 'and' method MAY results in including
             gates which have peviously been excluded because they were masked
             or invalid.
+        inclusive : bool
+            Indicates whether the specified value should also be excluded.
 
         """
         if inclusive:

--- a/pyart/correct/filters.py
+++ b/pyart/correct/filters.py
@@ -252,7 +252,7 @@ class GateFilter(object):
         if inclusive:
             marked = self._get_fdata(field) <= value
         else:
-            marked = self._get_fdate(field) < value
+            marked = self._get_fdata(field) < value
         return self._merge(marked, op, exclude_masked)
 
     def exclude_above(self, field, value, exclude_masked=True, op='or',

--- a/pyart/correct/filters.py
+++ b/pyart/correct/filters.py
@@ -216,7 +216,8 @@ class GateFilter(object):
     # exclude methods #
     ###################
 
-    def exclude_below(self, field, value, exclude_masked=True, op='or'):
+    def exclude_below(self, field, value, exclude_masked=True, op='or',
+                      inclusive=False):
         """
         Exclude gates where a given field is below a given value.
 
@@ -246,28 +247,43 @@ class GateFilter(object):
             or invalid.
 
         """
-        marked = np.ma.less(self._get_fdata(field), value)
+        if inclusive:
+            marked = self._get_fdata(field) <= value
+        else:
+            marked = self._get_fdate(field) < value
         return self._merge(marked, op, exclude_masked)
 
-    def exclude_above(self, field, value, exclude_masked=True, op='or'):
+    def exclude_above(self, field, value, exclude_masked=True, op='or',
+                      inclusive=False):
         """ Exclude gates where a given field is above a given value. """
-        marked = self._get_fdata(field) > value
+        if inclusive:
+            marked = self._get_fdata(field) >= value
+        else:
+            marked = self._get_fdata(field) > value
         return self._merge(marked, op, exclude_masked)
 
-    def exclude_inside(self, field, v1, v2, exclude_masked=True, op='or'):
+    def exclude_inside(self, field, v1, v2, exclude_masked=True, op='or',
+                       inclusive=True):
         """ Exclude gates where a given field is inside a given interval. """
         if v2 < v1:
             (v1, v2) = (v2, v1)
         fdata = self._get_fdata(field)
-        marked = (fdata >= v1) & (fdata <= v2)
+        if inclusive:
+            marked = (fdata >= v1) & (fdata <= v2)
+        else:
+            marked = (fdata > v1) & (fdata < v2)
         return self._merge(marked, op, exclude_masked)
 
-    def exclude_outside(self, field, v1, v2, exclude_masked=True, op='or'):
+    def exclude_outside(self, field, v1, v2, exclude_masked=True, op='or',
+                        inclusive=False):
         """ Exclude gates where a given field is outside a given interval. """
         if v2 < v1:
             (v1, v2) = (v2, v1)
         fdata = self._get_fdata(field)
-        marked = (fdata < v1) | (fdata > v2)
+        if inclusive:
+            marked = (fdata <= v1) | (fdata >= v2)
+        else:
+            marked = (fdata < v1) | (fdata > v2)
         return self._merge(marked, op, exclude_masked)
 
     def exclude_equal(self, field, value, exclude_masked=True, op='or'):
@@ -306,30 +322,46 @@ class GateFilter(object):
     # include_ methods #
     ####################
 
-    def include_below(self, field, value, exclude_masked=True, op='and'):
+    def include_below(self, field, value, exclude_masked=True, op='and',
+                      inclusive=False):
         """ Include gates where a given field is below a given value. """
-        marked = self._get_fdata(field) < value
+        if inclusive:
+            marked = self._get_fdata(field) <= value
+        else:
+            marked = self._get_fdata(field) < value
         self._merge(~marked, op, exclude_masked)
 
-    def include_above(self, field, value, exclude_masked=True, op='and'):
+    def include_above(self, field, value, exclude_masked=True, op='and',
+                      inclusive=False):
         """ Include gates where a given field is above a given value. """
-        marked = self._get_fdata(field) > value
+        if inclusive:
+            marked = self._get_fdata(field) >= value
+        else:
+            marked = self._get_fdata(field) > value
         self._merge(~marked, op, exclude_masked)
 
-    def include_inside(self, field, v1, v2, exclude_masked=True, op='and'):
+    def include_inside(self, field, v1, v2, exclude_masked=True, op='and',
+                       inclusive=True):
         """ Include gates where a given field is inside a given interval. """
         if v2 < v1:
             (v1, v2) = (v2, v1)
         fdata = self._get_fdata(field)
-        marked = (fdata >= v1) & (fdata <= v2)
+        if inclusive:
+            marked = (fdata >= v1) & (fdata <= v2)
+        else:
+            marked = (fdata > v1) & (fdata < v2)
         return self._merge(~marked, op, exclude_masked)
 
-    def include_outside(self, field, v1, v2, exclude_masked=True, op='and'):
+    def include_outside(self, field, v1, v2, exclude_masked=True, op='and',
+                        inclusive=False):
         """ Include gates where a given field is outside a given interval. """
         if v2 < v1:
             (v1, v2) = (v2, v1)
         fdata = self._get_fdata(field)
-        marked = (fdata < v1) | (fdata > v2)
+        if inclusive:
+            marked = (fdata <= v1) | (fdata >= v2)
+        else:
+            marked = (fdata < v1) | (fdata > v2)
         return self._merge(~marked, op, exclude_masked)
 
     def include_equal(self, field, value, exclude_masked=True, op='and'):


### PR DESCRIPTION
Adding an `inclusive` keyword to the relevant filter methods (e.g., exclude_below). This gives the user more control over the specifics and reduces ambiguity, for example, it's ambiguous as to whether the actual minimum and maximum values specified in exclude_inside (include_inside) will be excluded (included) or not unless the user dives into the actual code. One final point is that the default setting of the inclusive kwarg is consistent with what @jjhelmus originally intended with the filter methods.