### PR TITLE
ENH: More informative error messages when optional dependency is missing

### DIFF
--- a/doc/source/dev_reference/index.rst
+++ b/doc/source/dev_reference/index.rst
@@ -27,6 +27,7 @@ Documentation is broken down by directory and module.
     filters
     map
     util
+    pkg_util
     bridge
     testing
     _debug_info

--- a/doc/source/dev_reference/pkg_util.rst
+++ b/doc/source/dev_reference/pkg_util.rst
@@ -1,0 +1,8 @@
+==============
+pyart.pkg_util
+==============
+
+Package utilities.
+
+.. automodule:: pyart.pkg_util.decorators
+.. automodule:: pyart.pkg_util.exceptions

--- a/pyart/aux_io/__init__.py
+++ b/pyart/aux_io/__init__.py
@@ -39,11 +39,7 @@ from .d3r_gcpex_nc import read_d3r_gcpex_nc
 from .noxp_iphex_nc import read_noxp_iphex_nc
 from .arm_vpt import read_kazr
 from .edge_netcdf import read_edge_netcdf
-try:
-    from .gamic_hdf5 import read_gamic
-    from .odim_h5 import read_odim_h5
-    _HDF5_AVAILABLE = True
-except:
-    _HDF5_AVAILABLE = False
+from .odim_h5 import read_odim_h5
+from .gamic_hdf5 import read_gamic
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/aux_io/gamic_hdf5.py
+++ b/pyart/aux_io/gamic_hdf5.py
@@ -32,7 +32,7 @@ try:
     _HDF5_AVAILABLE = True
 except ImportError:
     _HDF5_AVAILABLE = False
-from ..pkg_util.requires_decorator import requires
+from ..pkg_util.decorators import requires
 
 
 LIGHT_SPEED = 2.99792458e8  # speed of light in meters per second

--- a/pyart/aux_io/gamic_hdf5.py
+++ b/pyart/aux_io/gamic_hdf5.py
@@ -27,12 +27,18 @@ import numpy as np
 from ..config import FileMetadata, get_fillvalue
 from ..io.common import make_time_unit_str, _test_arguments
 from ..core.radar import Radar
-from .gamicfile import GAMICFile
+try:
+    from .gamicfile import GAMICFile
+    _HDF5_AVAILABLE = True
+except ImportError:
+    _HDF5_AVAILABLE = False
+from ..pkg_util.requires_decorator import requires
 
 
 LIGHT_SPEED = 2.99792458e8  # speed of light in meters per second
 
 
+@requires('h5py', _HDF5_AVAILABLE)
 def read_gamic(filename, field_names=None, additional_metadata=None,
                file_field_names=False, exclude_fields=None,
                valid_range_from_file=True, units_from_file=True, **kwargs):

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -14,12 +14,17 @@ Routines for reading ODIM_H5 files.
 import datetime
 
 import numpy as np
-import h5py
+try:
+    import h5py
+    _HDF5_AVAILABLE = True
+except ImportError:
+    _HDF5_AVAILABLE = False
 
 from ..config import FileMetadata, get_fillvalue
 from ..io.common import make_time_unit_str, radar_coords_to_cart
 from ..io.common import _test_arguments
 from ..core.radar import Radar
+from ..pkg_util.requires_decorator import requires
 
 
 ODIM_H5_FIELD_NAMES = {
@@ -40,6 +45,7 @@ ODIM_H5_FIELD_NAMES = {
 }
 
 
+@requires('h5py', _HDF5_AVAILABLE)
 def read_odim_h5(filename, field_names=None, additional_metadata=None,
                  file_field_names=False, exclude_fields=None, **kwargs):
     """

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -24,7 +24,7 @@ from ..config import FileMetadata, get_fillvalue
 from ..io.common import make_time_unit_str, radar_coords_to_cart
 from ..io.common import _test_arguments
 from ..core.radar import Radar
-from ..pkg_util.requires_decorator import requires
+from ..pkg_util.decorators import requires
 
 
 ODIM_H5_FIELD_NAMES = {

--- a/pyart/bridge/__init__.py
+++ b/pyart/bridge/__init__.py
@@ -19,12 +19,6 @@ Phase functions
 
 """
 
-try:
-    from .wradlib_bridge import texture_of_complex_phase
-    _WRADLIB_AVAILABLE = True
-except ImportError:
-    _WRADLIB_AVAILABLE = False
-
-if _WRADLIB_AVAILABLE:
-    from .. import retrieve as _retrieve
-    _retrieve.texture_of_complex_phase = texture_of_complex_phase
+from .wradlib_bridge import texture_of_complex_phase
+from .. import retrieve as _retrieve
+_retrieve.texture_of_complex_phase = texture_of_complex_phase

--- a/pyart/bridge/tests/test_wradlib_bridge.py
+++ b/pyart/bridge/tests/test_wradlib_bridge.py
@@ -7,7 +7,7 @@ from numpy.testing.decorators import skipif
 import pyart
 
 
-@skipif(not pyart.bridge._WRADLIB_AVAILABLE)
+@skipif(not pyart.bridge.wradlib_bridge._WRADLIB_AVAILABLE)
 def test_texture_of_complex_phase():
     test_radar = pyart.testing.make_empty_ppi_radar(100, 360, 5)
     foo_field = {'data': np.zeros([360*5, 100])}

--- a/pyart/bridge/wradlib_bridge.py
+++ b/pyart/bridge/wradlib_bridge.py
@@ -11,13 +11,18 @@ Py-ART methods linking to wradlib functions, http://wradlib.bitbucket.org/
 
 """
 
-
-import wradlib
+try:
+    import wradlib
+    _WRADLIB_AVAILABLE = True
+except ImportError:
+    _WRADLIB_AVAILABLE = False
 import numpy as np
 
 from ..config import get_metadata, get_field_name
+from ..pkg_util.decorators import requires
 
 
+@requires('wradlib', _WRADLIB_AVAILABLE)
 def texture_of_complex_phase(radar, phidp_field=None,
                              phidp_texture_field=None):
     """

--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -36,10 +36,7 @@ Helper functions
 
 """
 
-try:
-    from .dealias import dealias_fourdd, find_time_in_interp_sonde
-except ImportError:
-    pass
+from .dealias import dealias_fourdd, find_time_in_interp_sonde
 from .attenuation import calculate_attenuation
 from .phase_proc import phase_proc_lp
 # for backwards compatibility GateFilter available in the correct namespace

--- a/pyart/correct/dealias.py
+++ b/pyart/correct/dealias.py
@@ -12,18 +12,22 @@ Front end to the University of Washington 4DD code for Doppler dealiasing.
     _create_rsl_volume
 
 """
-# Nothing from this module is imported to pyart.correct if RSL is not
-# installed.
 
 import numpy as np
 
 from ..config import get_field_name, get_fillvalue, get_metadata
-from ..io import _rsl_interface
-from . import _fourdd_interface
+try:
+    from ..io import _rsl_interface
+    from . import _fourdd_interface
+    _FOURDD_AVAILABLE = True
+except ImportError:
+    _FOURDD_AVAILABLE = False
 from ._common_dealias import _parse_gatefilter
 from ..util import datetime_utils
+from ..pkg_util.decorators import requires
 
 
+@requires('TRMM RSL', _FOURDD_AVAILABLE)
 def dealias_fourdd(radar, last_radar=None, sounding_heights=None,
                    sounding_wind_speeds=None, sounding_wind_direction=None,
                    gatefilter=False, filt=1, rsl_badval=131072.0,

--- a/pyart/correct/tests/test_dealias.py
+++ b/pyart/correct/tests/test_dealias.py
@@ -14,7 +14,7 @@ from numpy.testing.decorators import skipif
 from numpy.testing import assert_raises
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_find_time_in_interp_sounde():
     target = datetime.datetime(2011, 5, 10, 11, 30, 8)
     interp_sounde = netCDF4.Dataset(pyart.testing.INTERP_SOUNDE_FILE)
@@ -34,7 +34,7 @@ def test_find_time_in_interp_sounde():
     assert_almost_equal(direction[100], 231.8, 2) == 231.8
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_dealias_sounding():
     radar, dealias_vel = perform_dealias()
     assert_allclose(
@@ -46,7 +46,7 @@ def test_dealias_sounding():
     assert dealias_vel['data'][13, 47] is np.ma.masked
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_dealias_sounding_keep_original():
     radar, dealias_vel = perform_dealias(True)
     assert_allclose(
@@ -72,7 +72,7 @@ def perform_dealias(keep_original=False):
     return radar, dealias_vel
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_dealias_last_radar_and_sounding():
     radar = pyart.testing.make_velocity_aliased_radar()
     last_radar = pyart.testing.make_velocity_aliased_radar(False)
@@ -91,7 +91,7 @@ def test_dealias_last_radar_and_sounding():
     return
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_dealias_last_radar_and_sounding():
     radar = pyart.testing.make_velocity_aliased_radar()
     last_radar = pyart.testing.make_velocity_aliased_radar(False)
@@ -105,7 +105,7 @@ def test_dealias_last_radar_and_sounding():
     return
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
 def test_error_raising():
 
     # ValueError when no sounding or last_radar provided

--- a/pyart/graph/__init__.py
+++ b/pyart/graph/__init__.py
@@ -30,17 +30,7 @@ Plotting grid data
 from .radardisplay import RadarDisplay
 from . import cm
 from .radardisplay_airborne import RadarDisplay_Airborne
-
-try:
-    from .gridmapdisplay import GridMapDisplay
-except ImportError:
-    import warnings
-    warnings.warn('No grid plotting support, requires basemap.')
-
-try:
-    from .radarmapdisplay import RadarMapDisplay
-except ImportError:
-    import warnings
-    warnings.warn('No grid plotting support, requires basemap.')
+from .gridmapdisplay import GridMapDisplay
+from .radarmapdisplay import RadarMapDisplay
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -16,12 +16,18 @@ from __future__ import print_function
 
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import Basemap
-from mpl_toolkits.basemap import pyproj
+try:
+    from mpl_toolkits.basemap import Basemap
+    from mpl_toolkits.basemap import pyproj
+    _BASEMAP_AVAILABLE = True
+except ImportError:
+    _BASEMAP_AVAILABLE = False
 
 from . import common
+from ..pkg_util.decorators import requires
 
 
+@requires('basemap', _BASEMAP_AVAILABLE)
 class GridMapDisplay():
     """
     A class for creating plots from a grid object on top of a Basemap.

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -13,12 +13,18 @@ Class for creating plots on a geographic map using a Radar object.
 """
 
 import numpy as np
-from mpl_toolkits.basemap import Basemap
+try:
+    from mpl_toolkits.basemap import Basemap
+    _BASEMAP_AVAILABLE = True
+except ImportError:
+    _BASEMAP_AVAILABLE = False
 
 from .radardisplay import RadarDisplay
 from .common import parse_ax_fig, parse_vmin_vmax
+from ..pkg_util.decorators import requires
 
 
+@requires('basemap', _BASEMAP_AVAILABLE)
 class RadarMapDisplay(RadarDisplay):
     """
     A display object for creating plots on a geographic map from data in a
@@ -181,7 +187,7 @@ class RadarMapDisplay(RadarDisplay):
         resolution : 'c', 'l', 'i', 'h', or 'f'.
             Resolution of boundary database to use. See Basemap documentation
             for details.
-        gatefilter : GateFilter 
+        gatefilter : GateFilter
             GateFilter instance. None will result in no gatefilter mask being
             applied to data.
         filter_transitions : bool

--- a/pyart/graph/tests/test_gridmapdisplay.py
+++ b/pyart/graph/tests/test_gridmapdisplay.py
@@ -13,7 +13,7 @@ from numpy.testing.decorators import skipif
 RESOLUTION = 'c'    # crude resolution to speed up tests
 
 
-@skipif('GridMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
 def test_gridmapdisplay_simple(outfile=None):
     # test basic GridMapDisplay functionality
     grid = pyart.testing.make_target_grid()
@@ -26,7 +26,7 @@ def test_gridmapdisplay_simple(outfile=None):
         fig.savefig(outfile)
 
 
-@skipif('GridMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
 def test_gridmapdisplay_fancy(outfile=None):
     # test a bunch of GridMapDisplay functionality
     grid = pyart.testing.make_target_grid()
@@ -57,7 +57,7 @@ def test_gridmapdisplay_fancy(outfile=None):
         fig.savefig(outfile)
 
 
-@skipif('GridMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
 def test_error_raising():
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplay(grid)

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -13,7 +13,7 @@ from numpy.testing.decorators import skipif
 
 
 # Top level Figure generating tests
-@skipif('RadarMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.radarmapdisplay._BASEMAP_AVAILABLE)
 def test_radarmapdisplay_ppi(outfile=None):
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
     display = pyart.graph.RadarMapDisplay(radar, shift=(0.1, 0.0))
@@ -32,7 +32,7 @@ def test_radarmapdisplay_ppi(outfile=None):
 
 
 # Tests of methods, these tests do not generate figures
-@skipif('RadarMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.radarmapdisplay._BASEMAP_AVAILABLE)
 def test_radarmapdisplay_auto_range():
     # test the auto_range=True function
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
@@ -47,7 +47,7 @@ def test_radarmapdisplay_auto_range():
     plt.close()
 
 
-@skipif('RadarMapDisplay' not in dir(pyart.graph))
+@skipif(not pyart.graph.radarmapdisplay._BASEMAP_AVAILABLE)
 def test_error_raising():
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
     display = pyart.graph.RadarMapDisplay(radar, shift=(0.1, 0.0))

--- a/pyart/io/__init__.py
+++ b/pyart/io/__init__.py
@@ -67,11 +67,7 @@ Special use
 
 """
 
-try:
-    from .rsl import read_rsl
-    _RSL_AVAILABLE = True
-except ImportError:
-    _RSL_AVAILABLE = False
+from .rsl import read_rsl
 from .mdv_radar import read_mdv
 from .sigmet import read_sigmet
 from .chl import read_chl

--- a/pyart/io/auto_read.py
+++ b/pyart/io/auto_read.py
@@ -17,9 +17,7 @@ import gzip
 
 import netCDF4
 
-from . import _RSL_AVAILABLE
-if _RSL_AVAILABLE:
-    from .rsl import read_rsl
+from .rsl import read_rsl
 from .mdv_radar import read_mdv
 from .cfradial import read_cfradial
 from .sigmet import read_sigmet

--- a/pyart/io/rsl.py
+++ b/pyart/io/rsl.py
@@ -19,19 +19,24 @@ Python wrapper around the RSL library.
 
 """
 
-# Nothing from this module is imported into pyart.io if RSL is not installed.
 import sys
 import numpy as np
 import warnings
 import datetime
 
 from ..config import FileMetadata, get_fillvalue
-from . import _rsl_interface
+try:
+    from . import _rsl_interface
+    _RSL_AVAILABLE = True
+except ImportError:
+    _RSL_AVAILABLE = False
 from ..core.radar import Radar
 from .common import dms_to_d, make_time_unit_str
 from .lazydict import LazyLoadDict
+from ..pkg_util.decorators import requires
 
 
+@requires('TRMM RSL', _RSL_AVAILABLE)
 def read_rsl(filename, field_names=None, additional_metadata=None,
              file_field_names=False, exclude_fields=None,
              delay_field_loading=False,

--- a/pyart/io/tests/test_auto_read.py
+++ b/pyart/io/tests/test_auto_read.py
@@ -27,7 +27,7 @@ def test_autoread_sigmet():
     assert radar.metadata['original_container'] == 'sigmet'
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_autoread_sigmet_rsl():
     radar = pyart.io.read(pyart.testing.SIGMET_PPI_FILE, use_rsl=True)
     assert radar.metadata['original_container'] == 'rsl'

--- a/pyart/io/tests/test_rsl.py
+++ b/pyart/io/tests/test_rsl.py
@@ -12,12 +12,12 @@ import pyart
 ############################################
 
 # read in the sample file and create a a Radar object
-if pyart.io._RSL_AVAILABLE:
+if pyart.io.rsl._RSL_AVAILABLE:
     radar = pyart.io.read_rsl(pyart.testing.SIGMET_PPI_FILE)
 
 
 # time attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_time():
     assert 'comment' in radar.time.keys()
     assert 'long_name' in radar.time.keys()
@@ -31,7 +31,7 @@ def test_time():
 
 
 # range attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_range():
     assert 'long_name' in radar.range
     assert 'standard_name' in radar.range
@@ -48,20 +48,20 @@ def test_range():
 
 
 # metadata attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_metadata():
     assert 'instrument_name' in radar.metadata
     assert 'source' in radar.metadata
 
 
 # scan_type attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_scan_type():
     assert radar.scan_type == 'ppi'
 
 
 # latitude attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_latitude():
     assert 'data' in radar.latitude
     assert 'standard_name' in radar.latitude
@@ -71,7 +71,7 @@ def test_latitude():
 
 
 # longitude attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_longitude():
     assert 'data' in radar.longitude
     assert 'standard_name' in radar.longitude
@@ -81,7 +81,7 @@ def test_longitude():
 
 
 # altitude attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_altitude():
     assert 'data' in radar.altitude
     assert 'standard_name' in radar.altitude
@@ -92,20 +92,20 @@ def test_altitude():
 
 
 # altitude_agl attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_altitude_agl():
     assert radar.altitude_agl is None
 
 
 # sweep_number attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_sweep_number():
     assert 'standard_name' in radar.sweep_number
     assert np.all(radar.sweep_number['data'] == range(1))
 
 
 # sweep_mode attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_sweep_mode():
     assert 'standard_name' in radar.sweep_mode
     assert radar.sweep_mode['data'].shape == (1, )
@@ -114,7 +114,7 @@ def test_sweep_mode():
 
 
 # fixed_angle attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_fixed_angle():
     assert 'standard_name' in radar.fixed_angle
     assert 'units' in radar.fixed_angle
@@ -123,7 +123,7 @@ def test_fixed_angle():
 
 
 # sweep_start_ray_index attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_sweep_start_ray_index():
     assert 'long_name' in radar.sweep_start_ray_index
     assert radar.sweep_start_ray_index['data'].shape == (1, )
@@ -131,7 +131,7 @@ def test_sweep_start_ray_index():
 
 
 # sweep_end_ray_index attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_sweep_end_ray_index():
     assert 'long_name' in radar.sweep_end_ray_index
     assert radar.sweep_end_ray_index['data'].shape == (1, )
@@ -139,13 +139,13 @@ def test_sweep_end_ray_index():
 
 
 # target_scan_rate attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_target_scan_rate():
     assert radar.target_scan_rate is None
 
 
 # azimuth attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_azimuth():
     assert 'standard_name' in radar.azimuth
     assert 'long_name' in radar.azimuth
@@ -156,7 +156,7 @@ def test_azimuth():
 
 
 # elevation attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_elevation():
     assert 'standard_name' in radar.elevation
     assert 'long_name' in radar.azimuth
@@ -167,19 +167,19 @@ def test_elevation():
 
 
 # scan_rate attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_scan_rate():
     assert radar.scan_rate is None
 
 
 # antenna_transition attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_antenna_transition():
     assert radar.antenna_transition is None
 
 
 # instrument_parameters attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_instument_parameters():
     # instrument_parameter sub-convention
     keys = ['prt', 'unambiguous_range', 'prt_mode', 'nyquist_velocity']
@@ -196,7 +196,7 @@ def check_instrument_parameter(param):
 
 
 # radar_parameters attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_radar_parameters():
     # instrument_parameter sub-convention
     keys = ['radar_beam_width_h', 'radar_beam_width_v']
@@ -213,25 +213,25 @@ def check_radar_parameter(param):
 
 
 # radar_calibration attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_radar_calibration():
     assert radar.radar_calibration is None
 
 
 # ngates attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_ngates():
     assert radar.ngates == 25
 
 
 # nrays attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_nrays():
     assert radar.nrays == 20
 
 
 # nsweeps attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_nsweeps():
     assert radar.nsweeps == 1
 
@@ -241,7 +241,7 @@ def test_nsweeps():
 ####################
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_field_dics():
     fields = ['reflectivity', ]
     for field in fields:
@@ -250,7 +250,7 @@ def test_field_dics():
         yield check_field_dic, field
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def check_field_dic(field):
     """ Check that the required keys are present in a field dictionary. """
     assert 'standard_name' in radar.fields[field]
@@ -259,7 +259,7 @@ def check_field_dic(field):
     assert 'coordinates' in radar.fields[field]
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_field_shapes():
     fields = ['reflectivity', ]
     for field in fields:
@@ -272,7 +272,7 @@ def check_field_shape(field):
     assert radar.fields[field]['data'].shape == (20, 25)
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_field_types():
     fields = {'reflectivity': MaskedArray, }
     for field, field_type in fields.items():
@@ -285,7 +285,7 @@ def check_field_type(field, field_type):
     assert type(radar.fields[field]['data']) is field_type
 
 
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_field_first_points():
     # these values can be found using:
     # [round(radar.fields[f]['data'][0,0]) for f in radar.fields]
@@ -304,26 +304,26 @@ def check_field_first_point(field, value):
 # RHI tests #
 #############
 
-if pyart.io._RSL_AVAILABLE:
+if pyart.io.rsl._RSL_AVAILABLE:
     RADAR_RHI = pyart.io.read_rsl(pyart.testing.SIGMET_RHI_FILE,
                                   delay_field_loading=True)
 
 
 # nsweeps attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_nsweeps():
     assert RADAR_RHI.nsweeps == 1
 
 
 # sweep_number attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_sweep_number():
     assert 'standard_name' in RADAR_RHI.sweep_number
     assert np.all(RADAR_RHI.sweep_number['data'] == range(1))
 
 
 # sweep_mode attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_sweep_mode():
     assert 'standard_name' in RADAR_RHI.sweep_mode
     assert RADAR_RHI.sweep_mode['data'].shape == (1, )
@@ -332,7 +332,7 @@ def test_rhi_sweep_mode():
 
 
 # fixed_angle attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_fixed_angle():
     assert 'standard_name' in RADAR_RHI.fixed_angle
     assert 'units' in RADAR_RHI.fixed_angle
@@ -341,7 +341,7 @@ def test_rhi_fixed_angle():
 
 
 # sweep_start_ray_index attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_sweep_start_ray_index():
     assert 'long_name' in RADAR_RHI.sweep_start_ray_index
     assert RADAR_RHI.sweep_start_ray_index['data'].shape == (1, )
@@ -349,7 +349,7 @@ def test_rhi_sweep_start_ray_index():
 
 
 # sweep_end_ray_index attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_sweep_end_ray_index():
     assert 'long_name' in RADAR_RHI.sweep_end_ray_index
     assert RADAR_RHI.sweep_end_ray_index['data'].shape == (1, )
@@ -357,7 +357,7 @@ def test_rhi_sweep_end_ray_index():
 
 
 # azimuth attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_azimuth():
     assert 'standard_name' in RADAR_RHI.azimuth
     assert 'long_name' in RADAR_RHI.azimuth
@@ -368,7 +368,7 @@ def test_rhi_azimuth():
 
 
 # elevation attribute
-@skipif(not pyart.io._RSL_AVAILABLE)
+@skipif(not pyart.io.rsl._RSL_AVAILABLE)
 def test_rhi_elevation():
     assert 'standard_name' in RADAR_RHI.elevation
     assert 'long_name' in RADAR_RHI.azimuth

--- a/pyart/pkg_util/__init__.py
+++ b/pyart/pkg_util/__init__.py
@@ -1,0 +1,17 @@
+"""
+=================================
+Utilities (:mod:`pyart.pkg_util`)
+=================================
+
+Package utilities.
+
+Nothing in the sub-package is imported into the pyart namespace, and this
+docstring will not be present in the documentation.
+
+The intention of module in this directory is to provide features used
+internally within the package.  Users of Py-ART should never need interact
+with these modules.
+
+"""
+# Nothing imported, see above.
+# Features in this directory should be accessed using relative imports

--- a/pyart/pkg_util/decorators.py
+++ b/pyart/pkg_util/decorators.py
@@ -1,9 +1,8 @@
 """
-pyart.pkg_util.requires_decorator
-=================================
+pyart.pkg_util.decorators
+=========================
 
-Decorator for indicating a function or method requires that an optional
-dependecy by installed.
+Various decorators.
 
 .. autosummary::
     :toctree: generated/
@@ -12,13 +11,11 @@ dependecy by installed.
 
 """
 
-
-class MissingOptionalDepedency(Exception):
-    """ Exception raised when a optional depency is needed by not found. """
-    pass
+from .exceptions import MissingOptionalDepedency
 
 
-_MESSAGE = "The use of '%s' requires that the package %s be installed."
+_REQUIRES_MESSAGE = (
+    "The use of '%s' requires that the package %s be installed.")
 
 
 def requires(requirement_name, requirement_check):
@@ -49,7 +46,7 @@ def requires(requirement_name, requirement_check):
             """ Actual wrapper around the function/method. """
             if not requirement_check:
                 raise MissingOptionalDepedency(
-                    _MESSAGE % (func.__name__, requirement_name))
+                    _REQUIRES_MESSAGE % (func.__name__, requirement_name))
             return func(*args, **kwargs)
         return wrapper
     return wrap_with_requirement

--- a/pyart/pkg_util/exceptions.py
+++ b/pyart/pkg_util/exceptions.py
@@ -1,0 +1,17 @@
+"""
+pyart.pkg_util.exceptions
+=========================
+
+Various exceptions.
+
+.. autosummary::
+    :toctree: generated/
+
+    requires
+
+"""
+
+
+class MissingOptionalDepedency(Exception):
+    """ Exception raised when a optional depency is needed by not found. """
+    pass

--- a/pyart/pkg_util/exceptions.py
+++ b/pyart/pkg_util/exceptions.py
@@ -7,7 +7,7 @@ Various exceptions.
 .. autosummary::
     :toctree: generated/
 
-    requires
+    MissingOptionalDepedency
 
 """
 

--- a/pyart/pkg_util/requires_decorator.py
+++ b/pyart/pkg_util/requires_decorator.py
@@ -1,0 +1,55 @@
+"""
+pyart.pkg_util.requires_decorator
+=================================
+
+Decorator for indicating a function or method requires that an optional
+dependecy by installed.
+
+.. autosummary::
+    :toctree: generated/
+
+    requires
+
+"""
+
+
+class MissingOptionalDepedency(Exception):
+    """ Exception raised when a optional depency is needed by not found. """
+    pass
+
+
+_MESSAGE = "The use of '%s' requires that the package %s be installed."
+
+
+def requires(requirement_name, requirement_check):
+    """
+    Decorate a function which requires an optional dependency.
+
+    Use this function as a decorator to a function or method which requires
+    that a optional depency be installed.  The function can then be imported
+    into the package namespace.  When called the decorated function or method
+    will raise a MissingOptionalDepedency error with a helpful message to
+    providing information about what package must be installed to use the
+    particular function or method in question
+
+    Parameters
+    ----------
+    requirement_name : str
+        Name of package which is required for use of the decorated function or
+        method.
+    requirement_check : bool
+        Boolean indicating if the requirement has been met.  Typically this is
+        a variable which determines if required package is installed at run
+        time.
+
+    """
+    def wrap_with_requirement(func):
+        """ Wrap a function/method with a check for a requirement. """
+        def wrapper(*args, **kwargs):
+            """ Actual wrapper around the function/method. """
+            if not requirement_check:
+                raise MissingOptionalDepedency(
+                    _MESSAGE % (func.__name__, requirement_name))
+            return func(*args, **kwargs)
+        return wrapper
+    return wrap_with_requirement

--- a/pyart/pkg_util/setup.py
+++ b/pyart/pkg_util/setup.py
@@ -1,0 +1,12 @@
+
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('pkg_util', parent_package, top_path)
+    config.add_data_dir('tests')
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/pyart/pkg_util/tests/test_decorators.py
+++ b/pyart/pkg_util/tests/test_decorators.py
@@ -1,9 +1,9 @@
-""" Unit tests for the requires_decorator module. """
+""" Unit tests for the decorators module. """
 
 from numpy.testing import assert_raises
 
-from pyart.pkg_util.requires_decorator import requires
-from pyart.pkg_util.requires_decorator import MissingOptionalDepedency
+from pyart.pkg_util.decorators import requires
+from pyart.pkg_util.exceptions import MissingOptionalDepedency
 
 
 HAS_PACKAGE1 = True     # package 1 is installed

--- a/pyart/pkg_util/tests/test_requires_decorator.py
+++ b/pyart/pkg_util/tests/test_requires_decorator.py
@@ -1,0 +1,53 @@
+""" Unit tests for the requires_decorator module. """
+
+from numpy.testing import assert_raises
+
+from pyart.pkg_util.requires_decorator import requires
+from pyart.pkg_util.requires_decorator import MissingOptionalDepedency
+
+
+HAS_PACKAGE1 = True     # package 1 is installed
+HAS_PACKAGE2 = False    # package 2 is not installed
+
+
+@requires('Package 1', HAS_PACKAGE1)
+def function_that_requires_package1():
+    return 1
+
+
+@requires('Package 2', HAS_PACKAGE2)
+def function_that_requires_package2():
+    return 2
+
+
+class ExampleClass(object):
+
+    value = 9
+
+    @requires('Package 1', HAS_PACKAGE1)
+    def method1(self):
+        return self.value
+
+    @requires('Package 2', HAS_PACKAGE2)
+    def method2(self):
+        return self.value
+
+
+def test_requires_met():
+
+    assert function_that_requires_package1() == 1
+
+    example = ExampleClass()
+    assert example.method1() == 9
+
+
+def test_requires_unmet():
+
+    # accessing the function/method with unmet requirement should not raise an
+    # exception, only calling them
+    assert hasattr(function_that_requires_package2, '__call__')
+    example = ExampleClass()
+    assert hasattr(example.method2, '__call__')
+
+    assert_raises(MissingOptionalDepedency, function_that_requires_package2)
+    assert_raises(MissingOptionalDepedency, example.method2)

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -21,12 +21,7 @@ Radar retrievals
 
 """
 
-try:
-    from .echo_class import steiner_conv_strat
-    _F90_EXTENSIONS_AVAILABLE = True
-except:
-    _F90_EXTENSIONS_AVAILABLE = False
-
+from .echo_class import steiner_conv_strat
 from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
 

--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -14,9 +14,15 @@ steiner_conv_strat
 import numpy as np
 
 from ..config import get_fillvalue, get_field_name
-from . import _echo_steiner
+from ..pkg_util.decorators import requires
+try:
+    from . import _echo_steiner
+    _F90_EXTENSIONS_AVAILABLE = True
+except ImportError:
+    _F90_EXTENSIONS_AVAILABLE = False
 
 
+@requires('Fortran 90 extensions', _F90_EXTENSIONS_AVAILABLE)
 def steiner_conv_strat(grid, dx=None, dy=None, intense=42.0,
                        work_level=3000.0, peak_relation='default',
                        area_relation='medium', bkg_rad=11000.0,
@@ -109,7 +115,7 @@ def steiner_conv_strat(grid, dx=None, dy=None, intense=42.0,
             'valid_min': 0,
             'valid_max': 2,
             'comment_1': ('Convective-stratiform echo '
-                         'classification based on '
-                         'Steiner et al. (1995)'),
+                          'classification based on '
+                          'Steiner et al. (1995)'),
             'comment_2': ('0 = Undefined, 1 = Stratiform, '
                           '2 = Convective')}

--- a/pyart/retrieve/tests/test_echo_class.py
+++ b/pyart/retrieve/tests/test_echo_class.py
@@ -6,7 +6,7 @@ from numpy.testing.decorators import skipif
 import pyart
 
 
-@skipif(not pyart.retrieve._F90_EXTENSIONS_AVAILABLE)
+@skipif(not pyart.retrieve.echo_class._F90_EXTENSIONS_AVAILABLE)
 def test_steiner_conv_strat():
     grid = pyart.testing.make_storm_grid()
     eclass = pyart.retrieve.steiner_conv_strat(grid)

--- a/pyart/setup.py
+++ b/pyart/setup.py
@@ -13,6 +13,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('filters')
     config.add_subpackage('testing')
     config.add_subpackage('util')
+    config.add_subpackage('pkg_util')
     config.add_subpackage('aux_io')
     config.add_subpackage('bridge')
 


### PR DESCRIPTION
When a function or class is accessed which requires an optional dependency that is missing a **MissingOptionalDependecy** exception is raised with a helpful message.