### PR TITLE
BUG: refl_filter_flag=False not working in map_gate_to_grid

### DIFF
--- a/pyart/map/_gate_to_grid_map.pyx
+++ b/pyart/map/_gate_to_grid_map.pyx
@@ -287,7 +287,7 @@ cdef class GateToGridMapper:
             azimuth = azimuths[nray] * PI / 180.0
             for ngate in range(ngates):
 
-                if field_mask[nray, ngate, 0]:
+                if filter_flag and field_mask[nray, ngate, 0]:
                     continue
 
                 # calculate cartesian coordinate assuming 4/3 earth radius


### PR DESCRIPTION
Just a small bug. Please rebuild cython, I have problems doing in my computer because of isfinite 