### PR TITLE
ENH: Hildebrand-Sekhon estimation of noise levels

### DIFF
--- a/doc/source/dev_reference/util.rst
+++ b/doc/source/dev_reference/util.rst
@@ -5,4 +5,5 @@ pyart.util
 Miscellaneous utility functions.
 
 .. automodule:: pyart.util.circular_stats
+.. automodule:: pyart.util.hildebrand_sekhon
 .. automodule:: pyart.util.xsect

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -22,6 +22,7 @@ Direction statistics
     angular_std_deg
     interval_mean
     interval_std
+    estimate_noise_hs74
 
 Miscellaneous functions
 =======================
@@ -37,5 +38,6 @@ from .circular_stats import angular_mean, angular_std
 from .circular_stats import angular_mean_deg, angular_std_deg
 from .circular_stats import interval_mean, interval_std
 from .xsect import cross_section_ppi
+from .hildebrand_sekhon import estimate_noise_hs74
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/util/hildebrand_sekhon.py
+++ b/pyart/util/hildebrand_sekhon.py
@@ -1,0 +1,72 @@
+"""
+pyart.util.hildebrand_sekhon
+============================
+
+Estimation of noise in Doppler spectra using the Hildebrand Sekhon method.
+
+.. autosummary::
+    :toctree: generated/
+
+    estimate_noise_hs74
+
+"""
+
+import numpy as np
+
+
+def estimate_noise_hs74(spectrum, navg=1):
+    """
+    Estimate noise parameters of a Doppler spectrum.
+
+    Use the method of estimating the noise level in Doppler spectra outlined
+    by Hildebrand and Sehkon, 1974.
+
+    Parameters
+    ----------
+    spectrum : array like
+        Doppler spectrum in linear units.
+    navg : int, optional
+        The number of spectral bins over which a moving average has been
+        taken. Corresponds to the **p** variable from equation 9 of the
+        article.  The default value of 1 is appropiate when no moving
+        average has been applied to the spectrum.
+
+    Returns
+    -------
+    mean : float-like
+        Mean of points in the spectrum identified as noise.
+    threshold : float-like
+        Threshold separating noise from signal.  The point in the spectrum with
+        this value or below should be considered as noise, above this value
+        signal. It is possible that all points in the spectrum are identified
+        as noise.  If a peak is required for moment calculation then the point
+        with this value should be considered as signal.
+    var : float-like
+        Variance of the points in the spectrum identified as noise.
+    nnoise : int
+        Number of noise points in the spectrum.
+
+    References
+    ----------
+    P. H. Hildebrand and R. S. Sekhon, Objective Determination of the Noise
+    Level in Doppler Spectra. Journal of Applied Meteorology, 1974, 13,
+    808-811.
+
+    """
+    sorted_spectrum = np.sort(spectrum)
+    nnoise = len(spectrum)  # default to all points in the spectrum as noise
+    for npts in range(1, len(sorted_spectrum)+1):
+        partial = sorted_spectrum[:npts]
+        mean = partial.mean()
+        var = partial.var()
+        if var * navg < mean**2.:
+            nnoise = npts
+        else:
+            # partial spectrum no longer has characteristics of white noise
+            break
+
+    noise_spectrum = sorted_spectrum[:nnoise]
+    mean = noise_spectrum.mean()
+    threshold = sorted_spectrum[nnoise-1]
+    var = noise_spectrum.var()
+    return mean, threshold, var, nnoise

--- a/pyart/util/tests/test_hildebrand_sekhon.py
+++ b/pyart/util/tests/test_hildebrand_sekhon.py
@@ -1,0 +1,22 @@
+""" Unit tests for the hildebrand_sekhon module. """
+
+from pyart.util import hildebrand_sekhon
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+SAMPLE_SPECTRUM = np.array(
+    [11.089, 10.386, 11.081, 9.696, 9.21, 11.103, 9.425,
+     10.222, 8.393, 11.67, 9.632, 10.096, 9.807, 10.374,
+     8.065, 8.682, 10.164, 320.206, 480.898, 640.818, 490.483,
+     318.578, 9.682, 10.035, 9.134, 8.554, 9.274, 9.463,
+     9.501, 10.036, 9.211, 8.265])
+
+
+def test_hildebrand_sekhon():
+    noise_params = hildebrand_sekhon.estimate_noise_hs74(SAMPLE_SPECTRUM)
+    mean, thresh, var, nnoise = noise_params
+    assert_almost_equal(mean, 10, 0)
+    assert_almost_equal(thresh, 12, 0)
+    assert_almost_equal(var, 0.79, 2)
+    assert nnoise == 27


### PR DESCRIPTION
Add the pyart.util.estimate_noise_hs74 which estimates the noise parameter of a
Doppler spectrum using the Hildebrand and Sekhon method