### PR TITLE
BUG: plot_vpt with time_axis_flag=True works.

### DIFF
--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -586,7 +586,7 @@ class RadarDisplay(object):
         # set up the time axis
         if time_axis_flag:
             self._set_vpt_time_axis(ax, date_time_form=date_time_form, tz=tz)
-            x = datetimes_from_radar(radar)
+            x = datetimes_from_radar(self._radar)
 
         # mask the data where outside the limits
         if mask_outside:

--- a/pyart/graph/tests/test_radar_display.py
+++ b/pyart/graph/tests/test_radar_display.py
@@ -67,6 +67,20 @@ def test_radardisplay_vpt(outfile=None):
         fig.savefig(outfile)
     plt.close()
 
+
+def test_radardisplay_vpt_time(outfile=None):
+    radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    pyart.core.to_vpt(radar)      # hack to make the data a VPT
+    display = pyart.graph.RadarDisplay(radar)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    display.plot('reflectivity_horizontal', colorbar_flag=True,
+                 time_axis_flag=True,
+                 mask_tuple=('reflectivity_horizontal', -100), ax=ax)
+    if outfile:
+        fig.savefig(outfile)
+    plt.close()
+
 def test_radardisplay_azimuth_to_rhi(outfile=None):
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
     display = pyart.graph.RadarDisplay(radar)


### PR DESCRIPTION
Previously using RadarDisplay.plot_vpt with the time_axis_flag set to True
would raise an error as the radar variable was not in scope.  This should be
referring to the self._radar attribute.