### PR TITLE
ENH: Statistics on circular distributions

### DIFF
--- a/doc/source/dev_reference/index.rst
+++ b/doc/source/dev_reference/index.rst
@@ -25,6 +25,7 @@ Documentation is broken down by directory and module.
     retrieve
     graph
     map
+    util
     bridge
     testing
     _debug_info

--- a/doc/source/dev_reference/util.rst
+++ b/doc/source/dev_reference/util.rst
@@ -1,0 +1,7 @@
+==========
+pyart.util
+==========
+
+Miscellaneous utility functions.
+
+.. automodule:: pyart.util.circular_stats

--- a/doc/source/user_reference/index.rst
+++ b/doc/source/user_reference/index.rst
@@ -23,6 +23,7 @@ and private) aimed at developers please see the :ref:`developer`.
     retrieve
     graph
     map
+    util
     bridge
     testing
 

--- a/doc/source/user_reference/util.rst
+++ b/doc/source/user_reference/util.rst
@@ -1,0 +1,1 @@
+.. automodule:: pyart.util

--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -29,6 +29,7 @@ else:
     from . import correct
     from . import graph
     from . import map
+    from . import util
     from . import testing
     from . import config
     from . import aux_io

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -20,8 +20,8 @@ Py-ART may change between versions without depeciation, use with caution.
 
 """
 
-from .circular_stats import angular_mean, angular_std,
-from .curcular_stats import angular_mean_deg, angular_std_deg
-from .curcular_stats import interval_mean interval_std
+from .circular_stats import angular_mean, angular_std
+from .circular_stats import angular_mean_deg, angular_std_deg
+from .circular_stats import interval_mean, interval_std
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -3,8 +3,10 @@
 Utilities (:mod:`pyart.util`)
 =============================
 
-Utility functions.  The location and names of these functions within
-Py-ART may change between versions without depeciation, use with caution.
+Miscellaneous utility functions.
+
+The location and names of these functions within Py-ART may change between
+versions without depeciation, use with caution.
 
 .. currentmodule:: pyart.util
 

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -1,7 +1,27 @@
 """
-Utilities
+=============================
+Utilities (:mod:`pyart.util`)
+=============================
+
+Utility functions.  The location and names of these functions within
+Py-ART may change between versions without depeciation, use with caution.
+
+.. currentmodule:: pyart.util
+
+.. autosummary::
+    :toctree: generated/
+
+    angular_mean
+    angular_std
+    angular_mean_deg
+    angular_std_deg
+    interval_mean
+    interval_std
+
 """
 
-__all__ = ['met']
+from .circular_stats import angular_mean, angular_std,
+from .curcular_stats import angular_mean_deg, angular_std_deg
+from .curcular_stats import interval_mean interval_std
 
-from . import met
+__all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/util/circular_stats.py
+++ b/pyart/util/circular_stats.py
@@ -29,7 +29,7 @@ def angular_mean(angles):
     Compute the mean of a distribution of angles in radians.
 
     Parameters
-    ---------
+    ----------
     angles : array like
         Distribution of angles in radians.
 
@@ -37,6 +37,7 @@ def angular_mean(angles):
     -------
     mean : float
         The mean angle of the distribution in radians.
+
     """
     angles = np.asanyarray(angles)
     x = np.cos(angles)
@@ -49,13 +50,15 @@ def angular_std(angles):
     Compute the standard deviation of a distribution of angles in radians.
 
     Parameters
-    ---------
+    ----------
     angles : array like
         Distribution of angles in radians.
 
     Returns
     -------
     std : float
+        Standard deviation of the distribution.
+
     """
     angles = np.asanyarray(angles)
     x = np.cos(angles)
@@ -69,7 +72,7 @@ def angular_mean_deg(angles):
     Compute the mean of a distribution of angles in degrees.
 
     Parameters
-    ---------
+    ----------
     angles : array like
         Distribution of angles in degrees.
 
@@ -77,6 +80,7 @@ def angular_mean_deg(angles):
     -------
     mean : float
         The mean angle of the distribution in degrees.
+
     """
     return np.rad2deg(angular_mean(np.deg2rad(angles)))
 
@@ -86,13 +90,15 @@ def angular_std_deg(angles):
     Compute the standard deviation of a distribution of angles in degrees.
 
     Parameters
-    ---------
+    ----------
     angles : array like
         Distribution of angles in degrees.
 
     Returns
     -------
     std : float
+        Standard deviation of the distribution.
+
     """
     return np.rad2deg(angular_std(np.deg2rad(angles)))
 

--- a/pyart/util/circular_stats.py
+++ b/pyart/util/circular_stats.py
@@ -1,0 +1,159 @@
+"""
+pyart.util.circular_stats
+=========================
+
+Functions for computing statistics on circular (directional) distributions.
+
+.. autosummary::
+    :toctree: generated/
+
+    angular_mean
+    angular_std
+    angular_mean_deg
+    angular_std_deg
+    interval_mean
+    interval_std
+
+"""
+
+import numpy as np
+
+
+# For details on these computation see:
+# https://en.wikipedia.org/wiki/Directional_statistics
+# https://en.wikipedia.org/wiki/Mean_of_circular_quantities
+
+
+def angular_mean(angles):
+    """
+    Compute the mean of a distribution of angles in radians.
+
+    Parameters
+    ---------
+    angles : array like
+        Distribution of angles in radians.
+
+    Returns
+    -------
+    mean : float
+        The mean angle of the distribution in radians.
+    """
+    angles = np.asanyarray(angles)
+    x = np.cos(angles)
+    y = np.sin(angles)
+    return np.arctan2(y.mean(), x.mean())
+
+
+def angular_std(angles):
+    """
+    Compute the standard deviation of a distribution of angles in radians.
+
+    Parameters
+    ---------
+    angles : array like
+        Distribution of angles in radians.
+
+    Returns
+    -------
+    std : float
+    """
+    angles = np.asanyarray(angles)
+    x = np.cos(angles)
+    y = np.sin(angles)
+    norm = np.sqrt(x.mean()**2 + y.mean()**2)
+    return np.sqrt(-2 * np.log(norm))
+
+
+def angular_mean_deg(angles):
+    """
+    Compute the mean of a distribution of angles in degrees.
+
+    Parameters
+    ---------
+    angles : array like
+        Distribution of angles in degrees.
+
+    Returns
+    -------
+    mean : float
+        The mean angle of the distribution in degrees.
+    """
+    return np.rad2deg(angular_mean(np.deg2rad(angles)))
+
+
+def angular_std_deg(angles):
+    """
+    Compute the standard deviation of a distribution of angles in degrees.
+
+    Parameters
+    ---------
+    angles : array like
+        Distribution of angles in degrees.
+
+    Returns
+    -------
+    std : float
+    """
+    return np.rad2deg(angular_std(np.deg2rad(angles)))
+
+
+def interval_mean(dist, interval_min, interval_max):
+    """
+    Compute the mean of a distribution within an interval.
+
+    Return the average of the array elements which are interpreted as being
+    taken from a circular interval with endpoints given by interval_min and
+    interval_max.
+
+    Parameters
+    ----------
+    dist : array like
+        Distribution of values within an interval.
+    interval_min, interval_max : float
+        The endpoints of the interval.
+
+    Returns
+    -------
+    mean : float
+        The mean value of the distribution
+
+    """
+    # transform distribution from original interval to [-pi, pi]
+    half_width = (interval_max - interval_min) / 2.
+    center = interval_min + half_width
+    a = (np.asarray(dist) - center) / (half_width) * np.pi
+
+    # compute the angular mean and convert back to original interval
+    a_mean = angular_mean(a)
+    return (a_mean * (half_width) / np.pi) + center
+
+
+def interval_std(dist, interval_min, interval_max):
+    """
+    Compute the standard deviation of a distribution within an interval.
+
+    Return the standard deviation of the array elements which are interpreted
+    as being taken from a circular interval with endpoints given by
+    interval_min and interval_max.
+
+    Parameters
+    ----------
+    dist : array_like
+        Distribution of values within an interval.
+    interval_min, interval_max : float
+        The endpoints of the interval.
+
+    Returns
+    -------
+    std : float
+        The standard deviation of the distribution.
+
+    """
+    # transform distribution from original interval to [-pi, pi]
+    half_width = (interval_max - interval_min) / 2.
+    center = interval_min + half_width
+    a = (np.asarray(dist) - center) / (half_width) * np.pi
+
+    # compute the angular standard dev. and convert back to original interval
+    a_std = angular_std(a)
+    return (a_std * (half_width) / np.pi)

--- a/pyart/util/setup.py
+++ b/pyart/util/setup.py
@@ -3,6 +3,7 @@
 def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration('util', parent_package, top_path)
+    config.add_data_dir('tests')
     return config
 
 

--- a/pyart/util/tests/test_circular_stats.py
+++ b/pyart/util/tests/test_circular_stats.py
@@ -1,0 +1,30 @@
+""" Unit tests for the circular_stats.py module. """
+
+from pyart.util import circular_stats
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+
+def test_angles_radians():
+    dist = [2*np.pi-0.1, 0, 0.1]
+    mean = circular_stats.angular_mean(dist)
+    assert_almost_equal(mean, 0., 2)
+    std = circular_stats.angular_std(dist)
+    assert_almost_equal(std, 0.08, 2)
+
+
+def test_angles_degrees():
+    dist = [350, 0, 10, 20, 30]
+    mean = circular_stats.angular_mean_deg(dist)
+    assert_almost_equal(mean, 10., 0)
+    std = circular_stats.angular_std_deg(dist)
+    assert_almost_equal(std, 14., 0)
+
+
+def test_angles_interval():
+    dist = [7.5, 8.5, 9.5, 9.5, -9.5, -8.5]
+    mean = circular_stats.interval_mean(dist, -10, 10)
+    assert_almost_equal(mean, 9.5, 1)
+    std = circular_stats.interval_std(dist, -10, 10)
+    assert_almost_equal(std, 1.3, 1)


### PR DESCRIPTION
Add functions to calculate the mean and standard deviation for distribution of angles (in both radians and degrees) as well as distribution of samples taken over a circular interval.

These functions are useful when working with circular radar moments whose values are derived from phase based measurements, for example Doppler velocities, where conventional linear statistics are not appropriate.