### PR TITLE
ENH: replace_existing in Grid

### DIFF
--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -65,25 +65,34 @@ class Grid(object):
         write_grid(filename, self, format=format,
                    arm_time_variables=arm_time_variables)
 
-    def add_field(self, field_name, field_dict):
-        """ Add field to Grid object.
+    def add_field(self, field_name, field_dict, replace_existing=False):
+        """
+        Add a field to the object.
 
         Parameters
         ----------
         field_name : str
-            Name of field to add.
+            Name of the field to the fields dictionary.
         field_dict : dict
             Dictionary containing field data and metadata.
+        replace_existing : bool, optional
+            True to replace the existing field with key field_name if it
+            exists, overwriting the existing data. If False, a ValueError is
+            raised if field_name already exists.
+
         """
 
+        # grid fields should have dimensions of (nz, ny, nx)
         nz, ny, nx = self.fields[self.fields.keys[0]]['data'].shape
 
+        # checks to make sure input field dictionary is valid
         if 'data' not in field_dict:
             raise KeyError('Field dictionary must contain a "data" key')
-        if field_name in self.fields:
+        if field_name in self.fields and replace_existing is False:
             raise ValueError('A field named %s already exists' % (field_name))
         if field_dict['data'].shape != (nz, ny, nx):
             raise ValueError('Field has invalid shape')
 
         self.fields[field_name] = field_dict
+
         return

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -83,7 +83,7 @@ class Grid(object):
         """
 
         # grid fields should have dimensions of (nz, ny, nx)
-        nz, ny, nx = self.fields[self.fields.keys[0]]['data'].shape
+        nz, ny, nx = self.fields[self.fields.keys()[0]]['data'].shape
 
         # checks to make sure input field dictionary is valid
         if 'data' not in field_dict:


### PR DESCRIPTION
Adding the `replace_existing` kwarg to the `add_field` method of Grid. This is to be consistent with the Radar class and its add_field method. I know we plan on overhauling the Grid class but this method should be portable regardless of the changes to Grid in the future.