### PR TITLE
TST: Fix failing documentation build on Travis CI

### DIFF
--- a/continuous_integration/build_docs.sh
+++ b/continuous_integration/build_docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Adapted from the ci/build_docs.sh file from the pandas project
 # https://github.com/pydata/pandas
-set +e
+set -e
 
 cd "$TRAVIS_BUILD_DIR"
 

--- a/continuous_integration/build_docs.sh
+++ b/continuous_integration/build_docs.sh
@@ -6,7 +6,7 @@ set -e
 cd "$TRAVIS_BUILD_DIR"
 
 echo "Building Docs"
-conda install --yes sphinx pil h5py
+conda install --yes sphinx pil
 
 mv "$TRAVIS_BUILD_DIR"/doc /tmp
 cd /tmp/doc


### PR DESCRIPTION
* Fixes the failing build of the documentation on Travis CI.
* In the future when the documentation fails to build the CI build will fail.