### PR TITLE
BUG: Masked values not included in Barnes weights

### DIFF
--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -609,11 +609,9 @@ def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
 
         if weighting_function.upper() == 'CRESSMAN':
             weights = (r2 - dist2) / (r2 + dist2)
-            value = np.ma.average(nn_field_data, weights=weights, axis=0)
         elif weighting_function.upper() == 'BARNES':
-            w = np.exp(-dist2 / (2.0 * r2)) + 1e-5
-            w /= np.sum(w)
-            value = np.ma.dot(w, nn_field_data)
+            weights = np.exp(-dist2 / (2.0 * r2)) + 1e-5
+        value = np.ma.average(nn_field_data, weights=weights, axis=0)
 
         grid_data[iz, iy, ix] = value
 

--- a/pyart/map/tests/test_grid_mapper.py
+++ b/pyart/map/tests/test_grid_mapper.py
@@ -110,6 +110,27 @@ def test_map_to_grid_masked_refl_field():
     assert_almost_equal(center_slice, EXPECTED_CENTER_SLICE)
 
 
+def test_map_to_grid_barnes_filter_masked():
+
+    radar = pyart.testing.make_target_radar()
+
+    # mask and replace with non-sense values a region of radar volume
+    fdata = radar.fields['reflectivity']['data']
+    fdata = np.ma.array(fdata)
+    fdata[100:120, 20:40] = -9999.
+    fdata[100:120, 20:40] = np.ma.masked
+    radar.fields['reflectivity']['data'] = fdata
+
+    # check that non-sense values are masked
+    assert radar.fields['reflectivity']['data'].min() > -1.
+
+    grids = pyart.map.map_to_grid(
+        (radar,), weighting_function='Barnes', **COMMON_MAP_TO_GRID_ARGS)
+
+    # check that no masked values were included in the interpolation
+    assert grids['reflectivity'].min() > -1.
+
+
 def test_map_to_grid_no_copy():
     radar = pyart.testing.make_target_radar()
     grids = pyart.map.map_to_grid(


### PR DESCRIPTION
When using the 'Barnes' weighting_function with map_to_grid, masked values in
the radar gates within the radius of influence are not included in the
interpolation of the grid point. Previously these values may have been
included in the interpolated grid point due to a bug in numpy.ma.dot

closes #443