### PR TITLE
Made reader more resillient to missing sweep_number parameter

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -161,11 +161,19 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         altitude_agl = None
 
     # 4.7 Sweep variables -> create atrribute dictionaries
-    sweep_number = _ncvar_to_dict(ncvars['sweep_number'])
     sweep_mode = _ncvar_to_dict(ncvars['sweep_mode'])
     fixed_angle = _ncvar_to_dict(ncvars['fixed_angle'])
     sweep_start_ray_index = _ncvar_to_dict(ncvars['sweep_start_ray_index'])
     sweep_end_ray_index = _ncvar_to_dict(ncvars['sweep_end_ray_index'])
+ 
+    if 'sweep_number' in ncvars:
+        sweep_number = _ncvar_to_dict(ncvars['sweep_number'])
+    else:
+        nsweeps = len(sweep_start_ray_index['data'])
+        sweep_number = filemetadata('sweep_number')
+        sweep_number['data'] = np.arange(nsweeps, dtype='float32')
+        print("Warning: File violates CF/Radial convention. Missing sweep_number variable")
+
     if 'target_scan_rate' in ncvars:
         target_scan_rate = _ncvar_to_dict(ncvars['target_scan_rate'])
     else:

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -688,7 +688,7 @@ def _create_ncvar(dic, dataset, name, dimensions):
     # create array from list, etc.
     data = dic['data']
     if isinstance(data, np.ndarray) is not True:
-        warnings.warn("Warning, converting non-array to array:", name)
+        warnings.warn("Warning, converting non-array to array:%s" %  name)
         data = np.array(data)
 
     # convert string/unicode arrays to character arrays

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -172,7 +172,7 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         nsweeps = len(sweep_start_ray_index['data'])
         sweep_number = filemetadata('sweep_number')
         sweep_number['data'] = np.arange(nsweeps, dtype='float32')
-        print("Warning: File violates CF/Radial convention. Missing sweep_number variable")
+        warnings.warn("Warning: File violates CF/Radial convention. Missing sweep_number variable")
 
     if 'target_scan_rate' in ncvars:
         target_scan_rate = _ncvar_to_dict(ncvars['target_scan_rate'])
@@ -688,7 +688,7 @@ def _create_ncvar(dic, dataset, name, dimensions):
     # create array from list, etc.
     data = dic['data']
     if isinstance(data, np.ndarray) is not True:
-        print("Warning, converting non-array to array:", name)
+        warnings.warn("Warning, converting non-array to array:", name)
         data = np.array(data)
 
     # convert string/unicode arrays to character arrays


### PR DESCRIPTION
Added an error recovery measure for missing sweep_number parameters. I believe the parameter is fully redundant as long as fixed angles or sweep_start_ray_index exists. Also fixed a minor spelling error. 