### PR TITLE
ENH: grid creation function accept a single Radar object.

### DIFF
--- a/pyart/map/gates_to_grid.py
+++ b/pyart/map/gates_to_grid.py
@@ -19,6 +19,7 @@ Generate a Cartesian grid by mapping from radar gates onto the grid.
 
 import numpy as np
 from ..config import get_field_name
+from ..core.radar import Radar
 from ..graph.common import corner_to_point
 
 from ._gate_to_grid_map import GateToGridMapper
@@ -78,6 +79,10 @@ def map_gates_to_grid(
                   grid point.
 
     """
+    # make a tuple if passed a radar object as the first argument
+    if isinstance(radars, Radar):
+        radars = (radars, )
+
     if max_refl is None:    # parse max_refl
         max_refl = np.finfo('float32').max
     if grid_origin_alt is None:

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -31,6 +31,7 @@ from ..config import get_fillvalue, get_field_name
 from ..graph.common import corner_to_point
 from ..io.common import radar_coords_to_cart
 from ..core.grid import Grid
+from ..core.radar import Radar
 from ._load_nn_field_data import _load_nn_field_data
 from .ckdtree import cKDTree
 from .ball_tree import BallTree
@@ -47,7 +48,7 @@ def grid_from_radars(radars, grid_shape, grid_limits,
 
     Parameters
     ----------
-    radars : tuple of Radar objects.
+    radars : Radar or tuple of Radar objects.
         Radar objects which will be mapped to the Cartesian grid.
     grid_shape : 3-tuple of floats
         Number of points in the grid (z, y, x).
@@ -72,6 +73,10 @@ def grid_from_radars(radars, grid_shape, grid_limits,
                         radar fields.
 
     """
+    # make a tuple if passed a radar object as the first argument
+    if isinstance(radars, Radar):
+        radars = (radars, )
+
     # map the radar(s) to a cartesian grid
     if gridding_algo == 'map_to_grid':
         grids = map_to_grid(radars, grid_shape, grid_limits, **kwargs)
@@ -292,7 +297,7 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
 
     Parameters
     ----------
-    radars : tuple of Radar objects.
+    radars : Radar or tuple of Radar objects.
         Radar objects which will be mapped to the Cartesian grid.
     grid_shape : 3-tuple of floats
         Number of points in the grid (z, y, x).
@@ -404,6 +409,10 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
     grid_from_radars : Map to grid and return a Grid object.
 
     """
+    # make a tuple if passed a radar object as the first argument
+    if isinstance(radars, Radar):
+        radars = (radars, )
+
     # check the parameters
     if weighting_function.upper() not in ['CRESSMAN', 'BARNES']:
         raise ValueError('unknown weighting_function')

--- a/pyart/map/tests/test_gates_to_grid.py
+++ b/pyart/map/tests/test_gates_to_grid.py
@@ -17,6 +17,14 @@ COMMON_MAP_TO_GRID_ARGS = {
     'constant_roi': 30., }
 
 
+def test_map_to_grid_non_tuple():
+    radar = pyart.testing.make_target_radar()
+    grids = pyart.map.map_gates_to_grid(radar,
+                                        **COMMON_MAP_TO_GRID_ARGS)
+    center_slice = grids['reflectivity'][1, 4, :]
+    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+
+
 def test_map_to_grid_default():
     radar = pyart.testing.make_target_radar()
     grids = pyart.map.map_gates_to_grid((radar,),

--- a/pyart/map/tests/test_grid_mapper.py
+++ b/pyart/map/tests/test_grid_mapper.py
@@ -16,6 +16,14 @@ COMMON_MAP_TO_GRID_ARGS = {
     'roi_func': lambda z, y, x: 30, }
 
 
+def test_map_to_grid_non_tuple():
+    radar = pyart.testing.make_target_radar()
+    grids = pyart.map.map_to_grid(radar,
+                                  **COMMON_MAP_TO_GRID_ARGS)
+    center_slice = grids['reflectivity'][1, 4, :]
+    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+
+
 def test_map_to_grid_default():
     radar = pyart.testing.make_target_radar()
     grids = pyart.map.map_to_grid((radar,),
@@ -142,6 +150,25 @@ def test_grid_from_radars_errors():
 def test_grid_from_radars():
     radar = pyart.testing.make_target_radar()
     grid = pyart.map.grid_from_radars((radar,), **COMMON_MAP_TO_GRID_ARGS)
+
+    # check field data
+    center_slice = grid.fields['reflectivity']['data'][1, 4, :]
+    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+
+    # check other Grid object attributes
+    assert 'ROI' in grid.fields
+    assert np.all(grid.fields['ROI']['data'] == 30.)
+    assert_array_equal(grid.axes['x_disp']['data'],
+                       np.linspace(-900, 900, 10))
+    assert_array_equal(grid.axes['y_disp']['data'],
+                       np.linspace(-900, 900, 9).astype('float64'))
+    assert_array_equal(grid.axes['z_disp']['data'],
+                       np.linspace(-400, 400, 3).astype('float64'))
+
+
+def test_grid_from_radars_non_tuple():
+    radar = pyart.testing.make_target_radar()
+    grid = pyart.map.grid_from_radars(radar, **COMMON_MAP_TO_GRID_ARGS)
 
     # check field data
     center_slice = grid.fields['reflectivity']['data'][1, 4, :]


### PR DESCRIPTION
A common issue for users is forgetting that the grid_from_radars and underlying
function require a sequence as the first object and not a Radar object.
A one tuple is created when a single radar object is passed to these functions.