### PR TITLE
Airborne Display class name change

### DIFF
--- a/pyart/graph/__init__.py
+++ b/pyart/graph/__init__.py
@@ -29,7 +29,8 @@ Plotting grid data
 
 from .radardisplay import RadarDisplay
 from . import cm
-from .radardisplay_airborne import RadarDisplay_Airborne
+from .radardisplay_airborne import AirborneRadarDisplay
+from .radardisplay_airborne import  AirborneRadarDisplay as RadarDisplay_Airborne
 from .gridmapdisplay import GridMapDisplay
 from .radarmapdisplay import RadarMapDisplay
 

--- a/pyart/graph/__init__.py
+++ b/pyart/graph/__init__.py
@@ -15,7 +15,7 @@ Plotting radar data
 
     RadarDisplay
     RadarMapDisplay
-    RadarDisplay_Airborne
+    AirborneRadarDisplay
 
 Plotting grid data
 ==================
@@ -30,8 +30,20 @@ Plotting grid data
 from .radardisplay import RadarDisplay
 from . import cm
 from .radardisplay_airborne import AirborneRadarDisplay
-from .radardisplay_airborne import  AirborneRadarDisplay as RadarDisplay_Airborne
 from .gridmapdisplay import GridMapDisplay
 from .radarmapdisplay import RadarMapDisplay
 
 __all__ = [s for s in dir() if not s.startswith('_')]
+
+
+import warnings as _warnings
+
+class RadarDisplay_Airborne(AirborneRadarDisplay):
+    """ Depreciated name for the AirborneRadarDisplay class. """
+
+    def __init__(self, *args, **kwargs):
+        _warnings.warn(
+            ("'RadarDisplay_Airborne' is depreciated and will be removed in"
+             "future versions of Py-ART, please use 'AirborneRadarDisplay'"),
+            DeprecationWarning)
+        AirborneRadarDisplay.__init__(self, *args, **kwargs)

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -8,7 +8,7 @@ Class for creating plots from Airborne Radar objects.
     :toctree: generated/
     :template: dev_template.rst
 
-    RadarDisplay_Airborne
+    AirborneRadarDisplay
 
 """
 
@@ -20,7 +20,6 @@ from . import common
 from ..core.transforms import antenna_to_cartesian
 from ..core.transforms import antenna_to_cartesian_track_relative
 from ..core import transforms
-
 
 class AirborneRadarDisplay(RadarDisplay):
     """

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -22,7 +22,7 @@ from ..core.transforms import antenna_to_cartesian_track_relative
 from ..core import transforms
 
 
-class RadarDisplay_Airborne(RadarDisplay):
+class AirborneRadarDisplay(RadarDisplay):
     """
     A display object for creating plots from data in a airborne radar object.
 
@@ -97,7 +97,7 @@ class RadarDisplay_Airborne(RadarDisplay):
         self.heading = radar.heading['data']
         self.pitch = radar.pitch['data']
         self.altitude = radar.altitude['data']
-        super(RadarDisplay_Airborne, self).__init__(radar, shift)
+        super(AirborneRadarDisplay, self).__init__(radar, shift)
 
     def _calculate_localization(self, radar):
         """ Calculate self.x, self.y, self.z and self.loc. """


### PR DESCRIPTION
Changed name from RadarDisplay_Airborne to AirborneRadarDisplay.
Added an alias in pyart.graph.__init__.py

As discussed in Issue #364 to change name, very minor and easy fix. There is further discussion in there regarding time series, but I think that maybe a separate issue should be opened on how to handle that.