### PR TITLE
TST: Fix skipped basemap tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
     - python: 2.7
       env:
         - PYTHON_VERSION="2.7"
-        - NOSE_ARGS="-v --no-skip --with-cov --cov pyart pyart"
+        - NOSE_ARGS="-v --with-cov --cov pyart pyart"
         - COVERALLS="true"
     - python: 2.7
       env:
         - PYTHON_VERSION="2.7"
-        - NOSE_ARGS="-v --no-skip --with-cov --cov pyart --exe pyart"
+        - NOSE_ARGS="-v --with-cov --cov pyart --exe pyart"
         - FROM_RECIPE="true"
         - DOC_BUILD="true"
     - python: 2.6

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -38,7 +38,10 @@ if [[ $PYTHON_VERSION == '2.7' ]]; then
     conda install --yes -c http://conda.anaconda.org/jjhelmus cvxopt_glpk
 
     # wradlib and dependencies
-    conda install --yes sphinx gdal numpydoc h5py
+    # KLUDGE libgdal does not report its version dependency on geos which
+    # causes either gdal or basemap to break, force the exact libgdal version
+    # see: https://github.com/ContinuumIO/anaconda-issues/issues/584
+    conda install --yes sphinx gdal numpydoc h5py basemap libgdal=2.0.0=0
     conda install --yes sphinx_rtd_theme
     pip install sphinxcontrib-bibtex
     pip install xmltodict


### PR DESCRIPTION
All unit tests which depended on basemap or pyproj were being skipped on the Python 2.7 run on Travis CI due to a conda install issue with gdal and basemap.  Now these tests are run as intended.