### PR TITLE
ENH: New Layout from Grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ examples/plotting/KATX20130717_195021_V06
 examples/plotting/Level2_KATX_20130717_1950.ar2v
 examples/plotting/sgpxsaprrhicmacI5.c0.20110524.015604_NC4.nc
 examples/plotting/20110520100000_nex_3d.nc
+examples/plotting/20110520100000_nexrad_grid.nc
 examples/plotting/narr-a_221_20110520_0000_000.nc
 examples/plotting/nsaxsaprppiC1.a1.20140201.184802.nc
 

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -22,8 +22,8 @@ import pyart
 
 
 # read in the NEXRAD data, create the display
-fname = '20110520100000_nex_3d.nc'
-grid = pyart.io.read_legacy_grid(fname)
+fname = '20110520100000_nexrad_grid.nc'
+grid = pyart.io.read_grid(fname)
 display = pyart.graph.GridMapDisplay(grid)
 
 # create the figure

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -94,7 +94,7 @@ display.plot_latitude_slice(
     axislabels=('', 'Height (km)'))
 
 # add a title
-slc_height = grid.regular_z['data'][level]
+slc_height = grid.z['data'][level]
 dts = num2date(grid.time['data'], grid.time['units'])
 datestr = dts[0].strftime('%H:%M Z on %Y-%m-%d')
 title = 'Sliced at ' + str(slc_height) + ' meters at ' + datestr

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -23,7 +23,7 @@ import pyart
 
 # read in the NEXRAD data, create the display
 fname = '20110520100000_nex_3d.nc'
-grid = pyart.io.read_grid(fname)
+grid = pyart.io.read_legacy_grid(fname)
 display = pyart.graph.GridMapDisplay(grid)
 
 # create the figure

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -52,8 +52,7 @@ display.plot_grid('REF', level=level, vmin=vmin, vmax=vmax, title_flag=False,
 display.plot_crosshairs(lon=lon, lat=lat)
 
 # fetch NCEP NARR data
-grid_time = display.grid.axes['time']
-grid_date = num2date(grid_time['data'], grid_time['units'])[0]
+grid_date = num2date(grid.time['data'], grid.time['units'])[0]
 y_m_d = grid_date.strftime('%Y%m%d')
 y_m = grid_date.strftime('%Y%m')
 url = ('http://nomads.ncdc.noaa.gov/dods/NCEP_NARR_DAILY/' + y_m + '/' +
@@ -95,8 +94,8 @@ display.plot_latitude_slice(
     axislabels=('', 'Height (km)'))
 
 # add a title
-slc_height = grid.axes['z_disp']['data'][level]
-dts = num2date(grid.axes['time']['data'], grid.axes['time']['units'])
+slc_height = grid.regular_z['data'][level]
+dts = num2date(grid.time['data'], grid.time['units'])
 datestr = dts[0].strftime('%H:%M Z on %Y-%m-%d')
 title = 'Sliced at ' + str(slc_height) + ' meters at ' + datestr
 fig.text(0.5, 0.9, title)

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -79,6 +79,8 @@ class Grid(object):
         this dictionary. If this key is present and set to True, which is
         required when proj='pyart_aeqd', then the radar longitude and
         latitude will be added to the dictionary as 'lon_0' and 'lat_0'.
+    nx, ny, nz : int
+        Number of grid points along the given Cartesian dimension.
     axes : dict
         Dictionary of axes dictionaries.
         This attribute is Depreciated, it will be removed in the next Py-ART
@@ -99,6 +101,9 @@ class Grid(object):
         self.regular_x = regular_x
         self.regular_y = regular_y
         self.regular_z = regular_z
+        self.nx = len(regular_x['data'])
+        self.ny = len(regular_y['data'])
+        self.nz = len(regular_z['data'])
         self.projection = {'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
 
         # initialize attributes with Lazy load dictionaries

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -323,7 +323,10 @@ def _point_lon_lat_data_factory(grid, coordinate):
             projparams['lon_0'] = grid.origin_longitude['data'][0]
             projparams['lat_0'] = grid.origin_latitude['data'][0]
         geographic_coords = cartesian_to_geographic(x, y, projparams)
-        # set the other geographic coordinate
+        # Set point_latitude['data'] when point_longitude['data'] is evaluated
+        # and vice-versa.  This ensures that both attributes contain data from
+        # the same map projection and that the map projection only needs to be
+        # evaluated once.
         if coordinate == 0:
             grid.point_latitude['data'] = geographic_coords[1]
         else:

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -70,13 +70,13 @@ class Grid(object):
         attribute.
     projection : dic or str
         Projection parameters defining the map projection used to transform
-        from Cartesian to geographic coordinates.  The default dictionary sets
-        the 'proj' key to 'pyart_aeqd' indicating that the native Py-ART
-        azimuthal equidistant projection is used. This can be modified to
-        specify a valid pyproj.Proj projparams dictionary or string.
-        The special key '_include_lon_0_lat_0' is removed when interpreting
-        this dictionary. If this key is present and set to True, which is
-        required when proj='pyart_aeqd', then the radar longitude and
+        from Cartesian to geographic coordinates.  None will use the default
+        dictionary with the 'proj' key set to 'pyart_aeqd' indicating that
+        the native Py-ART azimuthal equidistant projection is used. Other
+        values should specify a valid pyproj.Proj projparams dictionary or
+        string.  The special key '_include_lon_0_lat_0' is removed when
+        interpreting this dictionary. If this key is present and set to True,
+        which is required when proj='pyart_aeqd', then the radar longitude and
         latitude will be added to the dictionary as 'lon_0' and 'lat_0'.
     nx, ny, nz : int
         Number of grid points along the given Cartesian dimension.
@@ -94,7 +94,7 @@ class Grid(object):
     def __init__(self, time, fields, metadata,
                  origin_latitude, origin_longitude, origin_altitude,
                  regular_x, regular_y, regular_z,
-                 radar_latitude=None, radar_longitude=None,
+                 projection=None, radar_latitude=None, radar_longitude=None,
                  radar_altitude=None, radar_time=None, radar_name=None):
         """ Initalize object. """
 
@@ -110,7 +110,11 @@ class Grid(object):
         self.nx = len(regular_x['data'])
         self.ny = len(regular_y['data'])
         self.nz = len(regular_z['data'])
-        self.projection = {'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
+        if projection is None:
+            self.projection = {
+                'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
+        else:
+            self.projection = projection
 
         self.radar_latitude = radar_latitude
         self.radar_longitude = radar_longitude

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -15,32 +15,53 @@ An class for holding gridded Radar data.
 
 class Grid(object):
     """
-    An object for holding gridded Radar data.
+    A class for storing rectilinear gridded radar data in Cartesian coordinate.
 
     Parameters
     ----------
     fields : dict
         Dictionary of field dictionaries.
-    axes : dict
-        Dictionary of axes dictionaries.
     metadata : dict
         Dictionary of metadata.
+    axes : dict
+        Dictionary of axes dictionaries.
 
     Attributes
     ----------
-    fields: dict
-        Dictionary of field dictionaries.
-    axes: dict
-        Dictionary of axes dictionaries.
+    fields: dict of dicts
+        Moments from radars or other variables.
     metadata: dict
-        Dictionary of metadata.
+        Metadata describing the grid.
+    time : dict
+        Time of the grid.
+    origin_longitude, origin_latitude, origin_altitude : dict
+        Geographic coordinate of the origin of the grid.
+    regular_x, regular_y, regular_z : dict
+        Regular locations of grid points from the origin in the three
+        Cartesian coordinates.
+    axes : dict
+        Dictionary of axes dictionaries.
+        This attribute is Depreciated, it will be removed in the next Py-ART
+        release.
 
     """
     def __init__(self, fields, axes, metadata):
         """ Initalize object. """
         self.fields = fields
         self.metadata = metadata
+
+        # unpack axes dictionary
+        self.time = axes['time']
+        self.origin_longitude = axes['lat']
+        self.origin_latitude = axes['lon']
+        self.origin_altitude = axes['alt']
+        self.regular_x = axes['x_disp']
+        self.regular_y = axes['y_disp']
+        self.regular_z = axes['z_disp']
+
+        # Depreciated axes attribute
         self.axes = axes
+
         return
 
     def write(self, filename, format='NETCDF4', arm_time_variables=False):

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -45,21 +45,31 @@ class Grid(object):
         release.
 
     """
-    def __init__(self, fields, axes, metadata):
+    def __init__(self, time, fields, metadata,
+                 origin_latitude, origin_longitude, origin_altitude,
+                 regular_x, regular_y, regular_z):
         """ Initalize object. """
+
+        self.time = time
         self.fields = fields
         self.metadata = metadata
-
-        # unpack axes dictionary
-        self.time = axes['time']
-        self.origin_longitude = axes['lat']
-        self.origin_latitude = axes['lon']
-        self.origin_altitude = axes['alt']
-        self.regular_x = axes['x_disp']
-        self.regular_y = axes['y_disp']
-        self.regular_z = axes['z_disp']
+        self.origin_latitude = origin_latitude
+        self.origin_longitude = origin_longitude
+        self.origin_altitude = origin_altitude
+        self.regular_x = regular_x
+        self.regular_y = regular_y
+        self.regular_z = regular_z
 
         # Depreciated axes attribute
+        axes = {'time': time,
+                'time_start': time,  # incorrect metadata
+                'time_end': time,    # incorrect metadata
+                'z_disp': regular_z,
+                'y_disp': regular_y,
+                'x_disp': regular_x,
+                'alt': origin_altitude,
+                'lat': origin_latitude,
+                'lon': origin_longitude}
         self.axes = axes
 
         return

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -85,11 +85,19 @@ class Grid(object):
         Dictionary of axes dictionaries.
         This attribute is Depreciated, it will be removed in the next Py-ART
         release.
+    radar_longitude, radar_latitude, radar_altitude : dict or None, optional
+        Geographic location of the radars which make up the grid.
+    radar_time : dict or None, optional
+        Start of collection for the radar which make up the grid.
+    radar_name : dict or None, optional
+        Names of the radars which make up the grid.
 
     """
     def __init__(self, time, fields, metadata,
                  origin_latitude, origin_longitude, origin_altitude,
-                 regular_x, regular_y, regular_z):
+                 regular_x, regular_y, regular_z,
+                 radar_latitude=None, radar_longitude=None,
+                 radar_altitude=None, radar_time=None, radar_name=None):
         """ Initalize object. """
 
         self.time = time
@@ -105,6 +113,13 @@ class Grid(object):
         self.ny = len(regular_y['data'])
         self.nz = len(regular_z['data'])
         self.projection = {'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
+
+        self.radar_latitude = radar_latitude
+        self.radar_longitude = radar_longitude
+        self.radar_altitude = radar_altitude
+        self.radar_time = radar_time
+        self.radar_name = radar_name
+        self.nradar = self._find_and_check_nradar()
 
         # initialize attributes with Lazy load dictionaries
         self.init_point_x_y_z()
@@ -124,6 +139,47 @@ class Grid(object):
         self.axes = axes
 
         return
+
+    def _find_and_check_nradar(self):
+        """
+        Return the number of radars which were used to create the grid.
+
+        Examine the radar_ attributes to determine the number of radars which
+        were used to create the grid.  If the size of the radar_ attributes
+        are inconsistent a ValueError is raised by this method.
+        """
+        nradar_set = False
+        nradar = 0
+
+        if self.radar_latitude is not None:
+            nradar = len(self.radar_latitude['data'])
+            nradar_set = True
+
+        if self.radar_longitude is not None:
+            if nradar_set and len(self.radar_longitude['data']) != nradar:
+                raise ValueError("Inconsistent length of radar_ arguments.")
+            nradar = len(self.radar_longitude['data'])
+            nradar_set = True
+
+        if self.radar_altitude is not None:
+            if nradar_set and len(self.radar_altitude['data']) != nradar:
+                raise ValueError("Inconsistent length of radar_ arguments.")
+            nradar = len(self.radar_altitude['data'])
+            nradar_set = True
+
+        if self.radar_time is not None:
+            if nradar_set and len(self.radar_time['data']) != nradar:
+                raise ValueError("Inconsistent length of radar_ arguments.")
+            nradar = len(self.radar_time['data'])
+            nradar_set = True
+
+        if self.radar_name is not None:
+            if nradar_set and len(self.radar_name['data']) != nradar:
+                raise ValueError("Inconsistent length of radar_ arguments.")
+            nradar = len(self.radar_name['data'])
+            nradar_set = True
+
+        return nradar
 
     # Attribute init/reset methods
     def init_point_x_y_z(self):

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -179,8 +179,8 @@ class Grid(object):
         """
         Return the number of radars which were used to create the grid.
 
-        Examine the radar_ attributes to determine the number of radars which
-        were used to create the grid.  If the size of the radar_ attributes
+        Examine the radar attributes to determine the number of radars which
+        were used to create the grid.  If the size of the radar attributes
         are inconsistent a ValueError is raised by this method.
         """
         nradar_set = False

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -48,15 +48,16 @@ class Grid(object):
         Time of the grid.
     origin_longitude, origin_latitude, origin_altitude : dict
         Geographic coordinate of the origin of the grid.
-    regular_x, regular_y, regular_z : dict
-        Regular locations of grid points from the origin in the three
-        Cartesian coordinates.
+    x, y, z : dict, 1D
+        Distance from the grid origin for each Cartesian coordinate axis in a
+        one dimensional array.  Defines the spacing along the three grid axes
+        which is repeated throughout the grid, making a rectilinear grid.
     point_x, point_y, point_z : LazyLoadDict
         The Cartesian locations of all grid points from the origin in the
         three Cartesian coordinates.  The three dimensional data arrays
-        contained these attributes are calculated from the regular_x,
-        regular_y, and regular_z attributes.  If these attributes are changed
-        use :py:func:`init_point_x_y_z` to reset the attributes.
+        contained these attributes are calculated from the x, y, and z
+        attributes.  If these attributes are changed use :py:func:
+        `init_point_x_y_z` to reset the attributes.
     point_longitude, point_latitude : LazyLoadDict
         Geographic location of each grid point. The projection parameter(s)
         defined in the `projection` attribute are used to perform an inverse
@@ -92,8 +93,7 @@ class Grid(object):
 
     """
     def __init__(self, time, fields, metadata,
-                 origin_latitude, origin_longitude, origin_altitude,
-                 regular_x, regular_y, regular_z,
+                 origin_latitude, origin_longitude, origin_altitude, x, y, z,
                  projection=None, radar_latitude=None, radar_longitude=None,
                  radar_altitude=None, radar_time=None, radar_name=None):
         """ Initalize object. """
@@ -104,12 +104,12 @@ class Grid(object):
         self.origin_latitude = origin_latitude
         self.origin_longitude = origin_longitude
         self.origin_altitude = origin_altitude
-        self.regular_x = regular_x
-        self.regular_y = regular_y
-        self.regular_z = regular_z
-        self.nx = len(regular_x['data'])
-        self.ny = len(regular_y['data'])
-        self.nz = len(regular_z['data'])
+        self.x = x
+        self.y = y
+        self.z = z
+        self.nx = len(x['data'])
+        self.ny = len(y['data'])
+        self.nz = len(z['data'])
         if projection is None:
             self.projection = {
                 'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
@@ -132,9 +132,9 @@ class Grid(object):
         axes = {'time': time,
                 'time_start': time,  # incorrect metadata
                 'time_end': time,    # incorrect metadata
-                'z_disp': regular_z,
-                'y_disp': regular_y,
-                'x_disp': regular_x,
+                'z_disp': z,
+                'y_disp': y,
+                'x_disp': x,
                 'alt': origin_altitude,
                 'lat': origin_latitude,
                 'lon': origin_longitude}
@@ -171,12 +171,12 @@ class Grid(object):
         origin_latitude = axes['lat']
         origin_longitude = axes['lon']
         origin_altitude = axes['alt']
-        regular_x = axes['x_disp']
-        regular_y = axes['y_disp']
-        regular_z = axes['z_disp']
+        x = axes['x_disp']
+        y = axes['y_disp']
+        z = axes['z_disp']
         grid = cls(time, fields, metadata,
                    origin_latitude, origin_longitude, origin_altitude,
-                   regular_x, regular_y, regular_z)
+                   x, y, z)
         return grid
 
     def _find_and_check_nradar(self):
@@ -303,9 +303,9 @@ def _point_data_factory(grid, coordinate):
     """ Return a function which returns the locations of all points.  """
     def _point_data():
         """ The function which returns the locations of all points. """
-        reg_x = grid.regular_x['data']
-        reg_y = grid.regular_y['data']
-        reg_z = grid.regular_z['data']
+        reg_x = grid.x['data']
+        reg_y = grid.y['data']
+        reg_z = grid.z['data']
         if coordinate == 'x':
             return np.tile(reg_x, (len(reg_z), len(reg_y), 1)).swapaxes(2, 2)
         elif coordinate == 'y':

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -66,7 +66,7 @@ class Grid(object):
     point_altitude : LazyLoadDict
         The altitude of each grid point as calculated from the altitude of the
         grid origin and the Cartesian z location of each grid point.  If this
-        attribute is changed use :py:func:`init_gate_altitude` to reset the
+        attribute is changed use :py:func:`init_point_altitude` to reset the
         attribute.
     projection : dic or str
         Projection parameters defining the map projection used to transform

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -249,21 +249,15 @@ class Grid(object):
             raised if field_name already exists.
 
         """
-
-        # grid fields should have dimensions of (nz, ny, nx)
-        nz, ny, nx = self.fields[self.fields.keys()[0]]['data'].shape
-
         # checks to make sure input field dictionary is valid
         if 'data' not in field_dict:
             raise KeyError('Field dictionary must contain a "data" key')
         if field_name in self.fields and replace_existing is False:
             raise ValueError('A field named %s already exists' % (field_name))
-        if field_dict['data'].shape != (nz, ny, nx):
+        if field_dict['data'].shape != (self.nz, self.ny, self.nx):
             raise ValueError('Field has invalid shape')
 
         self.fields[field_name] = field_dict
-
-        return
 
 
 def _point_data_factory(grid, coordinate):

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -19,6 +19,8 @@ An class for holding gridded Radar data.
 
 """
 
+import warnings
+
 import numpy as np
 
 from ..config import get_metadata
@@ -79,8 +81,8 @@ class Grid(object):
     nx, ny, nz : int
         Number of grid points along the given Cartesian dimension.
     axes : dict
-        Dictionary of axes dictionaries.  This attribute is Depreciated,
-        it will be removed in the next Py-ART release.
+        Dictionary of axes dictionaries.  This attribute is depreciated,
+        it will be removed in future versions of Py-ART.
     radar_longitude, radar_latitude, radar_altitude : dict or None, optional
         Geographic location of the radars which make up the grid.
     radar_time : dict or None, optional
@@ -156,6 +158,9 @@ class Grid(object):
             A Grid object.
 
         """
+        warnings.warn(
+            "from_legacy_parameters is depreciated and will be removed in a " +
+            "future version of Py-ART", DeprecationWarning)
         time = axes['time']
         fields = fields
         metadata = metadata

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -40,18 +40,38 @@ class Grid(object):
 
     Attributes
     ----------
+    time : dict
+        Time of the grid.
     fields: dict of dicts
         Moments from radars or other variables.
     metadata: dict
         Metadata describing the grid.
-    time : dict
-        Time of the grid.
     origin_longitude, origin_latitude, origin_altitude : dict
         Geographic coordinate of the origin of the grid.
     x, y, z : dict, 1D
         Distance from the grid origin for each Cartesian coordinate axis in a
         one dimensional array.  Defines the spacing along the three grid axes
         which is repeated throughout the grid, making a rectilinear grid.
+    nx, ny, nz : int
+        Number of grid points along the given Cartesian dimension.
+    projection : dic or str
+        Projection parameters defining the map projection used to transform
+        from Cartesian to geographic coordinates.  None will use the default
+        dictionary with the 'proj' key set to 'pyart_aeqd' indicating that
+        the native Py-ART azimuthal equidistant projection is used. Other
+        values should specify a valid pyproj.Proj projparams dictionary or
+        string.  The special key '_include_lon_0_lat_0' is removed when
+        interpreting this dictionary. If this key is present and set to True,
+        which is required when proj='pyart_aeqd', then the radar longitude and
+        latitude will be added to the dictionary as 'lon_0' and 'lat_0'.
+    radar_longitude, radar_latitude, radar_altitude : dict or None, optional
+        Geographic location of the radars which make up the grid.
+    radar_time : dict or None, optional
+        Start of collection for the radar which make up the grid.
+    radar_name : dict or None, optional
+        Names of the radars which make up the grid.
+    nradar : int
+        Number of radars whose data was used to make the grid.
     point_x, point_y, point_z : LazyLoadDict
         The Cartesian locations of all grid points from the origin in the
         three Cartesian coordinates.  The three dimensional data arrays
@@ -69,27 +89,9 @@ class Grid(object):
         grid origin and the Cartesian z location of each grid point.  If this
         attribute is changed use :py:func:`init_point_altitude` to reset the
         attribute.
-    projection : dic or str
-        Projection parameters defining the map projection used to transform
-        from Cartesian to geographic coordinates.  None will use the default
-        dictionary with the 'proj' key set to 'pyart_aeqd' indicating that
-        the native Py-ART azimuthal equidistant projection is used. Other
-        values should specify a valid pyproj.Proj projparams dictionary or
-        string.  The special key '_include_lon_0_lat_0' is removed when
-        interpreting this dictionary. If this key is present and set to True,
-        which is required when proj='pyart_aeqd', then the radar longitude and
-        latitude will be added to the dictionary as 'lon_0' and 'lat_0'.
-    nx, ny, nz : int
-        Number of grid points along the given Cartesian dimension.
     axes : dict
         Dictionary of axes dictionaries.  This attribute is depreciated,
         it will be removed in future versions of Py-ART.
-    radar_longitude, radar_latitude, radar_altitude : dict or None, optional
-        Geographic location of the radars which make up the grid.
-    radar_time : dict or None, optional
-        Start of collection for the radar which make up the grid.
-    radar_name : dict or None, optional
-        Names of the radars which make up the grid.
 
     """
     def __init__(self, time, fields, metadata,

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -30,14 +30,11 @@ class Grid(object):
     """
     A class for storing rectilinear gridded radar data in Cartesian coordinate.
 
-    Parameters
-    ----------
-    fields : dict
-        Dictionary of field dictionaries.
-    metadata : dict
-        Dictionary of metadata.
-    axes : dict
-        Dictionary of axes dictionaries.
+    Refer to the attribute section for information on the parameters.
+
+    To create a Grid object using legacy parameters present in Py-ART version
+    1.5 and before, use :py:func:`from_legacy_parameters`,
+    grid = Grid.from_legacy_parameters(fields, axes, metadata).
 
     Attributes
     ----------
@@ -82,9 +79,8 @@ class Grid(object):
     nx, ny, nz : int
         Number of grid points along the given Cartesian dimension.
     axes : dict
-        Dictionary of axes dictionaries.
-        This attribute is Depreciated, it will be removed in the next Py-ART
-        release.
+        Dictionary of axes dictionaries.  This attribute is Depreciated,
+        it will be removed in the next Py-ART release.
     radar_longitude, radar_latitude, radar_altitude : dict or None, optional
         Geographic location of the radars which make up the grid.
     radar_time : dict or None, optional
@@ -139,6 +135,40 @@ class Grid(object):
         self.axes = axes
 
         return
+
+    @classmethod
+    def from_legacy_parameters(cls, fields, axes, metadata):
+        """
+        Return a Grid class using legacy parameters.
+
+        Parameters
+        ----------
+        fields : dict
+            Dictionary of field dictionaries.
+        metadata : dict
+            Dictionary of metadata.
+        axes : dict
+            Dictionary of axes dictionaries.
+
+        Returns
+        --------
+        grid : Grid
+            A Grid object.
+
+        """
+        time = axes['time']
+        fields = fields
+        metadata = metadata
+        origin_latitude = axes['lat']
+        origin_longitude = axes['lon']
+        origin_altitude = axes['alt']
+        regular_x = axes['x_disp']
+        regular_y = axes['y_disp']
+        regular_z = axes['z_disp']
+        grid = cls(time, fields, metadata,
+                   origin_latitude, origin_longitude, origin_altitude,
+                   regular_x, regular_y, regular_z)
+        return grid
 
     def _find_and_check_nradar(self):
         """

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -195,11 +195,8 @@ class Grid(object):
 
     @property
     def projection_proj(self):
-        """
-        Proj instance as specified by the projection attribute.
-
-        Raises a ValueError if the pyart_aeqd projection is specified.
-        """
+        # Proj instance as specified by the projection attribute.
+        # Raises a ValueError if the pyart_aeqd projection is specified.
         projparams = self.get_projparams()
         if projparams['proj'] == 'pyart_aeqd':
             raise ValueError(

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -56,6 +56,10 @@ def test_grid_class():
     ny = 400
     nx = 320
 
+    assert grid.nx == nx
+    assert grid.ny == ny
+    assert grid.nz == nz
+
     assert isinstance(grid.metadata, dict)
     assert isinstance(grid.fields, dict)
     assert isinstance(grid.fields['reflectivity'], dict)

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -103,6 +103,30 @@ def test_grid_class():
     assert_almost_equal(
         grid.point_z['data'][:, 1, 1], grid.regular_z['data'][:])
 
+    assert isinstance(grid.point_longitude, LazyLoadDict)
+    assert grid.point_longitude['data'].shape == (nz, ny, nx)
+    assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -98.1, 1)
+
+    assert isinstance(grid.point_latitude, LazyLoadDict)
+    assert grid.point_latitude['data'].shape == (nz, ny, nx)
+    assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 36.7, 1)
+
+
+def test_init_point_longitude_latitude():
+    grid = pyart.testing.make_target_grid()
+
+    assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -98.1, 1)
+    assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 36.7, 1)
+
+    grid.origin_longitude['data'][0] = -80.0
+    grid.origin_latitude['data'][0] = 40.0
+    assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -98.1, 1)
+    assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 36.7, 1)
+
+    grid.init_point_longitude_latitude()
+    assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -80.0, 1)
+    assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 40.0, 1)
+
 
 def test_init_point_x_y_z():
     grid = pyart.testing.make_target_grid()

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -45,3 +45,37 @@ def test_grid_from_radars():
                     assert np.all(grid.fields[field][k] == v)
                 else:
                     assert grid2.fields[field][k] == v
+
+
+def test_grid_class():
+    grid = pyart.testing.make_target_grid()
+
+    nz = 2
+    ny = 400
+    nx = 320
+
+    assert isinstance(grid.metadata, dict)
+    assert isinstance(grid.fields, dict)
+    assert isinstance(grid.fields['reflectivity'], dict)
+    assert grid.fields['reflectivity']['data'].shape == (nz, ny, nx)
+
+    assert isinstance(grid.time, dict)
+    assert grid.time['data'].shape == (1, )
+
+    assert isinstance(grid.origin_longitude, dict)
+    assert grid.origin_longitude['data'].shape == (1, )
+
+    assert isinstance(grid.origin_latitude, dict)
+    assert grid.origin_latitude['data'].shape == (1, )
+
+    assert isinstance(grid.origin_altitude, dict)
+    assert grid.origin_altitude['data'].shape == (1, )
+
+    assert isinstance(grid.regular_x, dict)
+    assert grid.regular_x['data'].shape == (nx, )
+
+    assert isinstance(grid.regular_y, dict)
+    assert grid.regular_y['data'].shape == (ny, )
+
+    assert isinstance(grid.regular_z, dict)
+    assert grid.regular_z['data'].shape == (nz, )

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -79,3 +79,54 @@ def test_grid_class():
 
     assert isinstance(grid.regular_z, dict)
     assert grid.regular_z['data'].shape == (nz, )
+
+
+def test_grid_axes_attribute():
+    # test the depreciated axes Grid attribute
+    grid = pyart.testing.make_target_grid()
+
+    nz = 2
+    ny = 400
+    nx = 320
+
+    axes = grid.axes
+
+    assert isinstance(axes, dict)
+
+    assert isinstance(axes['time'], dict)
+    assert axes['time']['data'].shape == (1, )
+
+    assert isinstance(axes['time_start'], dict)
+    assert axes['time_start']['data'].shape == (1, )
+
+    assert isinstance(axes['time_end'], dict)
+    assert axes['time_end']['data'].shape == (1, )
+
+    assert isinstance(axes['lat'], dict)
+    assert axes['lat']['data'].shape == (1, )
+
+    assert isinstance(axes['lon'], dict)
+    assert axes['lon']['data'].shape == (1, )
+
+    assert isinstance(axes['alt'], dict)
+    assert axes['alt']['data'].shape == (1, )
+
+    assert isinstance(axes['x_disp'], dict)
+    assert axes['x_disp']['data'].shape == (nx, )
+
+    assert isinstance(axes['y_disp'], dict)
+    assert axes['y_disp']['data'].shape == (ny, )
+
+    assert isinstance(axes['z_disp'], dict)
+    assert axes['z_disp']['data'].shape == (nz, )
+
+    assert 'latitude' not in axes
+    assert 'longitude' not in axes
+
+    pyart.io.add_2d_latlon_axis(grid)
+
+    assert isinstance(axes['latitude'], dict)
+    assert axes['latitude']['data'].shape == (ny, nx)
+
+    assert isinstance(axes['longitude'], dict)
+    assert axes['longitude']['data'].shape == (ny, nx)

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -6,6 +6,13 @@ import functools
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_raises
+from numpy.testing.decorators import skipif
+
+try:
+    from mpl_toolkits.basemap import pyproj
+    _PYPROJ_AVAILABLE = True
+except ImportError:
+    _PYPROJ_AVAILABLE = False
 
 import pyart
 from pyart.lazydict import LazyLoadDict
@@ -243,6 +250,22 @@ def test_init_point_longitude_latitude():
     grid.init_point_longitude_latitude()
     assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -80.0, 1)
     assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 40.0, 1)
+
+
+@skipif(not _PYPROJ_AVAILABLE)
+def test_projection_proj():
+    grid = pyart.testing.make_target_grid()
+    grid.projection['proj'] = 'aeqd'
+    assert isinstance(grid.projection_proj, pyproj.Proj)
+
+
+def test_projection_proj_raised():
+    grid = pyart.testing.make_target_grid()
+
+    def access_projection_proj():
+        grid.projection_proj
+
+    assert_raises(ValueError, access_projection_proj)
 
 
 def test_init_point_x_y_z():

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -111,6 +111,25 @@ def test_grid_class():
     assert grid.point_latitude['data'].shape == (nz, ny, nx)
     assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 36.7, 1)
 
+    assert isinstance(grid.point_altitude, LazyLoadDict)
+    assert grid.point_altitude['data'].shape == (nz, ny, nx)
+    assert_almost_equal(grid.point_altitude['data'][0, 0, 0], 300, 0)
+    assert_almost_equal(grid.point_altitude['data'][1, 0, 0], 800, 0)
+
+
+def test_init_point_altitude():
+    grid = pyart.testing.make_target_grid()
+    assert_almost_equal(grid.point_altitude['data'][0, 0, 0], 300, 0)
+    assert_almost_equal(grid.point_altitude['data'][1, 0, 0], 800, 0)
+
+    grid.origin_altitude['data'][0] = 555.
+    assert_almost_equal(grid.point_altitude['data'][0, 0, 0], 300, 0)
+    assert_almost_equal(grid.point_altitude['data'][1, 0, 0], 800, 0)
+
+    grid.init_point_altitude()
+    assert_almost_equal(grid.point_altitude['data'][0, 0, 0], 555, 0)
+    assert_almost_equal(grid.point_altitude['data'][1, 0, 0], 1055, 0)
+
 
 def test_init_point_longitude_latitude():
     grid = pyart.testing.make_target_grid()

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -32,9 +32,9 @@ def test_grid_write_method():
         _check_dicts_similar(grid1.origin_longitude, grid2.origin_longitude)
         _check_dicts_similar(grid1.origin_altitude, grid2.origin_altitude)
 
-        _check_dicts_similar(grid1.regular_x, grid2.regular_x)
-        _check_dicts_similar(grid1.regular_y, grid2.regular_y)
-        _check_dicts_similar(grid1.regular_z, grid2.regular_z)
+        _check_dicts_similar(grid1.x, grid2.x)
+        _check_dicts_similar(grid1.y, grid2.y)
+        _check_dicts_similar(grid1.z, grid2.z)
 
         _check_dicts_similar(grid1.point_x, grid2.point_x)
         _check_dicts_similar(grid1.point_y, grid2.point_y)
@@ -98,35 +98,35 @@ def test_grid_class():
     assert isinstance(grid.origin_altitude, dict)
     assert grid.origin_altitude['data'].shape == (1, )
 
-    assert isinstance(grid.regular_x, dict)
-    assert grid.regular_x['data'].shape == (nx, )
+    assert isinstance(grid.x, dict)
+    assert grid.x['data'].shape == (nx, )
 
-    assert isinstance(grid.regular_y, dict)
-    assert grid.regular_y['data'].shape == (ny, )
+    assert isinstance(grid.y, dict)
+    assert grid.y['data'].shape == (ny, )
 
-    assert isinstance(grid.regular_z, dict)
-    assert grid.regular_z['data'].shape == (nz, )
+    assert isinstance(grid.z, dict)
+    assert grid.z['data'].shape == (nz, )
 
     assert isinstance(grid.point_x, LazyLoadDict)
     assert grid.point_x['data'].shape == (nz, ny, nx)
     assert_almost_equal(
-        grid.point_x['data'][0, 0, :], grid.regular_x['data'][:])
+        grid.point_x['data'][0, 0, :], grid.x['data'][:])
     assert_almost_equal(
-        grid.point_x['data'][1, 1, :], grid.regular_x['data'][:])
+        grid.point_x['data'][1, 1, :], grid.x['data'][:])
 
     assert isinstance(grid.point_y, LazyLoadDict)
     assert grid.point_y['data'].shape == (nz, ny, nx)
     assert_almost_equal(
-        grid.point_y['data'][0, :, 0], grid.regular_y['data'][:])
+        grid.point_y['data'][0, :, 0], grid.y['data'][:])
     assert_almost_equal(
-        grid.point_y['data'][1, :, 1], grid.regular_y['data'][:])
+        grid.point_y['data'][1, :, 1], grid.y['data'][:])
 
     assert isinstance(grid.point_z, LazyLoadDict)
     assert grid.point_z['data'].shape == (nz, ny, nx)
     assert_almost_equal(
-        grid.point_z['data'][:, 0, 0], grid.regular_z['data'][:])
+        grid.point_z['data'][:, 0, 0], grid.z['data'][:])
     assert_almost_equal(
-        grid.point_z['data'][:, 1, 1], grid.regular_z['data'][:])
+        grid.point_z['data'][:, 1, 1], grid.z['data'][:])
 
     assert isinstance(grid.point_longitude, LazyLoadDict)
     assert grid.point_longitude['data'].shape == (nz, ny, nx)
@@ -192,9 +192,8 @@ def test_projection_argument():
     grid = pyart.core.Grid(
         time={}, fields={}, metadata={},
         origin_latitude={}, origin_longitude={}, origin_altitude={},
-        regular_x={'data': [1]}, regular_y={'data': [1]},
-        regular_z={'data': [1]}, radar_latitude={'data': [1]},
-        projection={})
+        x={'data': [1]}, y={'data': [1]}, z={'data': [1]},
+        radar_latitude={'data': [1]}, projection={})
     assert grid.projection == {}
 
 
@@ -205,8 +204,8 @@ def test_inconsistent_radar_arguments():
     partial_grid = functools.partial(
         pyart.core.Grid, time={}, fields={}, metadata={},
         origin_latitude={}, origin_longitude={}, origin_altitude={},
-        regular_x={'data': [1]}, regular_y={'data': [1]},
-        regular_z={'data': [1]}, radar_latitude={'data': [1]})
+        x={'data': [1]}, y={'data': [1]}, z={'data': [1]},
+        radar_latitude={'data': [1]})
 
     # radar_ arguments indicating 2 radars should raise a ValueError
     bad = {'data': [1, 2]}
@@ -250,13 +249,13 @@ def test_init_point_x_y_z():
     grid = pyart.testing.make_target_grid()
     assert isinstance(grid.point_x, LazyLoadDict)
     assert grid.point_x['data'].shape == (2, 400, 320)
-    assert grid.point_x['data'][0, 0, 0] == grid.regular_x['data'][0]
+    assert grid.point_x['data'][0, 0, 0] == grid.x['data'][0]
 
-    grid.regular_x['data'][0] = -500000.
-    assert grid.point_x['data'][0, 0, 0] != grid.regular_x['data'][0]
+    grid.x['data'][0] = -500000.
+    assert grid.point_x['data'][0, 0, 0] != grid.x['data'][0]
 
     grid.init_point_x_y_z()
-    assert grid.point_x['data'][0, 0, 0] == grid.regular_x['data'][0]
+    assert grid.point_x['data'][0, 0, 0] == grid.x['data'][0]
 
 
 # Remove this test when Grid.axes is Depreciated

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -3,8 +3,10 @@
 from __future__ import print_function
 
 import numpy as np
+from numpy.testing import assert_almost_equal
 
 import pyart
+from pyart.lazydict import LazyLoadDict
 
 COMMON_MAP_TO_GRID_ARGS = {
     'grid_shape': (3, 9, 10),
@@ -79,6 +81,40 @@ def test_grid_class():
 
     assert isinstance(grid.regular_z, dict)
     assert grid.regular_z['data'].shape == (nz, )
+
+    assert isinstance(grid.point_x, LazyLoadDict)
+    assert grid.point_x['data'].shape == (nz, ny, nx)
+    assert_almost_equal(
+        grid.point_x['data'][0, 0, :], grid.regular_x['data'][:])
+    assert_almost_equal(
+        grid.point_x['data'][1, 1, :], grid.regular_x['data'][:])
+
+    assert isinstance(grid.point_y, LazyLoadDict)
+    assert grid.point_y['data'].shape == (nz, ny, nx)
+    assert_almost_equal(
+        grid.point_y['data'][0, :, 0], grid.regular_y['data'][:])
+    assert_almost_equal(
+        grid.point_y['data'][1, :, 1], grid.regular_y['data'][:])
+
+    assert isinstance(grid.point_z, LazyLoadDict)
+    assert grid.point_z['data'].shape == (nz, ny, nx)
+    assert_almost_equal(
+        grid.point_z['data'][:, 0, 0], grid.regular_z['data'][:])
+    assert_almost_equal(
+        grid.point_z['data'][:, 1, 1], grid.regular_z['data'][:])
+
+
+def test_init_point_x_y_z():
+    grid = pyart.testing.make_target_grid()
+    assert isinstance(grid.point_x, LazyLoadDict)
+    assert grid.point_x['data'].shape == (2, 400, 320)
+    assert grid.point_x['data'][0, 0, 0] == grid.regular_x['data'][0]
+
+    grid.regular_x['data'][0] = -500000.
+    assert grid.point_x['data'][0, 0, 0] != grid.regular_x['data'][0]
+
+    grid.init_point_x_y_z()
+    assert grid.point_x['data'][0, 0, 0] == grid.regular_x['data'][0]
 
 
 def test_grid_axes_attribute():

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -249,6 +249,7 @@ def test_init_point_x_y_z():
     assert grid.point_x['data'][0, 0, 0] == grid.regular_x['data'][0]
 
 
+# Remove this test when Grid.axes is Depreciated
 def test_grid_axes_attribute():
     # test the depreciated axes Grid attribute
     grid = pyart.testing.make_target_grid()
@@ -298,3 +299,108 @@ def test_grid_axes_attribute():
 
     assert isinstance(axes['longitude'], dict)
     assert axes['longitude']['data'].shape == (ny, nx)
+
+
+# Remove this function when Grid.from_legacy_parameters is Depreciated
+def make_empty_grid(grid_shape, grid_limits):
+    """
+    Make an empty grid object without any fields or metadata.
+
+    Parameters
+    ----------
+    grid_shape : 3-tuple of floats
+        Number of points in the grid (z, y, x).
+    grid_limits : 3-tuple of 2-tuples
+        Minimum and maximum grid location (inclusive) in meters for the
+        z, y, x coordinates.
+
+    Returns
+    -------
+    grid : Grid
+        Empty Grid object, centered near the ARM SGP site (Oklahoma).
+
+    """
+    time = {
+        'data': np.array([0.0]),
+        'units': 'seconds since 2000-01-01T00:00:00Z',
+        'calendar': 'gregorian',
+        'standard_name': 'time',
+        'long_name': 'Time in seconds since volume start'}
+
+    time_start = {
+        'data': np.array([0.0]),
+        'units': 'seconds since 2000-01-01T00:00:00Z',
+        'calendar': 'gregorian',
+        'standard_name': 'time',
+        'long_name': 'Time in seconds since volume start'}
+
+    time_end = {
+        'data': np.array([0.0]),
+        'units': 'seconds since 2000-01-01T00:00:00Z',
+        'calendar': 'gregorian',
+        'standard_name': 'time',
+        'long_name': 'Time in seconds since volume start'}
+
+    # grid coordinate dictionaries
+    nz, ny, nx = grid_shape
+    (z0, z1), (y0, y1), (x0, x1) = grid_limits
+
+    xaxis = {'data': np.linspace(x0, x1, nx),
+             'long_name': 'X-coordinate in Cartesian system',
+             'axis': 'X',
+             'units': 'm'}
+
+    yaxis = {'data': np.linspace(y0, y1, ny),
+             'long_name': 'Y-coordinate in Cartesian system',
+             'axis': 'Y',
+             'units': 'm'}
+
+    zaxis = {'data': np.linspace(z0, z1, nz),
+             'long_name': 'Z-coordinate in Cartesian system',
+             'axis': 'Z',
+             'units': 'm',
+             'positive': 'up'}
+
+    altorigin = {'data': np.array([300.]),
+                 'long_name': 'Altitude at grid origin',
+                 'units': 'm',
+                 'standard_name': 'altitude',
+                 }
+
+    latorigin = {'data': np.array([36.74]),
+                 'long_name': 'Latitude at grid origin',
+                 'units': 'degree_N',
+                 'standard_name': 'latitude',
+                 'valid_min': -90.,
+                 'valid_max': 90.
+                 }
+
+    lonorigin = {'data': np.array([-98.1]),
+                 'long_name': 'Longitude at grid origin',
+                 'units': 'degree_E',
+                 'standard_name': 'longitude',
+                 'valid_min': -180.,
+                 'valid_max': 180.
+                 }
+
+    axes = {'time': time,
+            'time_start': time_start,
+            'time_end': time_end,
+            'z_disp': zaxis,
+            'y_disp': yaxis,
+            'x_disp': xaxis,
+            'alt': altorigin,
+            'lat': latorigin,
+            'lon': lonorigin}
+
+    return pyart.core.Grid.from_legacy_parameters({}, axes, {})
+
+
+# Remove this test when Grid.from_legacy_parameters is Depreciated
+def test_grid_from_legacy_parameters():
+    grid_shape = (2, 3, 4)
+    grid_limits = ((0, 500), (-400000, 400000), (-300000, 300000))
+    grid = make_empty_grid(grid_shape, grid_limits)
+    assert grid.nx == 4
+    assert grid.ny == 3
+    assert grid.nz == 2

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -188,6 +188,16 @@ def test_add_field_raises():
     assert_raises(ValueError, grid.add_field, 'field_name', field_dict)
 
 
+def test_projection_argument():
+    grid = pyart.core.Grid(
+        time={}, fields={}, metadata={},
+        origin_latitude={}, origin_longitude={}, origin_altitude={},
+        regular_x={'data': [1]}, regular_y={'data': [1]},
+        regular_z={'data': [1]}, radar_latitude={'data': [1]},
+        projection={})
+    assert grid.projection == {}
+
+
 def test_inconsistent_radar_arguments():
 
     #  partially instantiate a Grid class with fake data and a radar_latitude

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -31,6 +31,8 @@ and antenna (azimuth, elevation, range) coordinate systems.
 
 """
 
+import warnings
+
 from ..exceptions import MissingOptionalDependency
 
 import numpy as np
@@ -595,6 +597,9 @@ def add_2d_latlon_axis(grid, **kwargs):
         Survey Professional Paper 1395, 1987, pp. 191-202.
 
     """
+    warnings.warn(
+        "add_2d_latlon_axis is depreciated and will be removed in a " +
+        "future version of Py-ART", DeprecationWarning)
     try:
         from mpl_toolkits.basemap import pyproj
         if 'proj' not in kwargs:
@@ -605,7 +610,6 @@ def add_2d_latlon_axis(grid, **kwargs):
                         lon_0=grid.axes["lon"]['data'][0], **kwargs)
         lon, lat = b(x, y, inverse=True)
     except ImportError:
-        import warnings
         warnings.warn('No basemap found, using internal implementation '
                       'for converting azimuthal equidistant to latlon')
         # azimutal equidistant projetion to latlon

--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -123,8 +123,8 @@ interpolated_profile = 'interpolated_profile'
 # Various parameters used in Py-ART.
 ##############################################################################
 
-FILL_VALUE = fill_value     # the default fill value for masked arrays and
-                            # the _FillValue key.
+# the default fill value for masked arrays and the _FillValue key
+FILL_VALUE = fill_value
 
 # The DEFAULT_FIELD_NAMES controls the field names which are used in the
 # correction and retrieval algorithms in Py-ART. The keys of the dictionary
@@ -630,6 +630,48 @@ DEFAULT_METADATA = {
         'units': 'unknown'},
 
     # Grid metadata
+
+    'grid_time': {
+        'units': 'seconds',
+        'standard_name': 'time',
+        'long_name': 'Time of grid',
+        'calendar': 'gregorian'},
+
+    'origin_longitude': {
+        'long_name': 'Longitude at grid origin',
+        'units': 'degrees_east',
+        'standard_name': 'longitude',
+        'valid_min': -180.,
+        'valid_max': 180.},
+
+    'origin_latitude': {
+        'long_name': 'Latitude at grid origin',
+        'units': 'degrees_north',
+        'standard_name': 'latitude',
+        'valid_min': -90.,
+        'valid_max': 90.},
+
+    'origin_altitude': {
+        'long_name': 'Altitude at grid origin',
+        'units': 'm',
+        'standard_name': 'altitude'},
+
+    'regular_x': {
+        'long_name': 'X-coordinate in Cartesian system',
+        'axis': 'X',
+        'units': 'm'},
+
+    'regular_y': {
+        'long_name': 'Y-coordinate in Cartesian system',
+        'axis': 'Y',
+        'units': 'm'},
+
+    'regular_z': {
+        'long_name': 'Z-coordinate in Cartesian system',
+        'axis': 'Z',
+        'units': 'm',
+        'positive': 'up'},
+
     'point_x': {
         'long_name': 'Cartesian x distance of each grid point from the origin',
         'units': 'meters'},
@@ -654,6 +696,25 @@ DEFAULT_METADATA = {
     'point_altitude': {
         'long_name': 'Altitude of each grid point',
         'units': 'meters'},
+
+    'radar_latitude': {
+        'long_name': 'Latitude of radars used to make the grid.',
+        'units': 'degrees_north', },
+
+    'radar_longitude': {
+        'long_name': 'Longitude of radars used to make the grid.',
+        'units': 'degrees_east', },
+
+    'radar_altitude': {
+        'long_name': 'Altitude of radars used to make the grid.',
+        'units': 'm', },
+
+    'radar_time': {
+        'calendar': 'gregorian',
+        'long_name': 'Time in seconds of the volume start for each radar'},
+
+    'radar_name': {
+        'long_name': 'Name of radar used to make the grid', },
 
 }
 

--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -656,18 +656,21 @@ DEFAULT_METADATA = {
         'units': 'm',
         'standard_name': 'altitude'},
 
-    'regular_x': {
-        'long_name': 'X-coordinate in Cartesian system',
+    'x': {
+        'standard_name': 'projection_x_coordinate',
+        'long_name': 'X distance on the projection plane from the origin',
         'axis': 'X',
         'units': 'm'},
 
-    'regular_y': {
-        'long_name': 'Y-coordinate in Cartesian system',
+    'y': {
+        'standard_name': 'projection_y_coordinate',
+        'long_name': 'Y distance on the projection plane from the origin',
         'axis': 'Y',
         'units': 'm'},
 
-    'regular_z': {
-        'long_name': 'Z-coordinate in Cartesian system',
+    'z': {
+        'standard_name': 'projection_z_coordinate',
+        'long_name': 'Z distance on the projection plane from the origin',
         'axis': 'Z',
         'units': 'm',
         'positive': 'up'},

--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -651,6 +651,10 @@ DEFAULT_METADATA = {
         'long_name': 'Latitude of each grid point',
         'units': 'degrees_east'},
 
+    'point_altitude': {
+        'long_name': 'Altitude of each grid point',
+        'units': 'meters'},
+
 }
 
 

--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -643,6 +643,14 @@ DEFAULT_METADATA = {
         'positive': 'up',
         'units': 'meters'},
 
+    'point_longitude': {
+        'long_name': 'Longitude of each grid point',
+        'units': 'degrees_north'},
+
+    'point_latitude': {
+        'long_name': 'Latitude of each grid point',
+        'units': 'degrees_east'},
+
 }
 
 

--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -629,6 +629,20 @@ DEFAULT_METADATA = {
         'standard_name':  'interpolated_profile',
         'units': 'unknown'},
 
+    # Grid metadata
+    'point_x': {
+        'long_name': 'Cartesian x distance of each grid point from the origin',
+        'units': 'meters'},
+
+    'point_y': {
+        'long_name': 'Cartesian y distance of each grid point from the origin',
+        'units': 'meters'},
+
+    'point_z': {
+        'long_name': 'Cartesian z distance of each grid point from the origin',
+        'positive': 'up',
+        'units': 'meters'},
+
 }
 
 

--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -73,9 +73,9 @@ def parse_vmin_vmax(container, field, vmin, vmax):
 def parse_lon_lat(grid, lon, lat):
     """ Parse lat and lon parameters """
     if lat is None:
-        lat = grid.axes['lat']['data'][0]
+        lat = grid.origin_latitude['data'][0]
     if lon is None:
-        lon = grid.axes['lon']['data'][0]
+        lon = grid.origin_latitude['data'][0]
     return lon, lat
 
 
@@ -124,16 +124,12 @@ def generate_radar_time_begin(radar):
 
 def generate_grid_time_begin(grid):
     """ Return time begin in datetime instance. """
-    # datetime object describing time
-    if "time_start" in grid.axes:
-        time = "time_start"
-    elif 'time' in grid.axes:
-        time = 'time'
-    elif 'time_end' in grid.axes:
-        time = 'time_end'
-    times = grid.axes[time]['data'][0]
-    units = grid.axes[time]['units']
-    calendar = grid.axes[time]['calendar']
+    times = grid.time['data'][0]
+    units = grid.time['units']
+    if 'calendar' in grid.time:
+        calendar = grid.time['calendar']
+    else:
+        calendar = 'standard'
     return num2date(times, units, calendar)
 
 
@@ -247,7 +243,7 @@ def generate_grid_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    height = grid.axes["z_disp"]['data'][level] / 1000.
+    height = grid.regular_z['data'][level] / 1000.
     l1 = "%s %.1f km %s " % (generate_grid_name(grid), height,
                              time_str)
     field_name = generate_field_name(grid, field)
@@ -275,7 +271,7 @@ def generate_longitudinal_level_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    disp = grid.axes["x_disp"]['data'][level] / 1000.
+    disp = grid.regular_x['data'][level] / 1000.
     if disp >= 0:
         direction = "east"
     else:
@@ -308,7 +304,7 @@ def generate_latitudinal_level_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    disp = grid.axes["y_disp"]['data'][level] / 1000.
+    disp = grid.regular_y['data'][level] / 1000.
     if disp >= 0:
         direction = "north"
     else:

--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -75,7 +75,7 @@ def parse_lon_lat(grid, lon, lat):
     if lat is None:
         lat = grid.origin_latitude['data'][0]
     if lon is None:
-        lon = grid.origin_latitude['data'][0]
+        lon = grid.origin_longitude['data'][0]
     return lon, lat
 
 

--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -243,7 +243,7 @@ def generate_grid_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    height = grid.regular_z['data'][level] / 1000.
+    height = grid.z['data'][level] / 1000.
     l1 = "%s %.1f km %s " % (generate_grid_name(grid), height,
                              time_str)
     field_name = generate_field_name(grid, field)
@@ -271,7 +271,7 @@ def generate_longitudinal_level_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    disp = grid.regular_x['data'][level] / 1000.
+    disp = grid.x['data'][level] / 1000.
     if disp >= 0:
         direction = "east"
     else:
@@ -304,7 +304,7 @@ def generate_latitudinal_level_title(grid, field, level):
 
     """
     time_str = generate_grid_time_begin(grid).isoformat() + 'Z'
-    disp = grid.regular_y['data'][level] / 1000.
+    disp = grid.y['data'][level] / 1000.
     if disp >= 0:
         direction = "north"
     else:

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -80,8 +80,8 @@ class GridMapDisplay():
                                 lat_0=lat0, lon_0=lon0)
 
         # determine grid latitudes and longitudes.
-        x_1d = grid.regular_x['data']
-        y_1d = grid.regular_y['data']
+        x_1d = grid.x['data']
+        y_1d = grid.y['data']
         x_2d, y_2d = np.meshgrid(x_1d, y_1d)
         self.grid_lons, self.grid_lats = self.proj(x_2d, y_2d, inverse=True)
 
@@ -211,8 +211,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        x_1d = self.grid.regular_x['data']
-        y_1d = self.grid.regular_y['data']
+        x_1d = self.grid.x['data']
+        y_1d = self.grid.y['data']
 
         if edges:
             if len(x_1d) > 1:
@@ -418,8 +418,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        x_1d = self.grid.regular_x['data'] / 1000.
-        z_1d = self.grid.regular_z['data'] / 1000.
+        x_1d = self.grid.x['data'] / 1000.
+        z_1d = self.grid.z['data'] / 1000.
         if edges:
             if len(x_1d) > 1:
                 x_1d = _interpolate_axes_edges(x_1d)
@@ -586,8 +586,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        y_1d = self.grid.regular_y['data'] / 1000.
-        z_1d = self.grid.regular_z['data'] / 1000.
+        y_1d = self.grid.y['data'] / 1000.
+        z_1d = self.grid.z['data'] / 1000.
         if edges:
             if len(y_1d) > 1:
                 y_1d = _interpolate_axes_edges(y_1d)
@@ -722,8 +722,8 @@ class GridMapDisplay():
             default_args['urcrnrlat'] = max_lat
         else:
             # determine width and height of the plot
-            x = self.grid.regular_x['data'][0]
-            y = self.grid.regular_y['data'][0]
+            x = self.grid.x['data'][0]
+            y = self.grid.y['data'][0]
             default_args['width'] = (x.max() - x.min())
             default_args['height'] = (y.max() - y.min())
 
@@ -747,8 +747,8 @@ class GridMapDisplay():
             print("x_cut: ", x_cut)
             print("y_cut: ", y_cut)
 
-        x_index = np.abs(self.grid.regular_x['data'] - x_cut).argmin()
-        y_index = np.abs(self.grid.regular_y['data'] - y_cut).argmin()
+        x_index = np.abs(self.grid.x['data'] - x_cut).argmin()
+        y_index = np.abs(self.grid.y['data'] - y_cut).argmin()
 
         if self.debug:
             print("x_index", x_index)

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -74,14 +74,14 @@ class GridMapDisplay():
         self.debug = debug
 
         # set up the projection
-        lat0 = grid.axes['lat']['data'][0]
-        lon0 = grid.axes['lon']['data'][0]
+        lat0 = grid.origin_latitude['data'][0]
+        lon0 = grid.origin_longitude['data'][0]
         self.proj = pyproj.Proj(proj='aeqd', datum='NAD83',
                                 lat_0=lat0, lon_0=lon0)
 
         # determine grid latitudes and longitudes.
-        x_1d = grid.axes['x_disp']['data']
-        y_1d = grid.axes['y_disp']['data']
+        x_1d = grid.regular_x['data']
+        y_1d = grid.regular_y['data']
         x_2d, y_2d = np.meshgrid(x_1d, y_1d)
         self.grid_lons, self.grid_lats = self.proj(x_2d, y_2d, inverse=True)
 
@@ -211,8 +211,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        x_1d = self.grid.axes['x_disp']['data']
-        y_1d = self.grid.axes['y_disp']['data']
+        x_1d = self.grid.regular_x['data']
+        y_1d = self.grid.regular_y['data']
 
         if edges:
             if len(x_1d) > 1:
@@ -418,8 +418,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        x_1d = self.grid.axes['x_disp']['data'] / 1000.
-        z_1d = self.grid.axes['z_disp']['data'] / 1000.
+        x_1d = self.grid.regular_x['data'] / 1000.
+        z_1d = self.grid.regular_z['data'] / 1000.
         if edges:
             if len(x_1d) > 1:
                 x_1d = _interpolate_axes_edges(x_1d)
@@ -586,8 +586,8 @@ class GridMapDisplay():
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the grid
-        y_1d = self.grid.axes['y_disp']['data'] / 1000.
-        z_1d = self.grid.axes['z_disp']['data'] / 1000.
+        y_1d = self.grid.regular_y['data'] / 1000.
+        z_1d = self.grid.regular_z['data'] / 1000.
         if edges:
             if len(y_1d) > 1:
                 y_1d = _interpolate_axes_edges(y_1d)
@@ -706,8 +706,8 @@ class GridMapDisplay():
             print("Minimum longitute: ", min_lon)
 
         # determine plot center
-        lat_0 = self.grid.axes['lat']['data'][0]
-        lon_0 = self.grid.axes['lon']['data'][0]
+        lat_0 = self.grid.origin_latitude['data'][0]
+        lon_0 = self.grid.origin_longitude['data'][0]
 
         default_args = {
             'lat_0': lat_0, 'lon_0': lon_0, 'lat_ts': lat_0,
@@ -722,8 +722,8 @@ class GridMapDisplay():
             default_args['urcrnrlat'] = max_lat
         else:
             # determine width and height of the plot
-            x = self.grid.axes['x_disp']['data'][0]
-            y = self.grid.axes['y_disp']['data'][0]
+            x = self.grid.regular_x['data'][0]
+            y = self.grid.regular_y['data'][0]
             default_args['width'] = (x.max() - x.min())
             default_args['height'] = (y.max() - y.min())
 
@@ -747,8 +747,8 @@ class GridMapDisplay():
             print("x_cut: ", x_cut)
             print("y_cut: ", y_cut)
 
-        x_index = np.abs(self.grid.axes['x_disp']['data'] - x_cut).argmin()
-        y_index = np.abs(self.grid.axes['y_disp']['data'] - y_cut).argmin()
+        x_index = np.abs(self.grid.regular_x['data'] - x_cut).argmin()
+        y_index = np.abs(self.grid.regular_y['data'] - y_cut).argmin()
 
         if self.debug:
             print("x_index", x_index)

--- a/pyart/io/__init__.py
+++ b/pyart/io/__init__.py
@@ -45,6 +45,7 @@ Reading grid data
     :toctree: generated/
 
     read_grid
+    read_legacy_grid
     read_grid_mdv
 
 Writing grid data
@@ -77,7 +78,7 @@ from .nexrad_cdm import read_nexrad_cdm
 from .nexradl3_read import read_nexrad_level3
 from .uf import read_uf
 from .uf_write import write_uf
-from .grid_io import read_grid, write_grid
+from .grid_io import read_grid, write_grid, read_legacy_grid
 from .auto_read import read
 from .mdv_grid import write_grid_mdv, read_grid_mdv
 from .common import prepare_for_read

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -10,9 +10,6 @@ Reading and writing Grid objects.
     read_grid
     write_grid
 
-    _read_grid_cf
-    _read_grid_wrf
-
 """
 
 from warnings import warn
@@ -192,71 +189,3 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
     ncobj.close()
 
     return
-
-
-def _read_grid_cf(filename):
-    """
-    Read a CF compliant netCDF file containing a grid.
-
-    Parameters
-    ----------
-    filename : str
-        Filename of the netCDF file.
-
-    Returns
-    -------
-    grid : Grid
-        Grid object containing gridded data.
-
-    Notes
-    -----
-    This function does only the most basic variable checking.  The resulting
-    Grid object is most likely not writable.
-
-    """
-    ncobj = netCDF4.Dataset(filename)
-    ncvars = ncobj.variables
-    fields = {}
-    axes = {}
-    for var in ncvars:
-        if len(ncvars[var].shape) > 1:
-            # dimensionality of 2+ are fields variables
-            fields[var] = _ncvar_to_dict(ncvars[var])
-        else:
-            # dimensionality of 1 are axes variables
-            axes[var] = _ncvar_to_dict(ncvars[var])
-    return Grid(fields, axes, {})
-
-
-def _read_grid_wrf(filename):
-    """
-    Read a WRF netCDF file containing a grid.
-
-    Parameters
-    ----------
-    filename : str
-        Filename of the WRF netCDF file.
-
-    Returns
-    -------
-    grid : Grid
-        Grid object containing data.
-
-    Notes
-    -----
-    This function does only the most basic variable checking.  The resulting
-    Grid object is most likely not writable.
-
-    """
-    ncobj = netCDF4.Dataset(filename)
-    ncvars = ncobj.variables
-    fields = {}
-    axes = {}
-    for var in ncvars:
-        if len(ncvars[var].shape) > 1:
-            # dimensionality of 2+ are fields variables
-            fields[var] = _ncvar_to_dict(ncvars[var])
-        else:
-            # dimensionality of 1 are axes variables
-            axes[var] = _ncvar_to_dict(ncvars[var])
-    return Grid(fields, axes, {})

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -131,15 +131,13 @@ def read_grid(filename, exclude_fields=None, **kwargs):
 
     dset.close()
 
-    grid = Grid(
+    return Grid(
         time, fields, metadata,
         origin_latitude, origin_longitude, origin_altitude,
-        regular_x, regular_y, regular_z,
+        regular_x, regular_y, regular_z, projection=projection,
         radar_latitude=radar_latitude, radar_longitude=radar_longitude,
         radar_altitude=radar_altitude, radar_name=radar_name,
         radar_time=radar_time)
-    grid.projection = projection
-    return grid
 
 
 def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -51,7 +51,7 @@ def read_grid(filename, exclude_fields=None, **kwargs):
         exclude_fields = []
 
     reserved_variables = [
-        'time', 'regular_x', 'regular_y', 'regular_z',
+        'time', 'x', 'y', 'z',
         'origin_latitude', 'origin_longitude', 'origin_altitude',
         'point_x', 'point_y', 'point_z', 'projection',
         'point_latitude', 'point_longitude', 'point_altitude',
@@ -68,9 +68,9 @@ def read_grid(filename, exclude_fields=None, **kwargs):
     origin_latitude = _ncvar_to_dict(dset.variables['origin_latitude'])
     origin_longitude = _ncvar_to_dict(dset.variables['origin_longitude'])
     origin_altitude = _ncvar_to_dict(dset.variables['origin_altitude'])
-    regular_x = _ncvar_to_dict(dset.variables['regular_x'])
-    regular_y = _ncvar_to_dict(dset.variables['regular_y'])
-    regular_z = _ncvar_to_dict(dset.variables['regular_z'])
+    x = _ncvar_to_dict(dset.variables['x'])
+    y = _ncvar_to_dict(dset.variables['y'])
+    z = _ncvar_to_dict(dset.variables['z'])
 
     # projection
     projection = _ncvar_to_dict(dset.variables['projection'])
@@ -133,8 +133,8 @@ def read_grid(filename, exclude_fields=None, **kwargs):
 
     return Grid(
         time, fields, metadata,
-        origin_latitude, origin_longitude, origin_altitude,
-        regular_x, regular_y, regular_z, projection=projection,
+        origin_latitude, origin_longitude, origin_altitude, x, y, z,
+        projection=projection,
         radar_latitude=radar_latitude, radar_longitude=radar_longitude,
         radar_altitude=radar_altitude, radar_name=radar_name,
         radar_time=radar_time)
@@ -196,9 +196,9 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
 
     # required variables
     _create_ncvar(grid.time, dset, 'time', ('time', ))
-    _create_ncvar(grid.regular_x, dset, 'regular_x', ('nx', ))
-    _create_ncvar(grid.regular_y, dset, 'regular_y', ('ny', ))
-    _create_ncvar(grid.regular_z, dset, 'regular_z', ('nz', ))
+    _create_ncvar(grid.x, dset, 'x', ('nx', ))
+    _create_ncvar(grid.y, dset, 'y', ('ny', ))
+    _create_ncvar(grid.z, dset, 'z', ('nz', ))
     _create_ncvar(grid.origin_latitude, dset, 'origin_latitude', ('time', ))
     _create_ncvar(grid.origin_longitude, dset, 'origin_longitude', ('time', ))
     _create_ncvar(grid.origin_altitude, dset, 'origin_altitude', ('time', ))

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -1,6 +1,6 @@
 """
-pyart.io.grid
-=============
+pyart.io.grid_io
+================
 
 Reading and writing Grid objects.
 
@@ -49,36 +49,52 @@ def read_grid(filename, exclude_fields=None, **kwargs):
     if exclude_fields is None:
         exclude_fields = []
 
-    ncobj = netCDF4.Dataset(filename, mode='r')
+    reserved_variables = [
+        'time', 'regular_x', 'regular_y', 'regular_z',
+        'origin_latitude', 'origin_longitude', 'origin_altitude',
+        'point_x', 'point_y', 'point_z', 'projection',
+        'point_latitude', 'point_longitude', 'point_altitude',
+        'radar_latitude', 'radar_longitude', 'radar_altitude',
+        'radar_name', 'radar_time', 'base_time', 'time_offset']
+
+    dset = netCDF4.Dataset(filename, mode='r')
 
     # metadata
-    metadata = dict([(k, getattr(ncobj, k)) for k in ncobj.ncattrs()])
+    metadata = dict([(k, getattr(dset, k)) for k in dset.ncattrs()])
 
-    # axes
-    axes_keys = ['time', 'time_start', 'time_end', 'base_time',
-                 'time_offset', 'z_disp', 'y_disp', 'x_disp',
-                 'alt', 'lat', 'lon', 'z', 'lev', 'y', 'x']
-    axes = dict((k, _ncvar_to_dict(ncobj.variables[k])) for k in axes_keys
-                if k in ncobj.variables)
+    # required reserved variables
+    time = _ncvar_to_dict(dset.variables['time'])
+    origin_latitude = _ncvar_to_dict(dset.variables['origin_latitude'])
+    origin_longitude = _ncvar_to_dict(dset.variables['origin_longitude'])
+    origin_altitude = _ncvar_to_dict(dset.variables['origin_altitude'])
+    regular_x = _ncvar_to_dict(dset.variables['regular_x'])
+    regular_y = _ncvar_to_dict(dset.variables['regular_y'])
+    regular_z = _ncvar_to_dict(dset.variables['regular_z'])
+
+    # projection
+    projection = _ncvar_to_dict(dset.variables['projection'])
+    projection.pop('data')
+    # map _include_lon_0_lat_0 key to bool type
+    if '_include_lon_0_lat_0' in projection:
+        v = projection['_include_lon_0_lat_0']
+        projection['_include_lon_0_lat_0'] = {'true': True, 'false': False}[v]
 
     # read in the fields
-    # determine the correct shape of the fields
-    # ARM standard requires the left-most dimension to be time, so the shape
-    # of the fields in the file is (1, nz, ny, nx) but the field data should
-    # be shaped (nz, ny, nx) in the Grid object
-    dim_keys = ['nz', 'ny', 'nx', 'z', 'y', 'x']
-    field_shape = tuple([len(ncobj.dimensions[k]) for k in dim_keys
-                         if k in ncobj.dimensions])
+    fields = {}
+
+    # fields in the file has a shape of (1, nz, ny, nx) with the leading 1
+    # indicating time but should shaped (nz, ny, nx) in the Grid object
+    field_shape = tuple([len(dset.dimensions[d]) for d in ['nz', 'ny', 'nx']])
     field_shape_with_time = (1, ) + field_shape
 
-    # check all non-axes variables, those with the correct shape
+    # check all non-reserved variables, those with the correct shape
     # are added to the field dictionary, if a wrong sized field is
     # detected a warning is raised
-    field_keys = [k for k in ncobj.variables if k not in axes_keys and
-                  k not in exclude_fields]
-    fields = {}
+    field_keys = [k for k in dset.variables if k not in reserved_variables]
     for field in field_keys:
-        field_dic = _ncvar_to_dict(ncobj.variables[field])
+        if field in exclude_fields:
+            continue
+        field_dic = _ncvar_to_dict(dset.variables[field])
         if field_dic['data'].shape == field_shape_with_time:
             field_dic['data'].shape = field_shape
             fields[field] = field_dic
@@ -86,11 +102,43 @@ def read_grid(filename, exclude_fields=None, **kwargs):
             bad_shape = field_dic['data'].shape
             warn('Field %s skipped due to incorrect shape' % (field))
 
-    ncobj.close()
+    # radar_ variables
+    if 'radar_latitude' in dset.variables:
+        radar_latitude = _ncvar_to_dict(dset.variables['radar_latitude'])
+    else:
+        radar_latitude = None
 
-    return Grid(axes['time'], fields, metadata,
-                axes['lat'], axes['lon'], axes['alt'],
-                axes['x_disp'], axes['y_disp'], axes['z_disp'])
+    if 'radar_longitude' in dset.variables:
+        radar_longitude = _ncvar_to_dict(dset.variables['radar_longitude'])
+    else:
+        radar_longitude = None
+
+    if 'radar_altitude' in dset.variables:
+        radar_altitude = _ncvar_to_dict(dset.variables['radar_altitude'])
+    else:
+        radar_altitude = None
+
+    if 'radar_name' in dset.variables:
+        radar_name = _ncvar_to_dict(dset.variables['radar_name'])
+    else:
+        radar_name = None
+
+    if 'radar_time' in dset.variables:
+        radar_time = _ncvar_to_dict(dset.variables['radar_time'])
+    else:
+        radar_time = None
+
+    dset.close()
+
+    grid = Grid(
+        time, fields, metadata,
+        origin_latitude, origin_longitude, origin_altitude,
+        regular_x, regular_y, regular_z,
+        radar_latitude=radar_latitude, radar_longitude=radar_longitude,
+        radar_altitude=radar_altitude, radar_name=radar_name,
+        radar_time=radar_time)
+    grid.projection = projection
+    return grid
 
 
 def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
@@ -127,32 +175,52 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
         time_offset. False will not write these variables.
 
     """
-    ncobj = netCDF4.Dataset(filename, mode='w', format=format)
+    dset = netCDF4.Dataset(filename, mode='w', format=format)
 
-    # create the time dimension
-    ncobj.createDimension('time', None)
+    # create dimensions
+    dset.createDimension('time', None)
+    dset.createDimension('nz', grid.nz)
+    dset.createDimension('ny', grid.ny)
+    dset.createDimension('nx', grid.nx)
+    if grid.nradar != 0:
+        dset.createDimension('nradar', grid.nradar)
+        if grid.radar_name is not None:
+            nradar_str_length = len(grid.radar_name['data'][0])
+            dset.createDimension('nradar_str_length', nradar_str_length)
 
-    # create additional dimensions
-    grid_shape = grid.fields[list(grid.fields.keys())[0]]['data'].shape
-    nz, ny, nx = grid_shape
-    ncobj.createDimension('nz', nz)
-    ncobj.createDimension('ny', ny)
-    ncobj.createDimension('nx', nx)
+    # required variables
+    _create_ncvar(grid.time, dset, 'time', ('time', ))
+    _create_ncvar(grid.regular_x, dset, 'regular_x', ('nx', ))
+    _create_ncvar(grid.regular_y, dset, 'regular_y', ('ny', ))
+    _create_ncvar(grid.regular_z, dset, 'regular_z', ('nz', ))
+    _create_ncvar(grid.origin_latitude, dset, 'origin_latitude', ('time', ))
+    _create_ncvar(grid.origin_longitude, dset, 'origin_longitude', ('time', ))
+    _create_ncvar(grid.origin_altitude, dset, 'origin_altitude', ('time', ))
 
-    # axes variables
-    _create_ncvar(grid.axes['time'], ncobj, 'time', ('time', ))
-    _create_ncvar(grid.axes['time_end'], ncobj, 'time_end', ('time', ))
-    _create_ncvar(grid.axes['time_start'], ncobj, 'time_start', ('time', ))
-    _create_ncvar(grid.axes['x_disp'], ncobj, 'x_disp', ('nx', ))
-    _create_ncvar(grid.axes['y_disp'], ncobj, 'y_disp', ('ny', ))
-    _create_ncvar(grid.axes['z_disp'], ncobj, 'z_disp', ('nz', ))
-    _create_ncvar(grid.axes['lat'], ncobj, 'lat', ('time', ))
-    _create_ncvar(grid.axes['lon'], ncobj, 'lon', ('time', ))
-    _create_ncvar(grid.axes['alt'], ncobj, 'alt', ('time', ))
+    # write the projection dictionary as a scalar
+    projection = grid.projection.copy()
+    projection['data'] = np.array(1, dtype='int32')
+    # NetCDF does not support boolean attribute, covert to string
+    if '_include_lon_0_lat_0' in projection:
+        include = projection['_include_lon_0_lat_0']
+        projection['_include_lon_0_lat_0'] = ['false', 'true'][include]
+    _create_ncvar(projection, dset, 'projection', ())
+
+    # radar_ attributes
+    radar_attr_names = [
+        'radar_latitude', 'radar_longitude', 'radar_altitude', 'radar_time']
+    for attr_name in radar_attr_names:
+        attr = getattr(grid, attr_name)
+        if attr is not None:
+            _create_ncvar(attr, dset, attr_name, ('nradar', ))
+
+    if grid.radar_name is not None:
+        _create_ncvar(grid.radar_name, dset, 'radar_name',
+                      ('nradar', 'nradar_str_length'))
 
     # create ARM time variables base_time and time_offset, if requested
     if arm_time_variables:
-        time = grid.axes['time']
+        time = grid.time
         dt = netCDF4.num2date(time['data'][0], time['units'])
         td = dt - datetime.datetime.utcfromtimestamp(0)
         td = td.seconds + td.days * 24 * 3600
@@ -164,7 +232,7 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
             'ancillary_variables': 'time_offset',
             'long_name': 'Base time in Epoch',
         }
-        _create_ncvar(base_time, ncobj, 'base_time', ())
+        _create_ncvar(base_time, dset, 'base_time', ())
 
         time_offset = {
             'data': np.array(time['data'], dtype=np.float64),
@@ -173,19 +241,18 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
             'ancillary_variables': 'time_offset',
             'calendar': 'gregorian',
         }
-        _create_ncvar(time_offset, ncobj, 'time_offset', ('time', ))
+        _create_ncvar(time_offset, dset, 'time_offset', ('time', ))
 
     # field variables
     for field, field_dic in grid.fields.items():
         # append 1, to the shape of all data to indicate the time var.
         field_dic['data'].shape = (1, ) + field_dic['data'].shape
-        _create_ncvar(field_dic, ncobj, field, ('time', 'nz', 'ny', 'nx'))
+        _create_ncvar(field_dic, dset, field, ('time', 'nz', 'ny', 'nx'))
         field_dic['data'].shape = field_dic['data'].shape[1:]
 
     # metadata
     for k, v in grid.metadata.items():
-        setattr(ncobj, k, v)
+        setattr(dset, k, v)
 
-    ncobj.close()
-
+    dset.close()
     return

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -10,6 +10,7 @@ Reading and writing Grid objects.
     read_grid
     write_grid
     read_legacy_grid
+    _make_coordinatesystem_dict
 
 """
 

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -13,7 +13,7 @@ Reading and writing Grid objects.
 
 """
 
-from warnings import warn
+import warnings
 
 import numpy as np
 import netCDF4
@@ -101,7 +101,7 @@ def read_grid(filename, exclude_fields=None, **kwargs):
             fields[field] = field_dic
         else:
             bad_shape = field_dic['data'].shape
-            warn('Field %s skipped due to incorrect shape' % (field))
+            warnings.warn('Field %s skipped due to incorrect shape' % (field))
 
     # radar_ variables
     if 'radar_latitude' in dset.variables:
@@ -299,6 +299,9 @@ def read_legacy_grid(filename, exclude_fields=None, **kwargs):
         Grid object containing gridded data.
 
     """
+    warnings.warn(
+        "read_legacy_grid is depreciated and will be removed in a future " +
+        "version of Py-ART", DeprecationWarning)
     # test for non empty kwargs
     _test_arguments(kwargs)
 

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -77,8 +77,8 @@ def read_grid(filename, exclude_fields=None, **kwargs):
     # check all non-axes variables, those with the correct shape
     # are added to the field dictionary, if a wrong sized field is
     # detected a warning is raised
-    field_keys = [k for k in ncobj.variables if k not in axes_keys
-                  and k not in exclude_fields]
+    field_keys = [k for k in ncobj.variables if k not in axes_keys and
+                  k not in exclude_fields]
     fields = {}
     for field in field_keys:
         field_dic = _ncvar_to_dict(ncobj.variables[field])
@@ -90,7 +90,10 @@ def read_grid(filename, exclude_fields=None, **kwargs):
             warn('Field %s skipped due to incorrect shape' % (field))
 
     ncobj.close()
-    return Grid(fields, axes, metadata)
+
+    return Grid(axes['time'], fields, metadata,
+                axes['lat'], axes['lon'], axes['alt'],
+                axes['x_disp'], axes['y_disp'], axes['z_disp'])
 
 
 def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -300,6 +300,10 @@ def write_grid(filename, grid, format='NETCDF4',
     for k, v in grid.metadata.items():
         setattr(dset, k, v)
 
+    # Add Conventions if not already present
+    if 'Conventions' not in dset.ncattrs():
+        dset.setncattr('Conventions', 'PyART_GRID-1.1')
+
     dset.close()
     return
 

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -235,7 +235,11 @@ def write_grid(filename, grid, format='NETCDF4',
             proj_coord_sys = _make_coordinatesystem_dict(grid)
 
         if proj_coord_sys is None:
-            warnings.warn('Foo')
+            warnings.warn(
+                'Cannot determine ProjectionCoordinateSystem parameter for ' +
+                'the given projection, the file will not be written ' +
+                ' without this information')
+
         else:
             proj_coord_sys['data'] = np.array(1, dtype='int32')
             _create_ncvar(

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -141,7 +141,8 @@ def read_grid(filename, exclude_fields=None, **kwargs):
     return grid
 
 
-def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
+def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
+               write_point_x_y_z=False, write_point_lon_lat_alt=False):
     """
     Write a Grid object to a CF-1.5 and ARM standard netcdf file
 
@@ -170,9 +171,15 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
         NetCDF format, one of 'NETCDF4', 'NETCDF4_CLASSIC',
         'NETCDF3_CLASSIC' or 'NETCDF3_64BIT'. See netCDF4 documentation for
         details.
-    arm_time_variables : bool
+    arm_time_variables : bool, optional
         True to write the ARM standard time variables base_time and
         time_offset. False will not write these variables.
+    write_point_x_y_z : bool, optional
+        True to include the point_x, point_y and point_z variables in the
+        written file, False will not write these variables.
+    write_point_lon_lat_alt : bool, optional
+        True to include the point_longitude, point_latitude and point_altitude
+        variables in the written file, False will not write these variables.
 
     """
     dset = netCDF4.Dataset(filename, mode='w', format=format)
@@ -242,6 +249,17 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False):
             'calendar': 'gregorian',
         }
         _create_ncvar(time_offset, dset, 'time_offset', ('time', ))
+
+    # optionally write point_ variables
+    if write_point_x_y_z:
+        _create_ncvar(grid.point_x, dset, 'point_x', ('nz', 'nx', 'ny'))
+        _create_ncvar(grid.point_y, dset, 'point_y', ('nz', 'nx', 'ny'))
+        _create_ncvar(grid.point_z, dset, 'point_z', ('nz', 'nx', 'ny'))
+    if write_point_lon_lat_alt:
+        dims = ('nz', 'ny', 'nx')
+        _create_ncvar(grid.point_latitude, dset, 'point_latitude', dims)
+        _create_ncvar(grid.point_longitude, dset, 'point_longitude', dims)
+        _create_ncvar(grid.point_altitude, dset, 'point_altitude', dims)
 
     # field variables
     for field, field_dic in grid.fields.items():

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -85,7 +85,7 @@ def read_grid(filename, exclude_fields=None, **kwargs):
 
     # fields in the file has a shape of (1, nz, ny, nx) with the leading 1
     # indicating time but should shaped (nz, ny, nx) in the Grid object
-    field_shape = tuple([len(dset.dimensions[d]) for d in ['nz', 'ny', 'nx']])
+    field_shape = tuple([len(dset.dimensions[d]) for d in ['z', 'y', 'x']])
     field_shape_with_time = (1, ) + field_shape
 
     # check all non-reserved variables, those with the correct shape
@@ -185,9 +185,9 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
 
     # create dimensions
     dset.createDimension('time', None)
-    dset.createDimension('nz', grid.nz)
-    dset.createDimension('ny', grid.ny)
-    dset.createDimension('nx', grid.nx)
+    dset.createDimension('z', grid.nz)
+    dset.createDimension('y', grid.ny)
+    dset.createDimension('x', grid.nx)
     if grid.nradar != 0:
         dset.createDimension('nradar', grid.nradar)
         if grid.radar_name is not None:
@@ -196,9 +196,9 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
 
     # required variables
     _create_ncvar(grid.time, dset, 'time', ('time', ))
-    _create_ncvar(grid.x, dset, 'x', ('nx', ))
-    _create_ncvar(grid.y, dset, 'y', ('ny', ))
-    _create_ncvar(grid.z, dset, 'z', ('nz', ))
+    _create_ncvar(grid.x, dset, 'x', ('x', ))
+    _create_ncvar(grid.y, dset, 'y', ('y', ))
+    _create_ncvar(grid.z, dset, 'z', ('z', ))
     _create_ncvar(grid.origin_latitude, dset, 'origin_latitude', ('time', ))
     _create_ncvar(grid.origin_longitude, dset, 'origin_longitude', ('time', ))
     _create_ncvar(grid.origin_altitude, dset, 'origin_altitude', ('time', ))
@@ -251,11 +251,11 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
 
     # optionally write point_ variables
     if write_point_x_y_z:
-        _create_ncvar(grid.point_x, dset, 'point_x', ('nz', 'nx', 'ny'))
-        _create_ncvar(grid.point_y, dset, 'point_y', ('nz', 'nx', 'ny'))
-        _create_ncvar(grid.point_z, dset, 'point_z', ('nz', 'nx', 'ny'))
+        _create_ncvar(grid.point_x, dset, 'point_x', ('z', 'x', 'y'))
+        _create_ncvar(grid.point_y, dset, 'point_y', ('z', 'x', 'y'))
+        _create_ncvar(grid.point_z, dset, 'point_z', ('z', 'x', 'y'))
     if write_point_lon_lat_alt:
-        dims = ('nz', 'ny', 'nx')
+        dims = ('z', 'y', 'x')
         _create_ncvar(grid.point_latitude, dset, 'point_latitude', dims)
         _create_ncvar(grid.point_longitude, dset, 'point_longitude', dims)
         _create_ncvar(grid.point_altitude, dset, 'point_altitude', dims)
@@ -264,7 +264,7 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
     for field, field_dic in grid.fields.items():
         # append 1, to the shape of all data to indicate the time var.
         field_dic['data'].shape = (1, ) + field_dic['data'].shape
-        _create_ncvar(field_dic, dset, field, ('time', 'nz', 'ny', 'nx'))
+        _create_ncvar(field_dic, dset, field, ('time', 'z', 'y', 'x'))
         field_dic['data'].shape = field_dic['data'].shape[1:]
 
     # metadata

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -9,6 +9,7 @@ Reading and writing Grid objects.
 
     read_grid
     write_grid
+    read_legacy_grid
 
 """
 
@@ -274,3 +275,72 @@ def write_grid(filename, grid, format='NETCDF4', arm_time_variables=False,
 
     dset.close()
     return
+
+
+def read_legacy_grid(filename, exclude_fields=None, **kwargs):
+    """
+    Read a legacy netCDF grid file.
+
+    Legacy files were produced by Py-ART version 1.5 and before.
+
+    Parameters
+    ----------
+    filename : str
+        Filename of NetCDF grid file to read.
+
+    Other Parameters
+    ----------------
+    exclude_fields : list
+        A list of fields to exclude from the grid object.
+
+    Returns
+    -------
+    grid : Grid
+        Grid object containing gridded data.
+
+    """
+    # test for non empty kwargs
+    _test_arguments(kwargs)
+
+    if exclude_fields is None:
+        exclude_fields = []
+
+    ncobj = netCDF4.Dataset(filename, mode='r')
+
+    # metadata
+    metadata = dict([(k, getattr(ncobj, k)) for k in ncobj.ncattrs()])
+
+    # axes
+    axes_keys = ['time', 'time_start', 'time_end', 'base_time',
+                 'time_offset', 'z_disp', 'y_disp', 'x_disp',
+                 'alt', 'lat', 'lon', 'z', 'lev', 'y', 'x']
+    axes = dict((k, _ncvar_to_dict(ncobj.variables[k])) for k in axes_keys
+                if k in ncobj.variables)
+
+    # read in the fields
+    # determine the correct shape of the fields
+    # ARM standard requires the left-most dimension to be time, so the shape
+    # of the fields in the file is (1, nz, ny, nx) but the field data should
+    # be shaped (nz, ny, nx) in the Grid object
+    dim_keys = ['nz', 'ny', 'nx', 'z', 'y', 'x']
+    field_shape = tuple([len(ncobj.dimensions[k]) for k in dim_keys
+                         if k in ncobj.dimensions])
+    field_shape_with_time = (1, ) + field_shape
+
+    # check all non-axes variables, those with the correct shape
+    # are added to the field dictionary, if a wrong sized field is
+    # detected a warning is raised
+    field_keys = [k for k in ncobj.variables if k not in axes_keys and
+                  k not in exclude_fields]
+    fields = {}
+    for field in field_keys:
+        field_dic = _ncvar_to_dict(ncobj.variables[field])
+        if field_dic['data'].shape == field_shape_with_time:
+            field_dic['data'].shape = field_shape
+            fields[field] = field_dic
+        else:
+            bad_shape = field_dic['data'].shape
+            warn('Field %s skipped due to incorrect shape' % (field))
+
+    ncobj.close()
+    return Grid.from_legacy_parameters(fields, axes, metadata)

--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -107,10 +107,9 @@ def write_grid_mdv(filename, grid, mdv_field_names=None,
     d["data_dimension"] = 3  # XXX are grid's always 3d?
     # =DATA_SYNTHESIS, I don't realy know, so miscellaneous!
     d["data_collection_type"] = 3
-    if (grid.regular_z['units'] == 'm' or grid.regular_z['units'] == 'meters'):
+    if (grid.z['units'] == 'm' or grid.z['units'] == 'meters'):
         d["native_vlevel_type"] = 4
-    elif (grid.regular_z['units'] == '\xc2' or
-          grid.regular_z['units'] == 'degree'):
+    elif (grid.z['units'] == '\xc2' or grid.z['units'] == 'degree'):
         d["native_vlevel_type"] = 9
     d["vlevel_type"] = d["native_vlevel_type"]
     d["nfields"] = nfields
@@ -175,12 +174,10 @@ def write_grid_mdv(filename, grid, mdv_field_names=None,
         d["data_dimension"] = 3
         d["proj_origin_lat"] = grid.origin_latitude['data'][0]
         d["proj_origin_lon"] = grid.origin_longitude['data'][0]
-        d["grid_dx"] = (grid.regular_x['data'][1] -
-                        grid.regular_x['data'][0]) / 1000.
-        d["grid_dy"] = (grid.regular_y['data'][1] -
-                        grid.regular_y['data'][0]) / 1000.
-        d["grid_minx"] = (grid.regular_x['data'][0]) / 1000.
-        d["grid_miny"] = (grid.regular_y['data'][0]) / 1000.
+        d["grid_dx"] = (grid.x['data'][1] - grid.x['data'][0]) / 1000.
+        d["grid_dy"] = (grid.y['data'][1] - grid.y['data'][0]) / 1000.
+        d["grid_minx"] = (grid.x['data'][0]) / 1000.
+        d["grid_miny"] = (grid.y['data'][0]) / 1000.
         if "scale_factor" in grid.fields[field].keys():
             d["scale"] = grid.fields[field]["scale_factor"]
         if "add_offset" in grid.fields[field].keys():
@@ -222,7 +219,7 @@ def write_grid_mdv(filename, grid, mdv_field_names=None,
         level = [0] * 122
         for iz in range(nz):
             typ[iz] = d["vlevel_type"]
-            level[iz] = grid.regular_z["data"][iz] / 1000.
+            level[iz] = grid.z["data"][iz] / 1000.
         l["type"] = typ
         l["level"] = level
 
@@ -358,17 +355,17 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
     elif mdv.field_headers[0]["vlevel_type"] == 7:  # VERT_TYPE_THETA
         zunits = 'kelvin'
 
-    regular_x = get_metadata('regular_x')
-    regular_x['data'] = np.linspace(x_start, x_start + x_step * (nx-1), nx)
-    regular_x['units'] = xunits
+    x = get_metadata('x')
+    x['data'] = np.linspace(x_start, x_start + x_step * (nx-1), nx)
+    x['units'] = xunits
 
-    regular_y = get_metadata('regular_y')
-    regular_y['data'] = np.linspace(y_start, y_start + y_step * (ny-1), ny)
-    regular_y['units'] = yunits
+    y = get_metadata('y')
+    y['data'] = np.linspace(y_start, y_start + y_step * (ny-1), ny)
+    y['units'] = yunits
 
-    regular_z = get_metadata('regular_z')
-    regular_z['data'] = np.array(z_line, dtype='float64')
-    regular_z['units'] = zunits
+    z = get_metadata('z')
+    z['data'] = np.array(z_line, dtype='float64')
+    z['units'] = zunits
 
     # metadata
     metadata = filemetadata('metadata')
@@ -397,8 +394,7 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
     if not delay_field_loading:
         mdv.close()
     return Grid(time, fields, metadata,
-                origin_latitude, origin_longitude, origin_altitude,
-                regular_x, regular_y, regular_z)
+                origin_latitude, origin_longitude, origin_altitude, x, y, z)
 
 
 # This function may be helpful in other cases and could be moved in common

--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -33,16 +33,10 @@ def write_grid_mdv(filename, grid, mdv_field_names=None,
     Write grid object to MDV file.
 
     Create a MDV file containing data from the provided grid instance.
-    The MDV file will contain parameters from the following keys if they are
-    contained in grid.metadata:
 
-        * instrument_name
-        * source
-        * radar_0_lon
-        * radar_0_lat
-        * radar_0_alt
-
-    If any of these keys are not present a default or sentinel value
+    The MDV file will contain parameters from the 'source' key if contained
+    in grid.metadata.  If this key or parameters related to the radar location
+    and name are not present in the grid a default or sentinel value.
     will be written in the MDV file in the place of the parameter.
 
     Grid fields will be saved in float32 unless the `_Write_as_dtype` key is

--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -325,28 +325,14 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
         'standard_name': 'time',
         'long_name': 'Time in seconds since volume start'}
 
-    time_start = {
-        'data': np.array([date2num(mdv.times['time_begin'], units)]),
-        'units': units,
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds of volume start'}
-
-    time_end = {
-        'data': np.array([date2num(mdv.times['time_end'], units)]),
-        'units': units,
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds of volume end'}
-
-    altorigin = {
+    origin_altitude = {
         'data': np.array([mdv.master_header["sensor_alt"] * 1000.],
                          dtype='float64'),
         'long_name': 'Altitude at grid origin',
         'units': 'm',
         'standard_name': 'altitude', }
 
-    latorigin = {
+    origin_latitude = {
         'data': np.array([mdv.master_header["sensor_lat"]],
                          dtype='float64'),
         'long_name': 'Latitude at grid origin',
@@ -355,7 +341,7 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
         'valid_min': -90.,
         'valid_max': 90., }
 
-    lonorigin = {
+    origin_longitude = {
         'data': np.array([mdv.master_header["sensor_lon"]],
                          dtype='float64'),
         'long_name': 'Longitude at grid origin',
@@ -399,32 +385,24 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
     elif mdv.field_headers[0]["vlevel_type"] == 7:  # VERT_TYPE_THETA
         zunits = 'kelvin'
 
-    xaxis = {'data':  np.linspace(x_start, x_start + x_step * (nx-1), nx),
-             'long_name': 'X-coordinate in Cartesian system',
-             'axis': 'X',
-             'units': xunits}
+    regular_x = {
+        'data':  np.linspace(x_start, x_start + x_step * (nx-1), nx),
+        'long_name': 'X-coordinate in Cartesian system',
+        'axis': 'X',
+        'units': xunits}
 
-    yaxis = {'data': np.linspace(y_start, y_start + y_step * (ny-1), ny),
-             'long_name': 'Y-coordinate in Cartesian system',
-             'axis': 'Y',
-             'units': yunits}
+    regular_y = {
+        'data': np.linspace(y_start, y_start + y_step * (ny-1), ny),
+        'long_name': 'Y-coordinate in Cartesian system',
+        'axis': 'Y',
+        'units': yunits}
 
-    zaxis = {'data': np.array(z_line, dtype='float64'),
-             'long_name': 'Z-coordinate in Cartesian system',
-             'axis': 'Z',
-             'units': zunits,
-             'positive': 'up'}
-
-    # axes dictionary
-    axes = {'time': time,
-            'time_start': time_start,
-            'time_end': time_end,
-            'z_disp': zaxis,
-            'y_disp': yaxis,
-            'x_disp': xaxis,
-            'alt': altorigin,
-            'lat': latorigin,
-            'lon': lonorigin}
+    regular_z = {
+        'data': np.array(z_line, dtype='float64'),
+        'long_name': 'Z-coordinate in Cartesian system',
+        'axis': 'Z',
+        'units': zunits,
+        'positive': 'up'}
 
     # metadata
     metadata = filemetadata('metadata')
@@ -452,7 +430,9 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
 
     if not delay_field_loading:
         mdv.close()
-    return Grid(fields, axes, metadata)
+    return Grid(time, fields, metadata,
+                origin_latitude, origin_longitude, origin_altitude,
+                regular_x, regular_y, regular_z)
 
 
 # This function may be helpful in other cases and could be moved in common

--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -20,7 +20,7 @@ import warnings
 from netCDF4 import num2date, date2num
 import numpy as np
 
-from ..config import FileMetadata, get_fillvalue
+from ..config import FileMetadata, get_fillvalue, get_metadata
 from ..core.grid import Grid
 from .common import make_time_unit_str, _test_arguments, prepare_for_read
 from ..lazydict import LazyLoadDict
@@ -318,37 +318,22 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
 
     # time dictionaries
     units = make_time_unit_str(mdv.times['time_begin'])
-    time = {
-        'data': np.array([date2num(mdv.times['time_centroid'], units)]),
-        'units': units,
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds since volume start'}
+    time = get_metadata('grid_time')
+    time['data'] = np.array([date2num(mdv.times['time_centroid'], units)])
+    time['units'] = units
 
-    origin_altitude = {
-        'data': np.array([mdv.master_header["sensor_alt"] * 1000.],
-                         dtype='float64'),
-        'long_name': 'Altitude at grid origin',
-        'units': 'm',
-        'standard_name': 'altitude', }
+    # origin dictionaries
+    origin_altitude = get_metadata('origin_altitude')
+    origin_altitude['data'] = np.array(
+        [mdv.master_header["sensor_alt"] * 1000.], dtype='float64')
 
-    origin_latitude = {
-        'data': np.array([mdv.master_header["sensor_lat"]],
-                         dtype='float64'),
-        'long_name': 'Latitude at grid origin',
-        'units': 'degree_N',
-        'standard_name': 'latitude',
-        'valid_min': -90.,
-        'valid_max': 90., }
+    origin_latitude = get_metadata('origin_latitude')
+    origin_latitude['data'] = np.array(
+        [mdv.master_header["sensor_lat"]], dtype='float64')
 
-    origin_longitude = {
-        'data': np.array([mdv.master_header["sensor_lon"]],
-                         dtype='float64'),
-        'long_name': 'Longitude at grid origin',
-        'units': 'degree_E',
-        'standard_name': 'longitude',
-        'valid_min': -180.,
-        'valid_max': 180., }
+    origin_longitude = get_metadata('origin_longitude')
+    origin_longitude['data'] = np.array(
+        [mdv.master_header["sensor_lon"]], dtype='float64')
 
     # grid coordinate dictionaries
     nz = mdv.master_header["max_nz"]
@@ -385,24 +370,17 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
     elif mdv.field_headers[0]["vlevel_type"] == 7:  # VERT_TYPE_THETA
         zunits = 'kelvin'
 
-    regular_x = {
-        'data':  np.linspace(x_start, x_start + x_step * (nx-1), nx),
-        'long_name': 'X-coordinate in Cartesian system',
-        'axis': 'X',
-        'units': xunits}
+    regular_x = get_metadata('regular_x')
+    regular_x['data'] = np.linspace(x_start, x_start + x_step * (nx-1), nx)
+    regular_x['units'] = xunits
 
-    regular_y = {
-        'data': np.linspace(y_start, y_start + y_step * (ny-1), ny),
-        'long_name': 'Y-coordinate in Cartesian system',
-        'axis': 'Y',
-        'units': yunits}
+    regular_y = get_metadata('regular_y')
+    regular_y['data'] = np.linspace(y_start, y_start + y_step * (ny-1), ny)
+    regular_y['units'] = yunits
 
-    regular_z = {
-        'data': np.array(z_line, dtype='float64'),
-        'long_name': 'Z-coordinate in Cartesian system',
-        'axis': 'Z',
-        'units': zunits,
-        'positive': 'up'}
+    regular_z = get_metadata('regular_z')
+    regular_z['data'] = np.array(z_line, dtype='float64')
+    regular_z['units'] = zunits
 
     # metadata
     metadata = filemetadata('metadata')

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 import netCDF4
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_warns
 
 import pyart
 
@@ -13,6 +13,7 @@ def test_grid_write_read():
     # write/read roundtrip and comparing the two Grid objects
     grid1 = pyart.testing.make_target_grid()
     grid1.projection['comment'] = 'This is a comment'
+    grid1.metadata['comment'] = 'This is another comment'
 
     with pyart.testing.InTemporaryDirectory():
         tmpfile = 'tmp_grid.nc'
@@ -94,3 +95,58 @@ def test_grid_write_point_vars():
         assert 'point_longitude' in dset.variables
         assert 'point_altitude' in dset.variables
         dset.close()
+
+
+def test_grid_write_arm_time_vars():
+    grid1 = pyart.testing.make_target_grid()
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1, arm_time_variables=True)
+        dset = netCDF4.Dataset(tmpfile, 'r')
+        assert 'base_time' in dset.variables
+        assert 'time_offset' in dset.variables
+        dset.close()
+
+
+def test_exclude_fields_argument():
+    grid1 = pyart.testing.make_target_grid()
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1)
+        grid2 = pyart.io.read_grid(tmpfile, exclude_fields=['reflectivity'])
+        assert 'reflectivity' in grid1.fields
+        assert 'reflectivity' not in grid2.fields
+
+
+def test_radar_attrs_none():
+    grid1 = pyart.testing.make_target_grid()
+    grid1.radar_latitude = None
+    grid1.radar_longitude = None
+    grid1.radar_altitude = None
+    grid1.radar_time = None
+    grid1.radar_name = None
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1)
+        grid2 = pyart.io.read_grid(tmpfile)
+        assert grid2.radar_latitude is None
+        assert grid2.radar_longitude is None
+        assert grid2.radar_altitude is None
+        assert grid2.radar_time is None
+        assert grid2.radar_name is None
+
+
+def test_bad_shaped_field():
+    grid1 = pyart.testing.make_target_grid()
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1)
+
+        # add a scalar variable named bad_field
+        dset = netCDF4.Dataset(tmpfile, 'a')
+        dset.createVariable('bad_field', 'f4', ())
+        dset.close()
+
+        # warning should be raised about incorrect shape of bad_field var
+        assert_warns(UserWarning, pyart.io.read_grid, tmpfile)

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -6,6 +6,7 @@ import netCDF4
 from numpy.testing import assert_almost_equal, assert_warns
 
 import pyart
+from pyart.io.common import stringarray_to_chararray
 
 
 def test_grid_write_read():
@@ -71,8 +72,16 @@ def _check_dicts_similar(dic1, dic2):
     for k, v in dic1.items():
         print("Checking key:", k)
         if k == 'data':
-            if v.dtype.char == 'S':
-                assert ''.join(*v) == ''.join(*dic2[k])
+            if v.dtype.char == 'S' or v.dtype.char == 'U':
+                s1 = v.astype('S')
+                if s1.ndim == 1:
+                    s1 = stringarray_to_chararray(s1)
+
+                s2 = dic2[k].astype('S')
+                if s1.ndim == 1:
+                    s2 = stringarray_to_chararray(s2)
+
+                assert b''.join(*s1) == b''.join(*s2)
             else:
                 assert_almost_equal(v, dic2[k])
         else:

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -1,0 +1,77 @@
+""" Unit Tests for Py-ART's io/grid_io.py module. """
+
+from __future__ import print_function
+
+from numpy.testing import assert_almost_equal
+
+import pyart
+
+
+def test_grid_write_read():
+    # test the read_grid and write_grid function by performing a
+    # write/read roundtrip and comparing the two Grid objects
+    grid1 = pyart.testing.make_target_grid()
+    grid1.projection['comment'] = 'This is a comment'
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        grid1.write(tmpfile)
+        grid2 = pyart.io.read_grid(tmpfile)
+
+        # check fields
+        for field in grid1.fields.keys():
+            _check_dicts_similar(grid1.fields[field], grid2.fields[field])
+
+        # check attributes
+        _check_attrs_similar(grid1, grid2, 'metadata')
+
+        _check_attrs_similar(grid1, grid2, 'time')
+
+        _check_attrs_similar(grid1, grid2, 'origin_latitude')
+        _check_attrs_similar(grid1, grid2, 'origin_longitude')
+        _check_attrs_similar(grid1, grid2, 'origin_altitude')
+
+        _check_attrs_similar(grid1, grid2, 'regular_x')
+        _check_attrs_similar(grid1, grid2, 'regular_y')
+        _check_attrs_similar(grid1, grid2, 'regular_z')
+
+        _check_attrs_similar(grid1, grid2, 'point_x')
+        _check_attrs_similar(grid1, grid2, 'point_y')
+        _check_attrs_similar(grid1, grid2, 'point_z')
+
+        _check_attrs_similar(grid1, grid2, 'projection')
+        assert grid1.projection['_include_lon_0_lat_0'] is True
+
+        _check_attrs_similar(grid1, grid2, 'point_latitude')
+        _check_attrs_similar(grid1, grid2, 'point_longitude')
+        _check_attrs_similar(grid1, grid2, 'point_altitude')
+
+        assert grid1.nx == grid2.nx
+        assert grid1.ny == grid2.ny
+        assert grid1.nz == grid2.nz
+
+        _check_attrs_similar(grid1, grid2, 'radar_latitude')
+        _check_attrs_similar(grid1, grid2, 'radar_longitude')
+        _check_attrs_similar(grid1, grid2, 'radar_altitude')
+        _check_attrs_similar(grid1, grid2, 'radar_time')
+        _check_attrs_similar(grid1, grid2, 'radar_name')
+        assert grid1.nradar == grid2.nradar
+
+
+def _check_attrs_similar(grid1, grid2, attr):
+    print("Checking attribute:", attr)
+    dic1 = getattr(grid1, attr)
+    dic2 = getattr(grid2, attr)
+    _check_dicts_similar(dic1, dic2)
+
+
+def _check_dicts_similar(dic1, dic2):
+    for k, v in dic1.items():
+        print("Checking key:", k)
+        if k == 'data':
+            if v.dtype.char == 'S':
+                assert ''.join(*v) == ''.join(*dic2[k])
+            else:
+                assert_almost_equal(v, dic2[k])
+        else:
+            assert dic2[k] == v

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -34,9 +34,9 @@ def test_grid_write_read():
         _check_attrs_similar(grid1, grid2, 'origin_longitude')
         _check_attrs_similar(grid1, grid2, 'origin_altitude')
 
-        _check_attrs_similar(grid1, grid2, 'regular_x')
-        _check_attrs_similar(grid1, grid2, 'regular_y')
-        _check_attrs_similar(grid1, grid2, 'regular_z')
+        _check_attrs_similar(grid1, grid2, 'x')
+        _check_attrs_similar(grid1, grid2, 'y')
+        _check_attrs_similar(grid1, grid2, 'z')
 
         _check_attrs_similar(grid1, grid2, 'point_x')
         _check_attrs_similar(grid1, grid2, 'point_y')

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import netCDF4
 from numpy.testing import assert_almost_equal
 
 import pyart
@@ -15,7 +16,7 @@ def test_grid_write_read():
 
     with pyart.testing.InTemporaryDirectory():
         tmpfile = 'tmp_grid.nc'
-        grid1.write(tmpfile)
+        pyart.io.write_grid(tmpfile, grid1)
         grid2 = pyart.io.read_grid(tmpfile)
 
         # check fields
@@ -75,3 +76,21 @@ def _check_dicts_similar(dic1, dic2):
                 assert_almost_equal(v, dic2[k])
         else:
             assert dic2[k] == v
+
+
+def test_grid_write_point_vars():
+    grid1 = pyart.testing.make_target_grid()
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1, write_point_x_y_z=True,
+                            write_point_lon_lat_alt=True)
+        dset = netCDF4.Dataset(tmpfile, 'r')
+
+        assert 'point_x' in dset.variables
+        assert 'point_y' in dset.variables
+        assert 'point_z' in dset.variables
+        assert 'point_latitude' in dset.variables
+        assert 'point_longitude' in dset.variables
+        assert 'point_altitude' in dset.variables
+        dset.close()

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -199,11 +199,9 @@ def test_unknown_projection():
     grid_shape = (2, 3, 4)
     grid_limits = ((0, 500), (-400000, 400000), (-300000, 300000))
     grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+    grid.projection['proj'] = 'null'
 
     with pyart.testing.InTemporaryDirectory():
-
-        # standard projection
-        grid.projection['proj'] = 'null'
         tmpfile = 'tmp_grid.nc'
         assert_warns(UserWarning, pyart.io.write_grid, tmpfile, grid,
                      write_proj_coord_sys=True)

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -26,6 +26,8 @@ def test_grid_write_read():
             _check_dicts_similar(grid1.fields[field], grid2.fields[field])
 
         # check attributes
+        assert 'Conventions' in grid2.metadata
+        grid2.metadata.pop('Conventions')
         _check_attrs_similar(grid1, grid2, 'metadata')
 
         _check_attrs_similar(grid1, grid2, 'time')

--- a/pyart/io/tests/test_mdv_grid.py
+++ b/pyart/io/tests/test_mdv_grid.py
@@ -29,7 +29,7 @@ class Mdv_grid_Tests(object):
         self.check_target_reflectivity_field(grid)
         attrs_to_check = [
             'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
-            'regular_x', 'regular_y', 'regular_z']
+            'x', 'y', 'z']
         for attr in attrs_to_check:
             self.check_attr_dics(grid, original_grid, attr)
 
@@ -77,7 +77,7 @@ class Mdv_grid_Tests(object):
         self.check_target_reflectivity_field(grid)
         attrs_to_check = [
             'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
-            'regular_x', 'regular_y', 'regular_z']
+            'x', 'y', 'z']
         for attr in attrs_to_check:
             self.check_attr_dics(grid, original_grid, attr)
 
@@ -98,7 +98,7 @@ class Mdv_grid_Tests(object):
         self.check_target_reflectivity_field(grid)
         attrs_to_check = [
             'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
-            'regular_x', 'regular_y', 'regular_z']
+            'x', 'y', 'z']
         for attr in attrs_to_check:
             self.check_attr_dics(grid, original_grid, attr)
         assert grid.metadata['instrument_name'] == 'testtesttest'
@@ -135,8 +135,8 @@ class Mdv_grid_Tests(object):
             UserWarning, pyart.io.write_grid_mdv, tmpfile, grid)
         tmpfile.seek(0)
         rgrid = pyart.io.read_grid_mdv(tmpfile)
-        assert len(grid.regular_z['data']) == 123
-        assert len(rgrid.regular_z['data']) == 122
+        assert len(grid.z['data']) == 123
+        assert len(rgrid.z['data']) == 122
 
     def test_write_types(self):
         # Write various data types
@@ -220,7 +220,7 @@ def test_mdv_degree_grid():
     assert np.ma.is_masked(fdata[0, 0, 0])
     assert_almost_equal(fdata[0, 130, 2536], 20.0, 1)
 
-    assert grid.regular_x['units'] == 'degree_E'
-    assert_almost_equal(grid.regular_x['data'][0], -129.99, 2)
-    assert grid.regular_y['units'] == 'degree_N'
-    assert_almost_equal(grid.regular_y['data'][0], 20.01, 2)
+    assert grid.x['units'] == 'degree_E'
+    assert_almost_equal(grid.x['data'][0], -129.99, 2)
+    assert grid.y['units'] == 'degree_N'
+    assert_almost_equal(grid.y['data'][0], 20.01, 2)

--- a/pyart/io/tests/test_mdv_grid.py
+++ b/pyart/io/tests/test_mdv_grid.py
@@ -27,9 +27,11 @@ class Mdv_grid_Tests(object):
 
         # check the contents of the grid which was read
         self.check_target_reflectivity_field(grid)
-        keys_to_check = grid.axes.keys()
-        for key in keys_to_check:
-            self.check_axes_dic(grid.axes, original_grid.axes, key)
+        attrs_to_check = [
+            'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
+            'regular_x', 'regular_y', 'regular_z']
+        for attr in attrs_to_check:
+            self.check_attr_dics(grid, original_grid, attr)
 
     @staticmethod
     def check_target_reflectivity_field(grid):
@@ -51,14 +53,16 @@ class Mdv_grid_Tests(object):
         assert np.abs(fdata[1, 160, 130] - 35.) <= 0.01
 
     @staticmethod
-    def check_axes_dic(axes, axes2, key):
-        print("Checking:", key)
+    def check_attr_dics(grid1, grid2, attr_name):
+        print("Checking:", attr_name)
+        dic1 = getattr(grid1, attr_name)
+        dic2 = getattr(grid2, attr_name)
         # check that the data and units keys are similar
-        assert np.allclose(axes[key]['data'], axes2[key]['data'])
-        assert axes[key]['data'].shape == axes2[key]['data'].shape
-        assert axes[key]['data'].dtype == axes2[key]['data'].dtype
-        if 'units' in axes[key]:
-            assert axes[key]['units'] == axes2[key]['units']
+        assert np.allclose(dic1['data'], dic2['data'])
+        assert dic1['data'].shape == dic2['data'].shape
+        assert dic1['data'].dtype == dic2['data'].dtype
+        if 'units' in dic1:
+            assert dic1['units'] == dic2['units']
 
     def test_write_read_target_delay(self):
         # write and read in the target grid with delayed field loading
@@ -71,15 +75,15 @@ class Mdv_grid_Tests(object):
 
         # check the contents of the grid which was read
         self.check_target_reflectivity_field(grid)
-        keys_to_check = grid.axes.keys()
-        for key in keys_to_check:
-            self.check_axes_dic(grid.axes, original_grid.axes, key)
+        attrs_to_check = [
+            'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
+            'regular_x', 'regular_y', 'regular_z']
+        for attr in attrs_to_check:
+            self.check_attr_dics(grid, original_grid, attr)
 
     def test_write_read_target_modified(self):
         # write and read in target grid with modifications
         original_grid = pyart.testing.make_target_grid()
-        del original_grid.axes['time_start']
-        del original_grid.axes['time_end']
         original_grid.metadata['radar_0_lon'] = -98.1
         original_grid.metadata['radar_0_lat'] = 36.74
         original_grid.metadata['radar_0_alt'] = 300.
@@ -92,10 +96,11 @@ class Mdv_grid_Tests(object):
 
         # check the contents of the grid which was read
         self.check_target_reflectivity_field(grid)
-        keys_to_check = ['time', 'x_disp', 'y_disp', 'z_disp', 'lat', 'lon',
-                         'alt']
-        for key in keys_to_check:
-            self.check_axes_dic(grid.axes, original_grid.axes, key)
+        attrs_to_check = [
+            'time', 'origin_latitude', 'origin_longitude', 'origin_altitude',
+            'regular_x', 'regular_y', 'regular_z']
+        for attr in attrs_to_check:
+            self.check_attr_dics(grid, original_grid, attr)
         assert grid.metadata['instrument_name'] == 'testtesttest'
 
     def test_read_write_mask(self):
@@ -130,8 +135,8 @@ class Mdv_grid_Tests(object):
             UserWarning, pyart.io.write_grid_mdv, tmpfile, grid)
         tmpfile.seek(0)
         rgrid = pyart.io.read_grid_mdv(tmpfile)
-        assert len(grid.axes['z_disp']['data']) == 123
-        assert len(rgrid.axes['z_disp']['data']) == 122
+        assert len(grid.regular_z['data']) == 123
+        assert len(rgrid.regular_z['data']) == 122
 
     def test_write_types(self):
         # Write various data types
@@ -215,7 +220,7 @@ def test_mdv_degree_grid():
     assert np.ma.is_masked(fdata[0, 0, 0])
     assert_almost_equal(fdata[0, 130, 2536], 20.0, 1)
 
-    assert grid.axes['x_disp']['units'] == 'degree_E'
-    assert_almost_equal(grid.axes['x_disp']['data'][0], -129.99, 2)
-    assert grid.axes['y_disp']['units'] == 'degree_N'
-    assert_almost_equal(grid.axes['y_disp']['data'][0], 20.01, 2)
+    assert grid.regular_x['units'] == 'degree_E'
+    assert_almost_equal(grid.regular_x['data'][0], -129.99, 2)
+    assert grid.regular_y['units'] == 'degree_N'
+    assert_almost_equal(grid.regular_y['data'][0], 20.01, 2)

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -115,39 +115,28 @@ def grid_from_radars(radars, grid_shape, grid_limits,
         'standard_name': first_radar.time['standard_name'],
         'long_name': 'Time in seconds since volume start'}
 
-    time_start = {
-        'data': np.array([first_radar.time['data'][0]]),
-        'units': first_radar.time['units'],
-        'calendar': first_radar.time['calendar'],
-        'standard_name': first_radar.time['standard_name'],
-        'long_name': 'Time in seconds of volume start'}
-
-    time_end = {
-        'data': np.array([first_radar.time['data'][-1]]),
-        'units': first_radar.time['units'],
-        'calendar': first_radar.time['calendar'],
-        'standard_name': first_radar.time['standard_name'],
-        'long_name': 'Time in seconds of volume end'}
-
     # grid coordinate dictionaries
     nz, ny, nx = grid_shape
     (z0, z1), (y0, y1), (x0, x1) = grid_limits
 
-    xaxis = {'data':  np.linspace(x0, x1, nx),
-             'long_name': 'X-coordinate in Cartesian system',
-             'axis': 'X',
-             'units': 'm'}
+    regular_x = {
+        'data':  np.linspace(x0, x1, nx),
+        'long_name': 'X-coordinate in Cartesian system',
+        'axis': 'X',
+        'units': 'm'}
 
-    yaxis = {'data': np.linspace(y0, y1, ny),
-             'long_name': 'Y-coordinate in Cartesian system',
-             'axis': 'Y',
-             'units': 'm'}
+    regular_y = {
+        'data': np.linspace(y0, y1, ny),
+        'long_name': 'Y-coordinate in Cartesian system',
+        'axis': 'Y',
+        'units': 'm'}
 
-    zaxis = {'data': np.linspace(z0, z1, nz),
-             'long_name': 'Z-coordinate in Cartesian system',
-             'axis': 'Z',
-             'units': 'm',
-             'positive': 'up'}
+    regular_z = {
+        'data': np.linspace(z0, z1, nz),
+        'long_name': 'Z-coordinate in Cartesian system',
+        'axis': 'Z',
+        'units': 'm',
+        'positive': 'up'}
 
     # grid origin location dictionaries
     if 'grid_origin' in kwargs:
@@ -162,38 +151,30 @@ def grid_from_radars(radars, grid_shape, grid_limits,
     else:
         alt = first_radar.altitude['data']
 
-    altorigin = {'data': alt,
-                 'long_name': 'Altitude at grid origin',
-                 'units': 'm',
-                 'standard_name': 'altitude',
-                 }
+    origin_altitude = {
+        'data': alt,
+        'long_name': 'Altitude at grid origin',
+        'units': 'm',
+        'standard_name': 'altitude',
+    }
 
-    latorigin = {'data': lat,
-                 'long_name': 'Latitude at grid origin',
-                 'units': 'degree_N',
-                 'standard_name': 'latitude',
-                 'valid_min': -90.,
-                 'valid_max': 90.
-                 }
+    origin_latitude = {
+        'data': lat,
+        'long_name': 'Latitude at grid origin',
+        'units': 'degree_N',
+        'standard_name': 'latitude',
+        'valid_min': -90.,
+        'valid_max': 90.
+    }
 
-    lonorigin = {'data': lon,
-                 'long_name': 'Longitude at grid origin',
-                 'units': 'degree_E',
-                 'standard_name': 'longitude',
-                 'valid_min': -180.,
-                 'valid_max': 180.
-                 }
-
-    # axes dictionary
-    axes = {'time': time,
-            'time_start': time_start,
-            'time_end': time_end,
-            'z_disp': zaxis,
-            'y_disp': yaxis,
-            'x_disp': xaxis,
-            'alt': altorigin,
-            'lat': latorigin,
-            'lon': lonorigin}
+    origin_longitude = {
+        'data': lon,
+        'long_name': 'Longitude at grid origin',
+        'units': 'degree_E',
+        'standard_name': 'longitude',
+        'valid_min': -180.,
+        'valid_max': 180.
+    }
 
     # metadata dictionary
     metadata = dict(first_radar.metadata)
@@ -211,7 +192,9 @@ def grid_from_radars(radars, grid_shape, grid_limits,
             i_name = ''
         metadata['radar_{0:d}_instrument_name'.format(i)] = i_name
 
-    return Grid(fields, axes, metadata)
+    return Grid(time, fields, metadata,
+                origin_latitude, origin_longitude, origin_altitude,
+                regular_x, regular_y, regular_z)
 
 
 class NNLocator:

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -119,14 +119,14 @@ def grid_from_radars(radars, grid_shape, grid_limits,
     nz, ny, nx = grid_shape
     (z0, z1), (y0, y1), (x0, x1) = grid_limits
 
-    regular_x = get_metadata('regular_x')
-    regular_x['data'] = np.linspace(x0, x1, nx)
+    x = get_metadata('x')
+    x['data'] = np.linspace(x0, x1, nx)
 
-    regular_y = get_metadata('regular_y')
-    regular_y['data'] = np.linspace(y0, y1, ny)
+    y = get_metadata('y')
+    y['data'] = np.linspace(y0, y1, ny)
 
-    regular_z = get_metadata('regular_z')
-    regular_z['data'] = np.linspace(z0, z1, nz)
+    z = get_metadata('z')
+    z['data'] = np.linspace(z0, z1, nz)
 
     # grid origin location dictionaries
     origin_latitude = get_metadata('origin_latitude')
@@ -173,8 +173,7 @@ def grid_from_radars(radars, grid_shape, grid_limits,
 
     return Grid(
         time, fields, metadata,
-        origin_latitude, origin_longitude, origin_altitude,
-        regular_x, regular_y, regular_z,
+        origin_latitude, origin_longitude, origin_altitude, x, y, z,
         radar_latitude=radar_latitude, radar_longitude=radar_longitude,
         radar_altitude=radar_altitude, radar_name=radar_name,
         radar_time=radar_time)

--- a/pyart/map/tests/test_gates_to_grid.py
+++ b/pyart/map/tests/test_gates_to_grid.py
@@ -138,9 +138,9 @@ def test_grid_from_radars_gates_to_grid():
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
-    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
-    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
+    assert_almost_equal(grid.x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.z['data'], np.linspace(-400, 400, 3))
 
 
 def test_map_to_grid_errors():
@@ -173,9 +173,9 @@ def test_grid_from_radars():
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
-    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
-    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
+    assert_almost_equal(grid.x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.z['data'], np.linspace(-400, 400, 3))
 
 
 def test_grid_from_radars_grid_origin():

--- a/pyart/map/tests/test_gates_to_grid.py
+++ b/pyart/map/tests/test_gates_to_grid.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_raises
+from numpy.testing import assert_almost_equal, assert_raises
 
 import pyart
 
@@ -42,7 +42,7 @@ def test_map_to_grid_non_tuple():
     grids = pyart.map.map_gates_to_grid(radar,
                                         **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_default():
@@ -50,7 +50,7 @@ def test_map_to_grid_default():
     grids = pyart.map.map_gates_to_grid((radar,),
                                         **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_cressman():
@@ -59,7 +59,7 @@ def test_map_to_grid_cressman():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='constant', constant_roi=30., weighting_function='CRESSMAN')
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_constant_roi():
@@ -68,7 +68,7 @@ def test_map_to_grid_constant_roi():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='constant', constant_roi=30.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_dist_roi():
@@ -77,7 +77,7 @@ def test_map_to_grid_dist_roi():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='dist', z_factor=0, xy_factor=0, min_radius=30.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_dist_beam_roi():
@@ -89,7 +89,7 @@ def test_map_to_grid_dist_beam_roi():
         fields=['reflectivity'],
         min_radius=30, bsp=0., h_factor=0.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_default_two_radars():
@@ -97,7 +97,7 @@ def test_map_to_grid_default_two_radars():
     grids = pyart.map.map_gates_to_grid((radar, radar),
                                         **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_masked_refl_field():
@@ -112,7 +112,7 @@ def test_map_to_grid_masked_refl_field():
     grids = pyart.map.map_gates_to_grid((radar,),
                                         **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_tiny_grid():
@@ -133,17 +133,14 @@ def test_grid_from_radars_gates_to_grid():
 
     # check field data
     center_slice = grid.fields['reflectivity']['data'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_array_equal(grid.axes['x_disp']['data'],
-                       np.linspace(-900, 900, 10))
-    assert_array_equal(grid.axes['y_disp']['data'],
-                       np.linspace(-900, 900, 9).astype('float64'))
-    assert_array_equal(grid.axes['z_disp']['data'],
-                       np.linspace(-400, 400, 3).astype('float64'))
+    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
 
 
 def test_map_to_grid_errors():
@@ -171,17 +168,14 @@ def test_grid_from_radars():
 
     # check field data
     center_slice = grid.fields['reflectivity']['data'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
 
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_array_equal(grid.axes['x_disp']['data'],
-                       np.linspace(-900, 900, 10))
-    assert_array_equal(grid.axes['y_disp']['data'],
-                       np.linspace(-900, 900, 9).astype('float64'))
-    assert_array_equal(grid.axes['z_disp']['data'],
-                       np.linspace(-400, 400, 3).astype('float64'))
+    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
 
 
 def test_grid_from_radars_grid_origin():
@@ -189,10 +183,8 @@ def test_grid_from_radars_grid_origin():
     radar.metadata.pop('instrument_name')
     grid = pyart.map.grid_from_radars((radar,), grid_origin=(36.4, -97.6),
                                       **COMMON_MAP_TO_GRID_ARGS)
-    print(round(grid.axes['lat']['data'][0], 2))
-    print(round(grid.axes['lon']['data'][0], 2))
-    assert round(grid.axes['lat']['data'][0], 2) == 36.4
-    assert round(grid.axes['lon']['data'][0], 2) == -97.6
+    assert_almost_equal(grid.origin_latitude['data'][0], 36.4, 1)
+    assert_almost_equal(grid.origin_longitude['data'][0], -97.6, 1)
 
 
 def test_example_roi_funcs():

--- a/pyart/map/tests/test_grid_mapper.py
+++ b/pyart/map/tests/test_grid_mapper.py
@@ -3,8 +3,7 @@
 from __future__ import print_function
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_raises
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_raises
 
 import pyart
 
@@ -26,33 +25,29 @@ def test_map_to_grid_filter():
     # without filtering bad gates leaks through
     gatefilter = pyart.filters.GateFilter(radar)
     grids = pyart.map.map_to_grid(
-        (radar,), gatefilters=(gatefilter, ),
-        **COMMON_MAP_TO_GRID_ARGS)
+        (radar,), gatefilters=(gatefilter, ), **COMMON_MAP_TO_GRID_ARGS)
     assert grids['reflectivity'].max() > 41.0
 
     # with filtering bad gates is supressed
     gatefilter = pyart.filters.GateFilter(radar)
     gatefilter.exclude_above('reflectivity', 41.0)
     grids = pyart.map.map_to_grid(
-        (radar,), gatefilters=(gatefilter, ),
-        **COMMON_MAP_TO_GRID_ARGS)
+        (radar,), gatefilters=(gatefilter, ), **COMMON_MAP_TO_GRID_ARGS)
     assert grids['reflectivity'].max() < 41.0
 
 
 def test_map_to_grid_non_tuple():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid(radar,
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid(radar, **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_default():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid((radar,),
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid((radar,), **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_cressman():
@@ -61,7 +56,7 @@ def test_map_to_grid_cressman():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='constant', constant_roi=30., weighting_function='CRESSMAN')
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_constant_roi():
@@ -70,7 +65,7 @@ def test_map_to_grid_constant_roi():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='constant', constant_roi=30.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_dist_roi():
@@ -79,7 +74,7 @@ def test_map_to_grid_dist_roi():
         (radar,), (3, 9, 10), ((-400.0, 400.0), (-900.0, 900.0), (-900, 900)),
         roi_func='dist', z_factor=0, xy_factor=0, min_radius=30.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_dist_beam_roi():
@@ -91,15 +86,14 @@ def test_map_to_grid_dist_beam_roi():
         fields=['reflectivity'],
         min_radius=30, bsp=0., h_factor=0.)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_default_two_radars():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid((radar, radar),
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid((radar, radar), **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_masked_refl_field():
@@ -111,34 +105,33 @@ def test_map_to_grid_masked_refl_field():
     fdata.mask[0, -1] = True
     radar.fields['reflectivity']['data'] = fdata
 
-    grids = pyart.map.map_to_grid((radar,),
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid((radar,), **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_no_copy():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid((radar,), copy_field_data=False,
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid(
+        (radar,), copy_field_data=False, **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_no_copy_two_radars():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid((radar, radar), copy_field_data=False,
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid(
+        (radar, radar), copy_field_data=False, **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_balltree():
     radar = pyart.testing.make_target_radar()
-    grids = pyart.map.map_to_grid((radar,), algorithm='ball_tree',
-                                  **COMMON_MAP_TO_GRID_ARGS)
+    grids = pyart.map.map_to_grid(
+        (radar,), algorithm='ball_tree', **COMMON_MAP_TO_GRID_ARGS)
     center_slice = grids['reflectivity'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
 def test_map_to_grid_tiny_grid():
@@ -176,17 +169,14 @@ def test_grid_from_radars():
 
     # check field data
     center_slice = grid.fields['reflectivity']['data'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_array_equal(grid.axes['x_disp']['data'],
-                       np.linspace(-900, 900, 10))
-    assert_array_equal(grid.axes['y_disp']['data'],
-                       np.linspace(-900, 900, 9).astype('float64'))
-    assert_array_equal(grid.axes['z_disp']['data'],
-                       np.linspace(-400, 400, 3).astype('float64'))
+    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
 
     # check that grid.radar_ attributes set correctly
     assert isinstance(grid.radar_latitude, dict)
@@ -225,17 +215,14 @@ def test_grid_from_radars_non_tuple():
 
     # check field data
     center_slice = grid.fields['reflectivity']['data'][1, 4, :]
-    assert_array_equal(np.round(center_slice), EXPECTED_CENTER_SLICE)
+    assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_array_equal(grid.axes['x_disp']['data'],
-                       np.linspace(-900, 900, 10))
-    assert_array_equal(grid.axes['y_disp']['data'],
-                       np.linspace(-900, 900, 9).astype('float64'))
-    assert_array_equal(grid.axes['z_disp']['data'],
-                       np.linspace(-400, 400, 3).astype('float64'))
+    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
 
 
 def test_grid_from_radars_grid_origin():
@@ -244,10 +231,8 @@ def test_grid_from_radars_grid_origin():
     grid = pyart.map.grid_from_radars((radar,), grid_origin=(36.4, -97.6),
                                       grid_origin_alt=200,
                                       **COMMON_MAP_TO_GRID_ARGS)
-    print(round(grid.axes['lat']['data'][0], 2))
-    print(round(grid.axes['lon']['data'][0], 2))
-    assert round(grid.axes['lat']['data'][0], 2) == 36.4
-    assert round(grid.axes['lon']['data'][0], 2) == -97.6
+    assert_almost_equal(grid.origin_latitude['data'][0], 36.4, 1)
+    assert_almost_equal(grid.origin_longitude['data'], -97.6, 1)
 
 
 def test_example_roi_funcs():

--- a/pyart/map/tests/test_grid_mapper.py
+++ b/pyart/map/tests/test_grid_mapper.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_raises
+from numpy.testing import assert_almost_equal
 
 import pyart
 
@@ -186,6 +187,36 @@ def test_grid_from_radars():
                        np.linspace(-900, 900, 9).astype('float64'))
     assert_array_equal(grid.axes['z_disp']['data'],
                        np.linspace(-400, 400, 3).astype('float64'))
+
+    # check that grid.radar_ attributes set correctly
+    assert isinstance(grid.radar_latitude, dict)
+    assert_almost_equal(grid.radar_latitude['data'][0], 36.5)
+
+    assert isinstance(grid.radar_longitude, dict)
+    assert_almost_equal(grid.radar_longitude['data'][0], -97.5)
+
+    assert isinstance(grid.radar_altitude, dict)
+    assert_almost_equal(grid.radar_altitude['data'][0], 200)
+
+    assert isinstance(grid.radar_time, dict)
+    assert_almost_equal(grid.radar_time['data'][0], 0.0)
+    assert grid.radar_time['units'] == radar.time['units']
+
+    assert isinstance(grid.radar_name, dict)
+    assert grid.radar_name['data'][0] == 'fake_radar'
+
+    assert grid.nradar == 1
+
+
+def test_unify_times_for_radars():
+    radar1 = pyart.testing.make_target_radar()
+    radar2 = pyart.testing.make_target_radar()
+    radar2.time['units'] = 'seconds since 1989-01-01T00:00:02Z'
+    radars = (radar1, radar2)
+    times, units = pyart.map.grid_mapper._unify_times_for_radars(radars)
+    assert_almost_equal(times[0], 0)
+    assert_almost_equal(times[1], 1)
+    assert units == 'seconds since 1989-01-01T00:00:01Z'
 
 
 def test_grid_from_radars_non_tuple():

--- a/pyart/map/tests/test_grid_mapper.py
+++ b/pyart/map/tests/test_grid_mapper.py
@@ -174,9 +174,9 @@ def test_grid_from_radars():
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
-    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
-    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
+    assert_almost_equal(grid.x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.z['data'], np.linspace(-400, 400, 3))
 
     # check that grid.radar_ attributes set correctly
     assert isinstance(grid.radar_latitude, dict)
@@ -220,9 +220,9 @@ def test_grid_from_radars_non_tuple():
     # check other Grid object attributes
     assert 'ROI' in grid.fields
     assert np.all(grid.fields['ROI']['data'] == 30.)
-    assert_almost_equal(grid.regular_x['data'], np.linspace(-900, 900, 10))
-    assert_almost_equal(grid.regular_y['data'], np.linspace(-900, 900, 9))
-    assert_almost_equal(grid.regular_z['data'], np.linspace(-400, 400, 3))
+    assert_almost_equal(grid.x['data'], np.linspace(-900, 900, 10))
+    assert_almost_equal(grid.y['data'], np.linspace(-900, 900, 9))
+    assert_almost_equal(grid.z['data'], np.linspace(-400, 400, 3))
 
 
 def test_grid_from_radars_grid_origin():

--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -93,14 +93,14 @@ def steiner_conv_strat(grid, dx=None, dy=None, intense=42.0,
 
     # parse dx and dy
     if dx is None:
-        dx = grid.axes['x_disp']['data'][1] - grid.axes['x_disp']['data'][0]
+        dx = grid.regular_x['data'][1] - grid.regular_x['data'][0]
     if dy is None:
-        dy = grid.axes['y_disp']['data'][1] - grid.axes['y_disp']['data'][0]
+        dy = grid.regular_y['data'][1] - grid.regular_y['data'][0]
 
-    # Get axes
-    x = grid.axes['x_disp']['data']
-    y = grid.axes['y_disp']['data']
-    z = grid.axes['z_disp']['data']
+    # Get coordinates
+    x = grid.regular_x['data']
+    y = grid.regular_y['data']
+    z = grid.regular_z['data']
 
     # Get reflectivity data
     ze = np.ma.copy(grid.fields[refl_field]['data'])

--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -93,14 +93,14 @@ def steiner_conv_strat(grid, dx=None, dy=None, intense=42.0,
 
     # parse dx and dy
     if dx is None:
-        dx = grid.regular_x['data'][1] - grid.regular_x['data'][0]
+        dx = grid.x['data'][1] - grid.x['data'][0]
     if dy is None:
-        dy = grid.regular_y['data'][1] - grid.regular_y['data'][0]
+        dy = grid.y['data'][1] - grid.y['data'][0]
 
     # Get coordinates
-    x = grid.regular_x['data']
-    y = grid.regular_y['data']
-    z = grid.regular_z['data']
+    x = grid.x['data']
+    y = grid.y['data']
+    z = grid.z['data']
 
     # Get reflectivity data
     ze = np.ma.copy(grid.fields[refl_field]['data'])

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -278,7 +278,7 @@ def make_empty_grid(grid_shape, grid_limits):
     metadata = {}
 
     radar_latitude = get_metadata('radar_latitude')
-    radar_latitude['data'] = np.array([-36.71])
+    radar_latitude['data'] = np.array([36.74])
 
     radar_longitude = get_metadata('radar_longitude')
     radar_longitude['data'] = np.array([-98.1])

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -256,14 +256,14 @@ def make_empty_grid(grid_shape, grid_limits):
     nz, ny, nx = grid_shape
     (z0, z1), (y0, y1), (x0, x1) = grid_limits
 
-    regular_x = get_metadata('regular_x')
-    regular_x['data'] = np.linspace(x0, x1, nx)
+    x = get_metadata('x')
+    x['data'] = np.linspace(x0, x1, nx)
 
-    regular_y = get_metadata('regular_y')
-    regular_y['data'] = np.linspace(y0, y1, ny)
+    y = get_metadata('y')
+    y['data'] = np.linspace(y0, y1, ny)
 
-    regular_z = get_metadata('regular_z')
-    regular_z['data'] = np.linspace(z0, z1, nz)
+    z = get_metadata('z')
+    z['data'] = np.linspace(z0, z1, nz)
 
     origin_altitude = get_metadata('origin_altitude')
     origin_altitude['data'] = np.array([300.])
@@ -294,8 +294,7 @@ def make_empty_grid(grid_shape, grid_limits):
     radar_name['data'] = np.array(['ExampleRadar'])
 
     return Grid(time, fields, metadata,
-                origin_latitude, origin_longitude, origin_altitude,
-                regular_x, regular_y, regular_z,
+                origin_latitude, origin_longitude, origin_altitude, x, y, z,
                 radar_latitude=radar_latitude, radar_longitude=radar_longitude,
                 radar_altitude=radar_altitude, radar_time=radar_time,
                 radar_name=radar_name)

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -306,9 +306,41 @@ def make_empty_grid(grid_shape, grid_limits):
     fields = {}
     metadata = {}
 
+    radar_latitude = {
+        'data': np.array([-36.71]),
+        'long_name': 'Latitude of radars used to make the grid.',
+        'units': 'degree_N',
+    }
+
+    radar_longitude = {
+        'data': np.array([-98.1]),
+        'long_name': 'Longitude of radars used to make the grid.',
+        'units': 'degree_E',
+    }
+
+    radar_altitude = {
+        'data': np.array([300.]),
+        'long_name': 'Altitude of radars used to make the grid.',
+        'units': 'm',
+    }
+
+    radar_time = {
+        'data': np.array([0.0]),
+        'units': 'seconds since 2000-01-01T00:00:00Z',
+        'calendar': 'gregorian',
+        'long_name': 'Time in seconds since volume start for each radar'}
+
+    radar_name = {
+        'data': np.array(['ExampleRadar']),
+        'long_name': 'Name of radar used to make the grid',
+    }
+
     return Grid(time, fields, metadata,
                 origin_latitude, origin_longitude, origin_altitude,
-                regular_x, regular_y, regular_z)
+                regular_x, regular_y, regular_z,
+                radar_latitude=radar_latitude, radar_longitude=radar_longitude,
+                radar_altitude=radar_altitude, radar_time=radar_time,
+                radar_name=radar_name)
 
 
 def make_target_grid():

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -255,73 +255,60 @@ def make_empty_grid(grid_shape, grid_limits):
         'standard_name': 'time',
         'long_name': 'Time in seconds since volume start'}
 
-    time_start = {
-        'data': np.array([0.0]),
-        'units': 'seconds since 2000-01-01T00:00:00Z',
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds since volume start'}
-
-    time_end = {
-        'data': np.array([0.0]),
-        'units': 'seconds since 2000-01-01T00:00:00Z',
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds since volume start'}
-
     # grid coordinate dictionaries
     nz, ny, nx = grid_shape
     (z0, z1), (y0, y1), (x0, x1) = grid_limits
 
-    xaxis = {'data': np.linspace(x0, x1, nx),
-             'long_name': 'X-coordinate in Cartesian system',
-             'axis': 'X',
-             'units': 'm'}
+    regular_x = {
+        'data': np.linspace(x0, x1, nx),
+        'long_name': 'X-coordinate in Cartesian system',
+        'axis': 'X',
+        'units': 'm'}
 
-    yaxis = {'data': np.linspace(y0, y1, ny),
-             'long_name': 'Y-coordinate in Cartesian system',
-             'axis': 'Y',
-             'units': 'm'}
+    regular_y = {
+        'data': np.linspace(y0, y1, ny),
+        'long_name': 'Y-coordinate in Cartesian system',
+        'axis': 'Y',
+        'units': 'm'}
 
-    zaxis = {'data': np.linspace(z0, z1, nz),
-             'long_name': 'Z-coordinate in Cartesian system',
-             'axis': 'Z',
-             'units': 'm',
-             'positive': 'up'}
+    regular_z = {
+        'data': np.linspace(z0, z1, nz),
+        'long_name': 'Z-coordinate in Cartesian system',
+        'axis': 'Z',
+        'units': 'm',
+        'positive': 'up'}
 
-    altorigin = {'data': np.array([300.]),
-                 'long_name': 'Altitude at grid origin',
-                 'units': 'm',
-                 'standard_name': 'altitude',
-                 }
+    origin_altitude = {
+        'data': np.array([300.]),
+        'long_name': 'Altitude at grid origin',
+        'units': 'm',
+        'standard_name': 'altitude',
+    }
 
-    latorigin = {'data': np.array([36.74]),
-                 'long_name': 'Latitude at grid origin',
-                 'units': 'degree_N',
-                 'standard_name': 'latitude',
-                 'valid_min': -90.,
-                 'valid_max': 90.
-                 }
+    origin_latitude = {
+        'data': np.array([36.74]),
+        'long_name': 'Latitude at grid origin',
+        'units': 'degree_N',
+        'standard_name': 'latitude',
+        'valid_min': -90.,
+        'valid_max': 90.
+    }
 
-    lonorigin = {'data': np.array([-98.1]),
-                 'long_name': 'Longitude at grid origin',
-                 'units': 'degree_E',
-                 'standard_name': 'longitude',
-                 'valid_min': -180.,
-                 'valid_max': 180.
-                 }
+    origin_longitude = {
+        'data': np.array([-98.1]),
+        'long_name': 'Longitude at grid origin',
+        'units': 'degree_E',
+        'standard_name': 'longitude',
+        'valid_min': -180.,
+        'valid_max': 180.
+    }
 
-    axes = {'time': time,
-            'time_start': time_start,
-            'time_end': time_end,
-            'z_disp': zaxis,
-            'y_disp': yaxis,
-            'x_disp': xaxis,
-            'alt': altorigin,
-            'lat': latorigin,
-            'lon': lonorigin}
+    fields = {}
+    metadata = {}
 
-    return Grid({}, axes, {})
+    return Grid(time, fields, metadata,
+                origin_latitude, origin_longitude, origin_altitude,
+                regular_x, regular_y, regular_z)
 
 
 def make_target_grid():

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -248,92 +248,50 @@ def make_empty_grid(grid_shape, grid_limits):
         Empty Grid object, centered near the ARM SGP site (Oklahoma).
 
     """
-    time = {
-        'data': np.array([0.0]),
-        'units': 'seconds since 2000-01-01T00:00:00Z',
-        'calendar': 'gregorian',
-        'standard_name': 'time',
-        'long_name': 'Time in seconds since volume start'}
+    time = get_metadata('grid_time')
+    time['data'] = np.array([0.0])
+    time['units'] = 'seconds since 2000-01-01T00:00:00Z'
 
     # grid coordinate dictionaries
     nz, ny, nx = grid_shape
     (z0, z1), (y0, y1), (x0, x1) = grid_limits
 
-    regular_x = {
-        'data': np.linspace(x0, x1, nx),
-        'long_name': 'X-coordinate in Cartesian system',
-        'axis': 'X',
-        'units': 'm'}
+    regular_x = get_metadata('regular_x')
+    regular_x['data'] = np.linspace(x0, x1, nx)
 
-    regular_y = {
-        'data': np.linspace(y0, y1, ny),
-        'long_name': 'Y-coordinate in Cartesian system',
-        'axis': 'Y',
-        'units': 'm'}
+    regular_y = get_metadata('regular_y')
+    regular_y['data'] = np.linspace(y0, y1, ny)
 
-    regular_z = {
-        'data': np.linspace(z0, z1, nz),
-        'long_name': 'Z-coordinate in Cartesian system',
-        'axis': 'Z',
-        'units': 'm',
-        'positive': 'up'}
+    regular_z = get_metadata('regular_z')
+    regular_z['data'] = np.linspace(z0, z1, nz)
 
-    origin_altitude = {
-        'data': np.array([300.]),
-        'long_name': 'Altitude at grid origin',
-        'units': 'm',
-        'standard_name': 'altitude',
-    }
+    origin_altitude = get_metadata('origin_altitude')
+    origin_altitude['data'] = np.array([300.])
 
-    origin_latitude = {
-        'data': np.array([36.74]),
-        'long_name': 'Latitude at grid origin',
-        'units': 'degree_N',
-        'standard_name': 'latitude',
-        'valid_min': -90.,
-        'valid_max': 90.
-    }
+    origin_latitude = get_metadata('origin_latitude')
+    origin_latitude['data'] = np.array([36.74])
 
-    origin_longitude = {
-        'data': np.array([-98.1]),
-        'long_name': 'Longitude at grid origin',
-        'units': 'degree_E',
-        'standard_name': 'longitude',
-        'valid_min': -180.,
-        'valid_max': 180.
-    }
+    origin_longitude = get_metadata('origin_longitude')
+    origin_longitude['data'] = np.array([-98.1])
 
     fields = {}
     metadata = {}
 
-    radar_latitude = {
-        'data': np.array([-36.71]),
-        'long_name': 'Latitude of radars used to make the grid.',
-        'units': 'degree_N',
-    }
+    radar_latitude = get_metadata('radar_latitude')
+    radar_latitude['data'] = np.array([-36.71])
 
-    radar_longitude = {
-        'data': np.array([-98.1]),
-        'long_name': 'Longitude of radars used to make the grid.',
-        'units': 'degree_E',
-    }
+    radar_longitude = get_metadata('radar_longitude')
+    radar_longitude['data'] = np.array([-98.1])
 
-    radar_altitude = {
-        'data': np.array([300.]),
-        'long_name': 'Altitude of radars used to make the grid.',
-        'units': 'm',
-    }
+    radar_altitude = get_metadata('radar_altitude')
+    radar_altitude['data'] = np.array([300.])
 
-    radar_time = {
-        'data': np.array([0.0]),
-        'units': 'seconds since 2000-01-01T00:00:00Z',
-        'calendar': 'gregorian',
-        'long_name': 'Time in seconds since volume start for each radar'}
+    radar_time = get_metadata('radar_time')
+    radar_time['data'] = np.array([0.0])
+    radar_time['units'] = 'seconds since 2000-01-01T00:00:00Z'
 
-    radar_name = {
-        'data': np.array(['ExampleRadar']),
-        'long_name': 'Name of radar used to make the grid',
-    }
+    radar_name = get_metadata('radar_name')
+    radar_name['data'] = np.array(['ExampleRadar'])
 
     return Grid(time, fields, metadata,
                 origin_latitude, origin_longitude, origin_altitude,

--- a/pyart/util/datetime_utils.py
+++ b/pyart/util/datetime_utils.py
@@ -27,5 +27,4 @@ def datetimes_from_dataset(dataset):
 
 def datetime_from_grid(grid):
     """ Return a datetime for the volume start in a Grid. """
-    return num2date(grid.axes['time_start']['data'][0],
-                    grid.axes['time_start']['units'])
+    return num2date(grid.time['data'][0], grid.time['units'])

--- a/scripts/convert_legacy_grid
+++ b/scripts/convert_legacy_grid
@@ -8,9 +8,11 @@ import warnings
 import netCDF4
 
 
-def _transfer_var(dset, name, var):
+def _transfer_var(dset, name, var, dimensions=None):
     """ Copy the a variable to a different Dataset with a given name. """
-    new_var = dset.createVariable(name, var.dtype, var.dimensions)
+    if dimensions is None:
+        dimensions = var.dimensions
+    new_var = dset.createVariable(name, var.dtype, dimensions)
     for ncattr in var.ncattrs():
         new_var.setncattr(ncattr, var.getncattr(ncattr))
     new_var[:] = var[:]
@@ -39,25 +41,31 @@ def main():
 
     # transfer dimensions
     dset_modern.createDimension('time', None)
-    dset_modern.createDimension('nz', len(dset_legacy.dimensions['nz']))
-    dset_modern.createDimension('ny', len(dset_legacy.dimensions['ny']))
-    dset_modern.createDimension('nx', len(dset_legacy.dimensions['nx']))
+    dset_modern.createDimension('z', len(dset_legacy.dimensions['nz']))
+    dset_modern.createDimension('y', len(dset_legacy.dimensions['ny']))
+    dset_modern.createDimension('x', len(dset_legacy.dimensions['nx']))
 
     # transfer axes variables
     variable_mappings = {
         'time': 'time',
-        'x_disp': 'regular_x',
-        'y_disp': 'regular_y',
-        'z_disp': 'regular_z',
+        'x_disp': 'x',
+        'y_disp': 'y',
+        'z_disp': 'z',
         'lat': 'origin_latitude',
         'lon': 'origin_longitude',
         'alt': 'origin_altitude'
     }
+    dim_mapping = {
+        'nx': 'x',
+        'ny': 'y',
+        'nz': 'z',
+        'time': 'time'}
     for legacy_varname, modern_varname in variable_mappings.items():
         if args.verbose:
             print("Variable:", legacy_varname, "->", modern_varname)
         legacy_var = dset_legacy.variables[legacy_varname]
-        _transfer_var(dset_modern, modern_varname, legacy_var)
+        dims = [dim_mapping[dim] for dim in legacy_var.dimensions]
+        _transfer_var(dset_modern, modern_varname, legacy_var, dims)
 
     # transfer fields
     field_shape = tuple(
@@ -73,13 +81,31 @@ def main():
         if legacy_var.shape != field_shape_with_time:
             warnings.warn('Field %s skipped due to incorrect shape' % (field))
             continue
-        _transfer_var(dset_modern, field, legacy_var)
+        _transfer_var(dset_modern, field, legacy_var, ('time', 'z', 'y', 'x'))
 
     # set a default projections variable
-    projection_var = dset_modern.createVariable('projection', 'int32', ())
+    projection_var = dset_modern.createVariable('projection', 'c', ())
     projection_var.setncattr('_include_lon_0_lat_0', 'true')
     projection_var.setncattr('proj', 'pyart_aeqd')
-    projection_var[:] = 1
+
+    # set a default projection coordinate system
+    proj = dset_modern.createVariable('ProjectionCoordinateSystem', 'c', ())
+    proj.setncattr('grid_mapping_name', "azimuthal_equidistant")
+    proj.setncattr('semi_major_axis', 6370997.0)
+    proj.setncattr('inverse_flattening', 298.25)
+    proj.setncattr('longitude_of_prime_meridian', 0.0)
+    proj.setncattr('false_easting', 0.0)
+    proj.setncattr('false_northing', 0.0)
+
+    lat = dset_legacy.variables['lat'][0]
+    proj.setncattr('latitude_of_projection_origin', lat)
+
+    lon = dset_legacy.variables['lon'][0]
+    proj.setncattr('longitude_of_projection_origin', lon)
+
+    proj.setncattr('_CoordinateTransformType', 'Projection')
+    proj.setncattr('_CoordinateAxes', 'x y z time')
+    proj.setncattr('_CoordinateAxesTypes', 'GeoX GeoY Height Time')
 
     # close files
     dset_legacy.close()

--- a/scripts/convert_legacy_grid
+++ b/scripts/convert_legacy_grid
@@ -107,6 +107,10 @@ def main():
     proj.setncattr('_CoordinateAxes', 'x y z time')
     proj.setncattr('_CoordinateAxesTypes', 'GeoX GeoY Height Time')
 
+    # Add Conventions if not already present
+    if 'Conventions' not in dset_modern.ncattrs():
+        dset_modern.setncattr('Conventions', 'PyART_GRID-1.1')
+
     # close files
     dset_legacy.close()
     dset_modern.close()

--- a/scripts/convert_legacy_grid
+++ b/scripts/convert_legacy_grid
@@ -1,0 +1,90 @@
+#! /usr/bin/env python
+""" Convert a legacy Py-ART grid NetCDF file to a modern NetCDF file. """
+
+from __future__ import print_function
+import argparse
+import warnings
+
+import netCDF4
+
+
+def _transfer_var(dset, name, var):
+    """ Copy the a variable to a different Dataset with a given name. """
+    new_var = dset.createVariable(name, var.dtype, var.dimensions)
+    for ncattr in var.ncattrs():
+        new_var.setncattr(ncattr, var.getncattr(ncattr))
+    new_var[:] = var[:]
+
+
+def main():
+    """ main function. """
+    # parse the arguments
+    parser = argparse.ArgumentParser(
+        description='Convert a legacy Py-ART grid netCDF file')
+    parser.add_argument(
+        'infile', type=str,
+        help='legacy netCDF grid file to covert')
+    parser.add_argument(
+        'outfile', type=str,
+        help='filename of new netCDF grid file')
+    parser.add_argument('-v', '--verb', dest='verbose', action='store_true',
+                        help='Verbose mode, print out debugging messages.')
+    args = parser.parse_args()
+
+    if args.verbose:
+        print("Converting:", args.infile, "-->", args.outfile)
+
+    dset_legacy = netCDF4.Dataset(args.infile, 'r')
+    dset_modern = netCDF4.Dataset(args.outfile, 'w')
+
+    # transfer dimensions
+    dset_modern.createDimension('time', None)
+    dset_modern.createDimension('nz', len(dset_legacy.dimensions['nz']))
+    dset_modern.createDimension('ny', len(dset_legacy.dimensions['ny']))
+    dset_modern.createDimension('nx', len(dset_legacy.dimensions['nx']))
+
+    # transfer axes variables
+    variable_mappings = {
+        'time': 'time',
+        'x_disp': 'regular_x',
+        'y_disp': 'regular_y',
+        'z_disp': 'regular_z',
+        'lat': 'origin_latitude',
+        'lon': 'origin_longitude',
+        'alt': 'origin_altitude'
+    }
+    for legacy_varname, modern_varname in variable_mappings.items():
+        if args.verbose:
+            print("Variable:", legacy_varname, "->", modern_varname)
+        legacy_var = dset_legacy.variables[legacy_varname]
+        _transfer_var(dset_modern, modern_varname, legacy_var)
+
+    # transfer fields
+    field_shape = tuple(
+        [len(dset_legacy.dimensions[d]) for d in ['nz', 'ny', 'nx']])
+    field_shape_with_time = (1, ) + field_shape
+    axes_keys = ['time', 'time_start', 'time_end', 'base_time',
+                 'time_offset', 'z_disp', 'y_disp', 'x_disp',
+                 'alt', 'lat', 'lon', 'z', 'lev', 'y', 'x']
+    for field in [k for k in dset_legacy.variables if k not in axes_keys]:
+        if args.verbose:
+            print("Field:", field)
+        legacy_var = dset_legacy.variables[field]
+        if legacy_var.shape != field_shape_with_time:
+            warnings.warn('Field %s skipped due to incorrect shape' % (field))
+            continue
+        _transfer_var(dset_modern, field, legacy_var)
+
+    # set a default projections variable
+    projection_var = dset_modern.createVariable('projection', 'int32', ())
+    projection_var.setncattr('_include_lon_0_lat_0', 'true')
+    projection_var.setncattr('proj', 'pyart_aeqd')
+    projection_var[:] = 1
+
+    # close files
+    dset_legacy.close()
+    dset_modern.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Introduce a new improved layout for the **Grid** class.  The new class has the following attributes:

* fields
* metadata
* time
* origin_latitude, origin_longitude, origin_altitude : specifying the geographic location of the grid origin
* x, y, z : specifying the regular Cartesian/cartographic distances from the grid origin.
* nx, ny, nz : the sizes of the three above dimensions.
* projection : specified the map projection used to transform between Cartesian and geographic coordinates.
* radar_latitude, radar_longitude, radar_altitude : Geographic location of the radar which were used to create the grid.
* radar_name, radar_time : Additional information about the radars which were used to create the grid.
* nradar : number of radar used to create the grid.

Additional the following attribute are lazily loaded upon first access of the 'data' key:

* point_x, point_y, point_z : Cartesian/cartographic location of all grid points.
* point_latitude, point_longitude, point_altitude : Geographic location of all grid point using the map projection specified by the *projection* attribute

The legacy *axes* attribute is still available but will be depreciated in future Py-ART versions.  

**Grid** objects are creating using a new set of parameters. Support for creating **Grid** objects using the legacy parameters is available using the `Grid.from_legacy_parameters` class method, which will be depreciated in future Py-ART versions.

The variables inside of the NetCDF files which Py-ART creates to store Grid objects have changed to match these new parameter names.  The `write_grid` and `read_grid` function use this new format.  The `read_legacy_grid` function is provide to read in NetCDF file using the older grid format, this function will be depreciated in future Py-ART versions.  

To further aid in the transition to the new Grid file layout, a **convert_legacy_grid** script is included with Py-ART which will create new style NetCDF files from the legacy NetCDF grid files.  This script does not make use of any functions inside Py-ART and should be usable regardless of if or what version of Py-ART is installed.

All code in Py-ART and examples have been update to use the new Grid layout and file format.

Finally the as the functionally of the `add_2d_latlon_axis` is now available in the *point_latitude* and *point_longitude* this function is depreciated and will be removed in future version of Py-ART.

Implements and closes #285 