### PR TITLE
BUG: get_field_colormap return string.

### DIFF
--- a/pyart/config.py
+++ b/pyart/config.py
@@ -139,7 +139,7 @@ def get_field_colormap(field):
         return _DEFAULT_FIELD_COLORMAP[field]
     else:
         import matplotlib.cm
-        return matplotlib.cm.get_cmap()
+        return matplotlib.cm.get_cmap().name
 
 
 def get_field_limits(field, container=None, selection=0):


### PR DESCRIPTION
correct the bug where `get_field_colormap` returned a colormap instance.This caused ARTView issue [#109](https://github.com/nguy/artview/issues/109)