### PR TITLE
A quick fix for single sweep mode type files that slightly violate CF…

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -180,7 +180,11 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         ray_angle_res = None
 
     # first sweep mode determines scan_type
-    mode = str(netCDF4.chartostring(sweep_mode['data'][0]))
+    try:
+        mode = str(netCDF4.chartostring(sweep_mode['data'][0]))
+    except IndexError:
+        mode = str(netCDF4.chartostring(sweep_mode['data']))
+
 
     # options specified in the CF/Radial standard
     if mode == 'rhi':


### PR DESCRIPTION
This is a small fix for files that slightly break cf/convention by having 1 sweep_mode per file. It just catches the exception and grabs the single value of sweep mode instead. 