### PR TITLE
Add GateFilter to RadarDisplay

### DIFF
--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -321,6 +321,9 @@ class RadarDisplay(object):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             plotted.
+        gatefilter : GateFilter Instance
+            pyart.correct.GateFilter instance. None will result in no
+            gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.
@@ -423,6 +426,9 @@ class RadarDisplay(object):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             not plotted.
+        gatefilter : GateFilter Instance
+            pyart.correct.GateFilter instance. None will result in no
+            gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.
@@ -989,9 +995,12 @@ class RadarDisplay(object):
             data = np.ma.masked_where(mdata < mask_value, data)
             
         # mask data if gatefilter provided
+#        if gatefilter is not None:
+#            mask_filter = gatefilter[start:end]
+#            data.mask = mask_filter
         if gatefilter is not None:
-            mask_filter = gatefilter[start:end]
-            data.mask = mask_filter
+            mask_filter = gatefilter.gate_excluded[start:end]
+            data = np.ma.masked_array(data, mask_filter)
 
         # filter out antenna transitions
         if filter_transitions and self.antenna_transition is not None:

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -267,6 +267,7 @@ class RadarDisplay(object):
                  axislabels=(None, None), axislabels_flag=True,
                  colorbar_flag=True, colorbar_label=None,
                  colorbar_orient='vertical', edges=True,
+                 gatefilter=None,
                  filter_transitions=True, ax=None, fig=None):
         """
         Plot a PPI.
@@ -336,7 +337,7 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, y = self._get_x_y(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -367,6 +368,7 @@ class RadarDisplay(object):
                  axislabels=(None, None), axislabels_flag=True,
                  reverse_xaxis=None, colorbar_flag=True, colorbar_label=None,
                  colorbar_orient='vertical', edges=True,
+                 gatefilter=None,
                  filter_transitions=True, ax=None, fig=None):
         """
         Plot a RHI.
@@ -437,7 +439,7 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, y, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -973,7 +975,8 @@ class RadarDisplay(object):
     # Get methods #
     ###############
 
-    def _get_data(self, field, sweep, mask_tuple, filter_transitions):
+    def _get_data(self, field, sweep, mask_tuple, filter_transitions, 
+                  gatefilter):
         """ Retrieve and return data from a plot function. """
         start = self.starts[sweep]
         end = self.ends[sweep] + 1
@@ -984,6 +987,11 @@ class RadarDisplay(object):
             mask_field, mask_value = mask_tuple
             mdata = self.fields[mask_field]['data'][start:end]
             data = np.ma.masked_where(mdata < mask_value, data)
+            
+        # mask data if gatefilter provided
+        if gatefilter is not None:
+            mask_filter = gatefilter[start:end]
+            data.mask = mask_filter
 
         # filter out antenna transitions
         if filter_transitions and self.antenna_transition is not None:

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -322,7 +322,7 @@ class RadarDisplay(object):
             in which the last gate in each ray and the entire last ray are not
             plotted.
         gatefilter : GateFilter Instance
-            pyart.correct.GateFilter instance. None will result in no
+            pyart.correct.filters.GateFilter instance. None will result in no
             gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
@@ -340,7 +340,8 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions, gatefilter)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
+                              gatefilter)
         x, y = self._get_x_y(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -427,7 +428,7 @@ class RadarDisplay(object):
             in which the last gate in each ray and the entire last ray are not
             not plotted.
         gatefilter : GateFilter Instance
-            pyart.correct.GateFilter instance. None will result in no
+            pyart.correct.filters.GateFilter instance. None will result in no
             gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
@@ -445,7 +446,8 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions, gatefilter)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
+                              gatefilter)
         x, y, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -995,9 +997,6 @@ class RadarDisplay(object):
             data = np.ma.masked_where(mdata < mask_value, data)
             
         # mask data if gatefilter provided
-#        if gatefilter is not None:
-#            mask_filter = gatefilter[start:end]
-#            data.mask = mask_filter
         if gatefilter is not None:
             mask_filter = gatefilter.gate_excluded[start:end]
             data = np.ma.masked_array(data, mask_filter)

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -321,9 +321,9 @@ class RadarDisplay(object):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             plotted.
-        gatefilter : GateFilter Instance
-            pyart.correct.filters.GateFilter instance. None will result in no
-            gatefilter mask being applied to data.
+        gatefilter : GateFilter 
+            GateFilter instance. None will result in no gatefilter mask being
+            applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.
@@ -427,9 +427,9 @@ class RadarDisplay(object):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             not plotted.
-        gatefilter : GateFilter Instance
-            pyart.correct.filters.GateFilter instance. None will result in no
-            gatefilter mask being applied to data.
+        gatefilter : GateFilter 
+            GateFilter instance. None will result in no gatefilter mask being
+            applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -221,9 +221,9 @@ class RadarDisplay_Airborne(RadarDisplay):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             plotted.
-        gatefilter : GateFilter Instance
-            pyart.correct.filters.GateFilter instance. None will result in no
-            gatefilter mask being applied to data.
+        gatefilter : GateFilter 
+            GateFilter instance. None will result in no gatefilter mask being
+            applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -221,6 +221,9 @@ class RadarDisplay_Airborne(RadarDisplay):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             plotted.
+        gatefilter : GateFilter Instance
+            pyart.correct.filters.GateFilter instance. None will result in no
+            gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.
@@ -237,7 +240,8 @@ class RadarDisplay_Airborne(RadarDisplay):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
+                              gatefilter)
         x, z = self._get_x_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -181,9 +181,9 @@ class RadarMapDisplay(RadarDisplay):
         resolution : 'c', 'l', 'i', 'h', or 'f'.
             Resolution of boundary database to use. See Basemap documentation
             for details.
-        gatefilter : GateFilter Instance
-            pyart.correct.filters.GateFilter instance. None will result in no
-            gatefilter mask being applied to data.
+        gatefilter : GateFilter 
+            GateFilter instance. None will result in no gatefilter mask being
+            applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -106,6 +106,7 @@ class RadarMapDisplay(RadarDisplay):
                      min_lon=None, max_lon=None, min_lat=None, max_lat=None,
                      width=None, height=None, lon_0=None, lat_0=None,
                      resolution='h', shapefile=None, edges=True,
+                     gatefilter=None,
                      filter_transitions=True, embelish=True, **kwargs):
         """
         Plot a PPI volume sweep onto a geographic map.
@@ -180,6 +181,9 @@ class RadarMapDisplay(RadarDisplay):
         resolution : 'c', 'l', 'i', 'h', or 'f'.
             Resolution of boundary database to use. See Basemap documentation
             for details.
+        gatefilter : GateFilter Instance
+            pyart.correct.filters.GateFilter instance. None will result in no
+            gatefilter mask being applied to data.
         filter_transitions : bool
             True to remove rays where the antenna was in transition between
             sweeps from the plot.  False will include these rays in the plot.
@@ -210,7 +214,8 @@ class RadarMapDisplay(RadarDisplay):
             lon_0 = self.loc[1]
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions)
+        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
+                              gatefilter)
         x, y = self._get_x_y(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits


### PR DESCRIPTION
Add GateFilter instance (pyart.correct.GateFilter) as a keyword input to ```plot_ppi``` and ```plot_rhi``` in  ```radardisplay.py```.
If acceptable, it could be extended to the other display code. It's a relatively simple change. It will make building the ARTView masking procedure much easier and allow users to see changes of applying a masking filter to data.