### PR TITLE
MAINT: Refactor of Display classes

### DIFF
--- a/examples/plotting/plot_rhi_cfradial.py
+++ b/examples/plotting/plot_rhi_cfradial.py
@@ -41,7 +41,8 @@ for snum in radar.sweep_number['data']:
                  colorbar_label=colorbar_label, ax=ax)
     display.set_limits(ylim=[0, 15], ax=ax)
 
-figure_title = 'Time: ' + display.time_begin.isoformat() + 'Z'
+time_start = netCDF4.num2date(radar.time['data'][0], radar.time['units'])
+figure_title = 'Time: ' + time_start.isoformat() + 'Z'
 fig.text(0.35, 0.92, figure_title)
 
 plt.show()

--- a/examples/plotting/plot_rhi_sigmet.py
+++ b/examples/plotting/plot_rhi_sigmet.py
@@ -14,6 +14,7 @@ print(__doc__)
 
 import matplotlib.pyplot as plt
 import pyart
+import netCDF4
 
 filename = 'XSW110520113537.RAW7HHL'
 
@@ -24,10 +25,11 @@ display = pyart.graph.RadarDisplay(radar)
 fig = plt.figure(figsize=[10, 4])
 ax = fig.add_subplot(111)
 
-radar_name = radar.metadata['instrument_name']
-time_text = ' ' + display.time_begin.isoformat() + 'Z '
+instrument_name = radar.metadata['instrument_name']
+time_start = netCDF4.num2date(radar.time['data'][0], radar.time['units'])
+time_text = ' ' + time_start.isoformat() + 'Z '
 azimuth = radar.fixed_angle['data'][0]
-title = 'RHI ' + radar_name + time_text + 'Azimuth %.2f' % (azimuth)
+title = 'RHI ' + instrument_name + time_text + 'Azimuth %.2f' % (azimuth)
 
 display.plot('reflectivity', 0, vmin=-32, vmax=64,
              title=title, colorbar_flag=False, ax=ax)

--- a/examples/plotting/plot_rhi_two_panel.py
+++ b/examples/plotting/plot_rhi_two_panel.py
@@ -14,6 +14,7 @@ print(__doc__)
 
 import matplotlib.pyplot as plt
 import pyart
+import netCDF4
 
 
 # read the data and create the display object
@@ -39,9 +40,10 @@ for plot_num in xrange(nplots):
     display.set_limits(ylim=[0, 17])
 
 # set the figure title and show
-radar_name = display.radar_name
-time_text = ' ' + display.time_begin.isoformat() + 'Z '
+instrument_name = radar.metadata['instrument_name']
+time_start = netCDF4.num2date(radar.time['data'][0], radar.time['units'])
+time_text = ' ' + time_start.isoformat() + 'Z '
 azimuth = radar.fixed_angle['data'][0]
-title = 'RHI ' + radar_name + time_text + 'Azimuth %.2f' % (azimuth)
+title = 'RHI ' + instrument_name + time_text + 'Azimuth %.2f' % (azimuth)
 plt.suptitle(title)
 plt.show()

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -32,6 +32,7 @@ except ImportError:
 from ..config import get_metadata
 from ..lazydict import LazyLoadDict
 from .transforms import cartesian_to_geographic
+from .transforms import cartesian_vectors_to_geographic
 
 
 class Grid(object):
@@ -334,6 +335,34 @@ class Grid(object):
             raise ValueError('Field has invalid shape')
 
         self.fields[field_name] = field_dict
+
+    def get_point_longitude_latitude(self, level=0, edges=False):
+        """
+        Return arrays of longitude and latitude for a given grid height level.
+
+        Parameters
+        ----------
+        level : int, optional
+            Grid height level at which to determine latitudes and longitudes.
+            This is not currently used as all height level have the same
+            layout.
+        edges : bool, optional
+            True to calculate the latitude and longitudes of the edges by
+            interpolating between Cartesian coordinates points and
+            extrapolating at the boundaries. False to calculate the locations
+            at the centers.
+
+        Returns
+        -------
+        longitude, latitude : 2D array
+            Arrays containing the latitude and longitudes, in degrees, of the
+            grid points or edges between grid points for the given height.
+
+        """
+        x = self.x['data']
+        y = self.y['data']
+        projparams = self.get_projparams()
+        return cartesian_vectors_to_geographic(x, y, projparams, edges=edges)
 
 
 def _point_data_factory(grid, coordinate):

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -282,6 +282,22 @@ def test_init_point_x_y_z():
     assert grid.point_x['data'][0, 0, 0] == grid.x['data'][0]
 
 
+def test_get_point_longitude_latitude():
+    grid = pyart.testing.make_target_grid()
+
+    longitude, latitude = grid.get_point_longitude_latitude()
+    assert latitude.shape == (400, 320)
+    assert longitude.shape == (400, 320)
+    assert_almost_equal(latitude[200, 160], 36.75, 2)
+    assert_almost_equal(longitude[200, 160], -98.09, 2)
+
+    longitude, latitude = grid.get_point_longitude_latitude(edges=True)
+    assert latitude.shape == (401, 321)
+    assert longitude.shape == (401, 321)
+    assert_almost_equal(latitude[200, 160], 36.74, 2)
+    assert_almost_equal(longitude[200, 160], -98.10, 2)
+
+
 # Remove this test when Grid.axes is Depreciated
 def test_grid_axes_attribute():
     # test the depreciated axes Grid attribute

--- a/pyart/core/tests/test_radar.py
+++ b/pyart/core/tests/test_radar.py
@@ -77,37 +77,91 @@ def test_gate_x_y_z():
     assert_allclose(radar.gate_z['data'][3], z_sweep0, atol=1e-8)
 
 
-def test_gate_edge_x_y_z():
+def test_get_gate_x_y_z():
+    radar = pyart.testing.make_empty_ppi_radar(5, 4, 2)
+    radar.azimuth['data'][:] = [0, 90, 180, 270, 0, 90, 180, 270]
+    radar.elevation['data'][:] = [0, 0, 0, 0, 10, 10, 10, 10]
+    radar.range['data'][:] = [5, 15, 25, 35, 45]
+
+    gate_x, gate_y, gate_z = radar.get_gate_x_y_z(0)
+    assert gate_x.shape == (4, 5)
+    assert_allclose(gate_x[0], [0, 0, 0, 0, 0], atol=1e-14)
+    assert_allclose(gate_x[1], [5, 15, 25, 35, 45], atol=1e-14)
+    assert_allclose(gate_x[2], [0, 0, 0, 0, 0], atol=1e-14)
+    assert_allclose(gate_x[3], [-5, -15, -25, -35, -45], atol=1e-14)
+
+    assert gate_y.shape == (4, 5)
+    assert_allclose(gate_y[0], [5, 15, 25, 35, 45], atol=1e-14)
+    assert_allclose(gate_y[1], [0, 0, 0, 0, 0], atol=1e-14)
+    assert_allclose(gate_y[2], [-5, -15, -25, -35, -45], atol=1e-14)
+    assert_allclose(gate_y[3], [0, 0, 0, 0, 0], atol=1e-14)
+
+    assert gate_z.shape == (4, 5)
+    z_sweep0 = np.array([1.47e-6, 1.324e-5, 3.679e-5, 7.210e-5, 1.1919e-4])
+    assert_allclose(gate_z[0], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[1], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[2], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[3], z_sweep0, atol=1e-8)
+
+
+def test_get_gate_x_y_z_edges():
     radar = pyart.testing.make_empty_ppi_radar(5, 4, 1)
     radar.azimuth['data'][:] = [315., 45, 135., 225.]
     radar.elevation['data'][:] = [0, 0, 0, 0]
     radar.range['data'][:] = [5, 15, 25, 35, 45]
 
+    gate_x, gate_y, gate_z = radar.get_gate_x_y_z(0, edges=True)
+
     zeros = np.array([0, 0, 0, 0, 0, 0])
     even = np.array([0, 10, 20, 30, 40, 50])
     atol = 1e-4
 
-    assert radar.gate_edge_x['data'].shape == (5, 6)
-    assert_allclose(radar.gate_edge_x['data'][0], -even, atol=atol)
-    assert_allclose(radar.gate_edge_x['data'][1], zeros, atol=atol)
-    assert_allclose(radar.gate_edge_x['data'][2], even, atol=atol)
-    assert_allclose(radar.gate_edge_x['data'][3], zeros, atol=atol)
-    assert_allclose(radar.gate_edge_x['data'][4], -even, atol=atol)
+    assert gate_x.shape == (5, 6)
+    assert_allclose(gate_x[0], -even, atol=atol)
+    assert_allclose(gate_x[1], zeros, atol=atol)
+    assert_allclose(gate_x[2], even, atol=atol)
+    assert_allclose(gate_x[3], zeros, atol=atol)
+    assert_allclose(gate_x[4], -even, atol=atol)
 
-    assert radar.gate_edge_y['data'].shape == (5, 6)
-    assert_allclose(radar.gate_edge_y['data'][0], zeros, atol=atol)
-    assert_allclose(radar.gate_edge_y['data'][1], even, atol=atol)
-    assert_allclose(radar.gate_edge_y['data'][2], zeros, atol=atol)
-    assert_allclose(radar.gate_edge_y['data'][3], -even, atol=atol)
-    assert_allclose(radar.gate_edge_y['data'][4], zeros, atol=atol)
+    assert gate_y.shape == (5, 6)
+    assert_allclose(gate_y[0], zeros, atol=atol)
+    assert_allclose(gate_y[1], even, atol=atol)
+    assert_allclose(gate_y[2], zeros, atol=atol)
+    assert_allclose(gate_y[3], -even, atol=atol)
+    assert_allclose(gate_y[4], zeros, atol=atol)
 
-    assert radar.gate_edge_z['data'].shape == (5, 6)
+    assert gate_z.shape == (5, 6)
     z_sweep0 = np.array([0, 5.89e-6, 2.354e-5, 5.297e-5, 9.418e-5, 1.4715e-4])
-    assert_allclose(radar.gate_edge_z['data'][0], z_sweep0, atol=1e-8)
-    assert_allclose(radar.gate_edge_z['data'][1], z_sweep0, atol=1e-8)
-    assert_allclose(radar.gate_edge_z['data'][2], z_sweep0, atol=1e-8)
-    assert_allclose(radar.gate_edge_z['data'][3], z_sweep0, atol=1e-8)
-    assert_allclose(radar.gate_edge_z['data'][4], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[0], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[1], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[2], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[3], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[4], z_sweep0, atol=1e-8)
+
+
+def test_get_gate_x_y_z_transitions():
+    radar = pyart.testing.make_empty_ppi_radar(5, 4, 2)
+    radar.azimuth['data'][:] = [0, 90, 180, 270, 0, 90, 180, 270]
+    radar.elevation['data'][:] = [0, 0, 0, 0, 10, 10, 10, 10]
+    radar.range['data'][:] = [5, 15, 25, 35, 45]
+    radar.antenna_transition = {'data': np.array([0, 0, 1, 0, 0, 0, 0, 0])}
+
+    gate_x, gate_y, gate_z = radar.get_gate_x_y_z(0, filter_transitions=True)
+    assert gate_x.shape == (3, 5)
+    assert_allclose(gate_x[0], [0, 0, 0, 0, 0], atol=1e-14)
+    assert_allclose(gate_x[1], [5, 15, 25, 35, 45], atol=1e-14)
+    assert_allclose(gate_x[2], [-5, -15, -25, -35, -45], atol=1e-14)
+
+    assert gate_y.shape == (3, 5)
+    assert_allclose(gate_y[0], [5, 15, 25, 35, 45], atol=1e-14)
+    assert_allclose(gate_y[1], [0, 0, 0, 0, 0], atol=1e-14)
+    assert_allclose(gate_y[2], [0, 0, 0, 0, 0], atol=1e-14)
+
+    assert gate_z.shape == (3, 5)
+    z_sweep0 = np.array([1.47e-6, 1.324e-5, 3.679e-5, 7.210e-5, 1.1919e-4])
+    assert_allclose(gate_z[0], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[1], z_sweep0, atol=1e-8)
+    assert_allclose(gate_z[2], z_sweep0, atol=1e-8)
 
 
 def test_init_gate_x_y_z():
@@ -135,36 +189,6 @@ def test_init_gate_x_y_z():
     assert_allclose(radar.gate_y['data'][0], [15, 25, 35, 45, 55], atol=1e-14)
     z_sweep0 = np.array([1.324e-5, 3.679e-5, 7.210e-5, 1.1919e-4, 1.7805e-4])
     assert_allclose(radar.gate_z['data'][0], z_sweep0, atol=1e-8)
-
-
-def test_init_gate_edge_x_y_z():
-    radar = pyart.testing.make_empty_ppi_radar(5, 4, 1)
-    radar.azimuth['data'][:] = [315., 45, 135., 225.]
-    radar.elevation['data'][:] = [0, 0, 0, 0]
-    radar.range['data'][:] = [5, 15, 25, 35, 45]
-
-    even = np.array([0, 10, 20, 30, 40, 50])
-    assert_allclose(radar.gate_edge_x['data'][2], even, atol=1e-12)
-    assert_allclose(radar.gate_edge_y['data'][1], even, atol=1e-12)
-    z_sweep0 = np.array([0, 5.89e-6, 2.354e-5, 5.297e-5, 9.418e-5, 1.4715e-4])
-    assert_allclose(radar.gate_edge_z['data'][0], z_sweep0, atol=1e-8)
-
-    # change range, gate_edhe_x, y, z are not updated
-    radar.range['data'][:] = [15, 25, 35, 45, 55]
-    even = np.array([0, 10, 20, 30, 40, 50])
-    assert_allclose(radar.gate_edge_x['data'][2], even, atol=1e-12)
-    assert_allclose(radar.gate_edge_y['data'][1], even, atol=1e-12)
-    z_sweep0 = np.array([0, 5.89e-6, 2.354e-5, 5.297e-5, 9.418e-5, 1.4715e-4])
-    assert_allclose(radar.gate_edge_z['data'][0], z_sweep0, atol=1e-8)
-
-    # call init_gate_edge_x_y_z, now the attributes are updated
-    radar.init_gate_edge_x_y_z()
-    even = np.array([10, 20, 30, 40, 50, 60])
-    assert_allclose(radar.gate_edge_x['data'][2], even, atol=1e-12)
-    assert_allclose(radar.gate_edge_y['data'][1], even, atol=1e-12)
-    z_sweep0 = np.array(
-        [5.89e-6, 2.354e-5, 5.297e-5, 9.418e-5, 1.4715e-4, 2.1190e-4])
-    assert_allclose(radar.gate_edge_z['data'][0], z_sweep0, atol=1e-8)
 
 
 def test_rays_per_sweep_attribute():

--- a/pyart/core/tests/test_transforms.py
+++ b/pyart/core/tests/test_transforms.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+import numpy as np
+
 from pyart.core import transforms
 from numpy.testing import assert_almost_equal
 from numpy.testing.decorators import skipif
@@ -90,6 +92,38 @@ def test_cartesian_to_geographic():
     lon, lat = transforms.cartesian_to_geographic(x, y, projparams)
     assert_almost_equal(lat, -20.0, 3)  # 20.0 S latitude
     assert_almost_equal(lon, 100.0, 3)  # 100.0 E longitude
+
+
+def test_cartesian_vectors_to_geographic():
+    # Example taken from:
+    # Snyder, J.P. Map Projections A Working Manual, 1987, page 338.
+    R = 3.0
+    lon_0 = -100.        # 100 degrees West longitude
+    lat_0 = 40.0        # 40 degrees North latitude
+    x = -5.8311398
+    y = 5.5444634
+
+    projparams = {
+        'proj': 'pyart_aeqd',
+        'lat_0': lat_0,
+        'lon_0': lon_0,
+        'R': R,
+    }
+    lon, lat = transforms.cartesian_vectors_to_geographic(
+        x, y, projparams, edges=False)
+    assert lon.shape == (1, 1)
+    assert lat.shape == (1, 1)
+    assert_almost_equal(lat, -20.0, 3)  # 20.0 S latitude
+    assert_almost_equal(lon, 100.0, 3)  # 100.0 E longitude
+
+    x = np.array([x - 1, x + 1])
+    y = np.array([y - 1, y + 1])
+    lon, lat = transforms.cartesian_vectors_to_geographic(
+        x, y, projparams, edges=True)
+    assert lon.shape == (3, 3)
+    assert lat.shape == (3, 3)
+    assert_almost_equal(lat[1, 1], -20.0, 3)  # 20.0 S latitude
+    assert_almost_equal(lon[1, 1], 100.0, 3)  # 100.0 E longitude
 
 
 @skipif(not transforms._PYPROJ_AVAILABLE)

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -426,7 +426,7 @@ def geographic_to_cartesian_aeqd(lon, lat, lon_0, lat_0, R=6370997.):
 
 def cartesian_to_geographic(x, y, projparams):
     """
-    Geographic to Cartesian coordinate transform.
+    Cartesian to Geographic coordinate transform.
 
     Transform a set of Cartesian/Cartographic coordinates (x, y) to a
     geographic coordinate system (lat, lon) using pyproj or a build in

--- a/pyart/exceptions.py
+++ b/pyart/exceptions.py
@@ -8,6 +8,7 @@ Custom Py-ART exceptions.
     :toctree: generated/
 
     MissingOptionalDependency
+    DepreciatedAttribute
     DepreciatedFunctionName
     _depreciated_alias
 
@@ -18,6 +19,11 @@ import warnings
 
 class MissingOptionalDependency(Exception):
     """ Exception raised when a optional depency is needed by not found. """
+    pass
+
+
+class DepreciatedAttribute(DeprecationWarning):
+    """ Warning catagory for an attribute which has been renamed/moved.  """
     pass
 
 

--- a/pyart/graph/__init__.py
+++ b/pyart/graph/__init__.py
@@ -33,10 +33,8 @@ from .radardisplay_airborne import AirborneRadarDisplay
 from .gridmapdisplay import GridMapDisplay
 from .radarmapdisplay import RadarMapDisplay
 
-__all__ = [s for s in dir() if not s.startswith('_')]
-
-
 import warnings as _warnings
+
 
 class RadarDisplay_Airborne(AirborneRadarDisplay):
     """ Depreciated name for the AirborneRadarDisplay class. """
@@ -47,3 +45,5 @@ class RadarDisplay_Airborne(AirborneRadarDisplay):
              "future versions of Py-ART, please use 'AirborneRadarDisplay'"),
             DeprecationWarning)
         AirborneRadarDisplay.__init__(self, *args, **kwargs)
+
+__all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/graph/_cm.py
+++ b/pyart/graph/_cm.py
@@ -60,7 +60,7 @@ _NWSRef_data = {
         (0.78571429, 0.75294117647058822, 0.75294117647058822),
         (0.85714286, 1.0, 1.0),
         (0.92857143, 0.59999999999999998, 0.59999999999999998),
-    (1.0, 0.0, 0.0)]
+        (1.0, 0.0, 0.0)]
 }
 
 _NWSVel_data = {
@@ -1724,8 +1724,8 @@ _BuDRd12_data = {
         (1.0, 0.65000000000000002, 0.65000000000000002)]
 }
 
-#LangRainbow12 developed to be friendlier to color blindness and B&W printing
-#than most rainbow color scales.
+# LangRainbow12 developed to be friendlier to color blindness and B&W printing
+# than most rainbow color scales.
 _LangRainbow12_data = {
     'blue': [
         (0.0, 0.97000000000000008, 0.97000000000000008),

--- a/pyart/graph/cm.py
+++ b/pyart/graph/cm.py
@@ -86,10 +86,10 @@ def revcmap(data):
     for key, val in data.items():
         if callable(val):
             valnew = _reverser(val)
-                # This doesn't work: lambda x: val(1-x)
-                # The same "val" (the first one) is used
-                # each time, so the colors are identical
-                # and the result is shades of gray.
+            # This doesn't work: lambda x: val(1-x)
+            # The same "val" (the first one) is used
+            # each time, so the colors are identical
+            # and the result is shades of gray.
         else:
             # Flip x and exchange the y values facing x = 0 and x = 1.
             valnew = [(1.0 - x, y1, y0) for x, y0, y1 in reversed(val)]

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -47,9 +47,6 @@ class GridMapDisplay(object):
         Grid object.
     debug : bool
         True to print debugging messages, False to supressed them.
-    proj : Proj
-        Object for performing cartographic transformations specific to the
-        grid.
     basemap : Basemap
         Last plotted basemap, None when no basemap has been plotted.
     mappables : list
@@ -68,20 +65,23 @@ class GridMapDisplay(object):
                 "Basemap is required to use GridMapDisplay but is not " +
                 "installed")
 
+        # set attributes
         self.grid = grid
         self.debug = debug
-
-        # set up the projection
-        lat0 = grid.origin_latitude['data'][0]
-        lon0 = grid.origin_longitude['data'][0]
-        self.proj = pyproj.Proj(
-            proj='aeqd', datum='NAD83', lat_0=lat0, lon_0=lon0)
-
-        # set attributes
         self.mappables = []
         self.fields = []
         self.origin = 'origin'
         self.basemap = None
+
+    @property
+    def proj(self):
+        """ Depreciated proj attribute. """
+        warnings.warn(
+            "The 'proj' attribute has been depreciated and will be removed "
+            "in future versions of Py-ART", category=DepreciatedAttribute)
+        lat0 = self.grid.origin_latitude['data'][0]
+        lon0 = self.grid.origin_longitude['data'][0]
+        return pyproj.Proj(proj='aeqd', datum='NAD83', lat_0=lat0, lon_0=lon0)
 
     @property
     def grid_lats(self):

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -28,7 +28,7 @@ from ..exceptions import MissingOptionalDependency
 from ..core.transforms import _interpolate_axes_edges
 
 
-class GridMapDisplay():
+class GridMapDisplay(object):
     """
     A class for creating plots from a grid object on top of a Basemap.
 
@@ -76,8 +76,8 @@ class GridMapDisplay():
         # set up the projection
         lat0 = grid.origin_latitude['data'][0]
         lon0 = grid.origin_longitude['data'][0]
-        self.proj = pyproj.Proj(proj='aeqd', datum='NAD83',
-                                lat_0=lat0, lon_0=lon0)
+        self.proj = pyproj.Proj(
+            proj='aeqd', datum='NAD83', lat_0=lat0, lon_0=lon0)
 
         # determine grid latitudes and longitudes.
         x_1d = grid.x['data']
@@ -91,11 +91,10 @@ class GridMapDisplay():
         self.origin = 'origin'
         self.basemap = None
 
-    def plot_basemap(self, lat_lines=None, lon_lines=None,
-                     resolution='l', area_thresh=10000,
-                     auto_range=True,
-                     min_lon=-92, max_lon=-86, min_lat=40, max_lat=44,
-                     ax=None, **kwargs):
+    def plot_basemap(
+            self, lat_lines=None, lon_lines=None, resolution='l',
+            area_thresh=10000, auto_range=True, min_lon=-92, max_lon=-86,
+            min_lat=40, max_lat=44, ax=None, **kwargs):
         """
         Plot a basemap.
 
@@ -136,16 +135,17 @@ class GridMapDisplay():
 
         self.basemap.drawcoastlines(linewidth=1.25)
         self.basemap.drawstates()
-        self.basemap.drawparallels(lat_lines,
-                                   labels=[True, False, False, False])
-        self.basemap.drawmeridians(lon_lines,
-                                   labels=[False, False, False, True])
+        self.basemap.drawparallels(
+            lat_lines, labels=[True, False, False, False])
+        self.basemap.drawmeridians(
+            lon_lines, labels=[False, False, False, True])
 
-    def plot_grid(self, field, level=0, vmin=None, vmax=None, cmap='jet',
-                  mask_outside=False, title=None, title_flag=True,
-                  axislabels=(None, None), axislabels_flag=False,
-                  colorbar_flag=True, colorbar_label=None,
-                  colorbar_orient='vertical', edges=True, ax=None, fig=None):
+    def plot_grid(
+            self, field, level=0, vmin=None, vmax=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=False,
+            colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True, ax=None, fig=None):
         """
         Plot the grid onto the current basemap.
 
@@ -237,14 +237,14 @@ class GridMapDisplay():
             self._label_axes_grid(axislabels, ax)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orientation=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orientation=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
         return
 
-    def plot_crosshairs(self, lon=None, lat=None,
-                        line_style='r--', linewidth=2, ax=None):
+    def plot_crosshairs(
+            self, lon=None, lat=None, line_style='r--', linewidth=2, ax=None):
         """
         Plot crosshairs at a given longitude and latitude.
 
@@ -277,13 +277,12 @@ class GridMapDisplay():
         ax.plot(x_lat, y_lat, line_style, linewidth=linewidth)
         return
 
-    def plot_latitude_slice(self, field, lon=None, lat=None,
-                            vmin=None, vmax=None, cmap='jet',
-                            mask_outside=False, title=None, title_flag=True,
-                            axislabels=(None, None), axislabels_flag=True,
-                            colorbar_flag=True, colorbar_label=None,
-                            colorbar_orient='vertical', edges=True, ax=None,
-                            fig=None):
+    def plot_latitude_slice(
+            self, field, lon=None, lat=None, vmin=None, vmax=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
+            colorbar_label=None, colorbar_orient='vertical', edges=True,
+            ax=None, fig=None):
         """
         Plot a slice along a given latitude.
 
@@ -337,8 +336,7 @@ class GridMapDisplay():
 
         """
         # parse parameters
-
-        x_index, y_index = self._find_nearest_grid_indices(lon, lat)
+        _, y_index = self._find_nearest_grid_indices(lon, lat)
         self.plot_latitudinal_level(
             field=field, y_index=y_index, vmin=vmin, vmax=vmax, cmap=cmap,
             mask_outside=mask_outside, title=title, title_flag=title_flag,
@@ -346,13 +344,12 @@ class GridMapDisplay():
             colorbar_flag=colorbar_flag, colorbar_label=colorbar_label,
             colorbar_orient=colorbar_orient, edges=edges, ax=ax, fig=fig)
 
-    def plot_latitudinal_level(self, field, y_index,
-                               vmin=None, vmax=None, cmap='jet',
-                               mask_outside=False, title=None, title_flag=True,
-                               axislabels=(None, None), axislabels_flag=True,
-                               colorbar_flag=True, colorbar_label=None,
-                               colorbar_orient='vertical', edges=True,
-                               ax=None, fig=None):
+    def plot_latitudinal_level(
+            self, field, y_index, vmin=None, vmax=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
+            colorbar_label=None, colorbar_orient='vertical', edges=True,
+            ax=None, fig=None):
         """
         Plot a slice along a given latitude.
 
@@ -408,8 +405,6 @@ class GridMapDisplay():
         ax, fig = common.parse_ax_fig(ax, fig)
         vmin, vmax = common.parse_vmin_vmax(self.grid, field, vmin, vmax)
 
-        basemap = self.get_basemap()
-
         data = self.grid.fields[field]['data'][:, y_index, :]
 
         # mask the data where outside the limits
@@ -441,18 +436,17 @@ class GridMapDisplay():
             self._label_axes_latitude(axislabels, ax)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orientation=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orientation=colorbar_orient,
+                field=field, ax=ax, fig=fig)
         return
 
-    def plot_longitude_slice(self, field, lon=None, lat=None,
-                             vmin=None, vmax=None, cmap='jet',
-                             mask_outside=False, title=None, title_flag=True,
-                             axislabels=(None, None), axislabels_flag=True,
-                             colorbar_flag=True, colorbar_label=None,
-                             colorbar_orient='vertical', edges=True, ax=None,
-                             fig=None):
+    def plot_longitude_slice(
+            self, field, lon=None, lat=None, vmin=None, vmax=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
+            colorbar_label=None, colorbar_orient='vertical', edges=True,
+            ax=None, fig=None):
         """
         Plot a slice along a given longitude.
 
@@ -505,7 +499,7 @@ class GridMapDisplay():
             Figure to add the colorbar to. None will use the current figure.
 
         """
-        x_index, y_index = self._find_nearest_grid_indices(lon, lat)
+        x_index, _ = self._find_nearest_grid_indices(lon, lat)
         self.plot_longitudinal_level(
             field=field, x_index=x_index, vmin=vmin, vmax=vmax, cmap=cmap,
             mask_outside=mask_outside, title=title, title_flag=title_flag,
@@ -513,14 +507,12 @@ class GridMapDisplay():
             colorbar_flag=colorbar_flag, colorbar_label=colorbar_label,
             colorbar_orient=colorbar_orient, edges=edges, ax=ax, fig=fig)
 
-    def plot_longitudinal_level(self, field, x_index,
-                                vmin=None, vmax=None, cmap='jet',
-                                mask_outside=False, title=None,
-                                title_flag=True, axislabels=(None, None),
-                                axislabels_flag=True, colorbar_flag=True,
-                                colorbar_label=None,
-                                colorbar_orient='vertical', edges=True,
-                                ax=None, fig=None):
+    def plot_longitudinal_level(
+            self, field, x_index, vmin=None, vmax=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
+            colorbar_label=None, colorbar_orient='vertical', edges=True,
+            ax=None, fig=None):
         """
         Plot a slice along a given longitude.
 
@@ -576,8 +568,6 @@ class GridMapDisplay():
         ax, fig = common.parse_ax_fig(ax, fig)
         vmin, vmax = common.parse_vmin_vmax(self.grid, field, vmin, vmax)
 
-        basemap = self.get_basemap()
-
         data = self.grid.fields[field]['data'][:, :, x_index]
 
         # mask the data where outside the limits
@@ -609,13 +599,14 @@ class GridMapDisplay():
             self._label_axes_longitude(axislabels, ax)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orientation=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orientation=colorbar_orient,
+                field=field, ax=ax, fig=fig)
         return
 
-    def plot_colorbar(self, mappable=None, orientation='horizontal',
-                      label=None, cax=None, ax=None, fig=None, field=None):
+    def plot_colorbar(
+            self, mappable=None, orientation='horizontal', label=None,
+            cax=None, ax=None, fig=None, field=None):
         """
         Plot a colorbar.
 
@@ -663,9 +654,10 @@ class GridMapDisplay():
 
         return
 
-    def _make_basemap(self, resolution='l', area_thresh=10000,
-                      auto_range=True, min_lon=-92, max_lon=-86,
-                      min_lat=40, max_lat=44, ax=None, **kwargs):
+    def _make_basemap(
+            self, resolution='l', area_thresh=10000, auto_range=True,
+            min_lon=-92, max_lon=-86, min_lat=40, max_lat=44, ax=None,
+            **kwargs):
         """
         Make a basemap.
 
@@ -762,15 +754,15 @@ class GridMapDisplay():
 
     def _get_label_x(self):
         """ Get default label for x units. """
-        return ('East West distance from ' + self.origin + ' (km)')
+        return 'East West distance from ' + self.origin + ' (km)'
 
     def _get_label_y(self):
         """ Get default label for y units. """
-        return ('North South distance from ' + self.origin + ' (km)')
+        return 'North South distance from ' + self.origin + ' (km)'
 
     def _get_label_z(self):
         """ Get default label for z units. """
-        return ('Distance Above ' + self.origin + '  (km)')
+        return 'Distance Above ' + self.origin + '  (km)'
 
     def _label_axes_grid(self, axis_labels, ax):
         """ Set the x and y axis labels for a grid plot. """
@@ -866,8 +858,8 @@ class GridMapDisplay():
             Plot title.
 
         """
-        return common.generate_longitudinal_level_title(self.grid, field,
-                                                        level)
+        return common.generate_longitudinal_level_title(
+            self.grid, field, level)
 
     def generate_latitudinal_level_title(self, field, level):
         """
@@ -886,8 +878,8 @@ class GridMapDisplay():
             Plot title.
 
         """
-        return common.generate_latitudinal_level_title(self.grid, field,
-                                                       level)
+        return common.generate_latitudinal_level_title(
+            self.grid, field, level)
 
     ##########################
     #      get methods       #

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -298,8 +298,7 @@ class RadarDisplay(object):
                  cmap='jet', mask_outside=False, title=None, title_flag=True,
                  axislabels=(None, None), axislabels_flag=True,
                  colorbar_flag=True, colorbar_label=None,
-                 colorbar_orient='vertical', edges=True,
-                 gatefilter=None,
+                 colorbar_orient='vertical', edges=True, gatefilter=None,
                  filter_transitions=True, ax=None, fig=None):
         """
         Plot a PPI.
@@ -1293,14 +1292,12 @@ class RadarDisplay(object):
 
     def _get_x_z(self, field, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, _, z = self._get_x_y_z(field, sweep, edges,
-                                  filter_transitions=filter_transitions)
+        x, _, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
         return x, z
 
     def _get_x_y(self, field, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, y, _ = self._get_x_y_z(field, sweep, edges,
-                                  filter_transitions=filter_transitions)
+        x, y, _ = self._get_x_y_z(field, sweep, edges, filter_transitions)
         return x, y
 
     def _get_x_y_z(self, field, sweep, edges, filter_transitions):

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -46,8 +46,6 @@ class RadarDisplay(object):
         List of fields plotted, order matches plot list.
     cbs : list
         List of colorbars created.
-    radar_name : str
-        Name of radar.
     origin : str
         'Origin' or 'Radar'.
     shift : (float, float)
@@ -90,10 +88,6 @@ class RadarDisplay(object):
             self.antenna_transition = None
         else:
             self.antenna_transition = radar.antenna_transition['data']
-        if 'instrument_name' in radar.metadata:
-            self.radar_name = radar.metadata['instrument_name']
-        else:
-            self.radar_name = ''
 
         # origin
         if shift != (0.0, 0.0):
@@ -136,6 +130,17 @@ class RadarDisplay(object):
         units = self._radar.time['units']
         calendar = self._radar.time['calendar']
         return netCDF4.num2date(times, units, calendar)
+
+    @property
+    def radar_name(self):
+        warnings.warn(
+            "The 'radar_name' attribute has been depreciated and will be "
+            "removed in future versions of Py-ART",
+            category=DepreciatedAttribute)
+        if 'instrument_name' in self._radar.metadata:
+            return self._radar.metadata['instrument_name']
+        else:
+            return ''
 
     def _calculate_localization(self, radar):
         """ Calculate self.x, self.y, self.z and self.loc. """

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -58,8 +58,6 @@ class RadarDisplay(object):
         Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
-    time_begin : datetime
-        Beginning time of first radar scan.
     fields : dict
         Radar fields.
     scan_type : str
@@ -108,11 +106,6 @@ class RadarDisplay(object):
         self.shift = shift
         self._calculate_localization(radar)
 
-        # datetime object describing first sweep time
-        times = radar.time['data'][0]
-        units = radar.time['units']
-        calendar = radar.time['calendar']
-        self.time_begin = netCDF4.num2date(times, units, calendar)
 
         # list to hold plots, plotted fields and plotted colorbars
         self.plots = []
@@ -134,6 +127,18 @@ class RadarDisplay(object):
             "The 'ends' attribute has been depreciated and will be removed"
             "in future version of Py-ART", category=DepreciatedAttribute)
         return self._radar.sweep_end_ray_index['data']
+
+    @property
+    def time_begin(self):
+        """ Depeciated datetime object describing first sweep time. """
+        warnings.warn(
+            "The 'time_begin' attribute has been depreciated and will be "
+            "removed in future versions of Py-ART",
+            category=DepreciatedAttribute)
+        times = self._radar.time['data'][0]
+        units = self._radar.time['units']
+        calendar = self._radar.time['calendar']
+        return netCDF4.num2date(times, units, calendar)
 
     def _calculate_localization(self, radar):
         """ Calculate self.x, self.y, self.z and self.loc. """

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -192,7 +192,6 @@ class RadarDisplay(object):
     def plot_ray(self, field, ray, format_str='k-', mask_tuple=None,
                  ray_min=None, ray_max=None, mask_outside=False, title=None,
                  title_flag=True, axislabels=(None, None),
-                 filter_transitions=True,
                  axislabels_flag=True, ax=None, fig=None):
         """
         Plot a single ray.
@@ -233,11 +232,6 @@ class RadarDisplay(object):
             False.
         axislabel_flag : bool
             True to add label the axes, False does not label the axes.
-        filter_transitions : bool
-            True to remove rays where the antenna was in transition between
-            sweeps from the plot.  False will include these rays in the plot.
-            No rays are filtered when the antenna_transition attribute of the
-            underlying radar is not present.
         ax : Axis
             Axis to plot on. None will use the current axis.
         fig : Figure
@@ -248,7 +242,7 @@ class RadarDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
 
         # get the data and mask
-        data = self._get_ray_data(field, ray, mask_tuple, filter_transitions)
+        data = self._get_ray_data(field, ray, mask_tuple)
 
         # mask the data where outside the limits
         if mask_outside:
@@ -1218,7 +1212,7 @@ class RadarDisplay(object):
 
         return data.T
 
-    def _get_ray_data(self, field, ray, mask_tuple, filter_transitions):
+    def _get_ray_data(self, field, ray, mask_tuple):
         """ Retrieve and return ray data from a plot function. """
         data = self.fields[field]['data'][ray]
 
@@ -1226,11 +1220,6 @@ class RadarDisplay(object):
             mask_field, mask_value = mask_tuple
             mdata = self.fields[mask_field]['data'][ray]
             data = np.ma.masked_where(mdata < mask_value, data)
-
-        # filter out antenna transitions
-        if filter_transitions and self.antenna_transition is not None:
-            in_trans = self.antenna_transition[ray]
-            data = data[in_trans == 0]
 
         return data
 

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -373,7 +373,7 @@ class RadarDisplay(object):
         # get data for the plot
         data = self._get_data(
             field, sweep, mask_tuple, filter_transitions, gatefilter)
-        x, y = self._get_x_y(field, sweep, edges, filter_transitions)
+        x, y = self._get_x_y(sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
         _mask_outside(mask_outside, data, vmin, vmax)
@@ -477,7 +477,7 @@ class RadarDisplay(object):
         # get data for the plot
         data = self._get_data(
             field, sweep, mask_tuple, filter_transitions, gatefilter)
-        x, y, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
+        x, y, z = self._get_x_y_z(sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
         _mask_outside(mask_outside, data, vmin, vmax)
@@ -1290,17 +1290,17 @@ class RadarDisplay(object):
         z = z / 1000.0
         return data, x, y, z
 
-    def _get_x_z(self, field, sweep, edges, filter_transitions):
+    def _get_x_z(self, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, _, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
+        x, _, z = self._get_x_y_z(sweep, edges, filter_transitions)
         return x, z
 
-    def _get_x_y(self, field, sweep, edges, filter_transitions):
+    def _get_x_y(self, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, y, _ = self._get_x_y_z(field, sweep, edges, filter_transitions)
+        x, y, _ = self._get_x_y_z(sweep, edges, filter_transitions)
         return x, y
 
-    def _get_x_y_z(self, field, sweep, edges, filter_transitions):
+    def _get_x_y_z(self, sweep, edges, filter_transitions):
         """ Retrieve and return x, y, and z coordinate in km. """
         sweep_slice = self._radar.get_slice(sweep)
         azimuths = self.azimuths[sweep_slice]

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -23,7 +23,7 @@ from . import common
 from ..exceptions import DepreciatedAttribute
 from ..core.transforms import antenna_to_cartesian
 from ..core.transforms import antenna_vectors_to_cartesian
-from ..core.transforms import corner_to_point
+from ..core.transforms import geographic_to_cartesian_aeqd
 from ..util.datetime_utils import datetimes_from_radar
 
 
@@ -843,6 +843,10 @@ class RadarDisplay(object):
         """
         Plot a single symbol and label at a given location.
 
+        Transforms of the symbol location in latitude and longitude units to
+        x and y plot units is performed using an azimuthal equidistance
+        map projection centered at the radar.
+
         Parameters
         ----------
         label : str
@@ -860,11 +864,14 @@ class RadarDisplay(object):
 
         """
         ax = common.parse_ax(ax)
-        loc_x, loc_y = corner_to_point(self.loc, location)
-        loc_x /= 1000.0
-        loc_y /= 1000.0
-        ax.plot([loc_x], [loc_y], symbol)
-        ax.text(loc_x - 5.0, loc_y, label, color=text_color)
+        location_lat, location_lon = location
+        radar_lat, radar_lon = self.loc
+        location_x, location_y = geographic_to_cartesian_aeqd(
+            location_lon, location_lat, radar_lon, radar_lat)
+        location_x /= 1000.0
+        location_y /= 1000.0
+        ax.plot([location_x], [location_y], symbol)
+        ax.text(location_x - 5.0, location_y, label, color=text_color)
 
     @staticmethod
     def plot_cross_hair(size, npts=100, ax=None):

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -739,8 +739,9 @@ class RadarDisplay(object):
             self.plot_range_ring(range_ring_location_km, ax=ax, col=col,
                                  ls=ls, lw=lw)
 
-    def plot_range_ring(self, range_ring_location_km, npts=100, ax=None,
-                        col='k', ls='-', lw=2):
+    @staticmethod
+    def plot_range_ring(
+            range_ring_location_km, npts=100, ax=None, col='k', ls='-', lw=2):
         """
         Plot a single range ring.
 
@@ -765,7 +766,8 @@ class RadarDisplay(object):
         y = r * np.cos(theta)
         ax.plot(x, y, c=col, ls=ls, lw=lw)
 
-    def plot_grid_lines(self, ax=None, col='k', ls=':', lw=2):
+    @staticmethod
+    def plot_grid_lines(ax=None, col='k', ls=':'):
         """
         Plot grid lines.
 
@@ -844,7 +846,8 @@ class RadarDisplay(object):
         ax.plot([loc_x], [loc_y], symbol)
         ax.text(loc_x - 5.0, loc_y, label, color=text_color)
 
-    def plot_cross_hair(self, size, npts=100, ax=None):
+    @staticmethod
+    def plot_cross_hair(size, npts=100, ax=None):
         """
         Plot a cross-hair on a ppi plot.
 
@@ -906,7 +909,8 @@ class RadarDisplay(object):
     # Plot adjusting methods #
     ##########################
 
-    def set_limits(self, xlim=None, ylim=None, ax=None):
+    @staticmethod
+    def set_limits(xlim=None, ylim=None, ax=None):
         """
         Set the display limits.
 
@@ -942,12 +946,14 @@ class RadarDisplay(object):
         ax = common.parse_ax(ax)
         ax.set_ylabel('Distance Above ' + self.origin + '  (km)')
 
-    def label_xaxis_rays(self, ax=None):
+    @staticmethod
+    def label_xaxis_rays(ax=None):
         """ Label the yaxis with the default label for rays. """
         ax = common.parse_ax(ax)
         ax.set_xlabel('Ray number (unitless)')
 
-    def label_xaxis_time(self, ax=None):
+    @staticmethod
+    def label_xaxis_time(ax=None):
         """ Label the yaxis with the default label for rays. """
         ax = common.parse_ax(ax)
         ax.set_xlabel('Time (HH:MM)')
@@ -957,7 +963,8 @@ class RadarDisplay(object):
         ax = common.parse_ax(ax)
         ax.set_ylabel(self._get_colorbar_label(field))
 
-    def set_aspect_ratio(self, aspect_ratio=0.75, ax=None):
+    @staticmethod
+    def set_aspect_ratio(aspect_ratio=0.75, ax=None):
         """ Set the aspect ratio for plot area. """
         ax = common.parse_ax(ax)
         ax.set_aspect(aspect_ratio)
@@ -1041,7 +1048,8 @@ class RadarDisplay(object):
         else:
             ax.set_ylabel(y_label)
 
-    def _set_vpt_time_axis(self, ax, date_time_form=None, tz=None):
+    @staticmethod
+    def _set_vpt_time_axis(ax, date_time_form=None, tz=None):
         """ Set the x axis as a time formatted axis.
 
         Parameters

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -50,8 +50,6 @@ class RadarDisplay(object):
         'Origin' or 'Radar'.
     shift : (float, float)
         Shift in meters.
-    x, y, z : array
-        Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
     fields : dict
@@ -96,7 +94,22 @@ class RadarDisplay(object):
             self.origin = 'radar'
 
         self.shift = shift
-        self._calculate_localization(radar)
+
+        # radar location in latitude and longitude
+        if radar.latitude['data'].size == 1:
+            lat = float(radar.latitude['data'])
+            lon = float(radar.longitude['data'])
+        else:
+            # for moving platforms stores use the median location.
+            # The RadarDisplay object does not give a proper
+            # visualization for moving platform data as the origin
+            # of each ray changes and needs to be calculated individually or
+            # georeferences.  When that is not available the following
+            # gives acceptable results.
+            lat = np.median(radar.latitude['data'])
+            lon = np.median(radar.longitude['data'])
+            warnings.warn('RadarDisplay does not correct for moving platforms')
+        self.loc = (lat, lon)
 
         # list to hold plots, plotted fields and plotted colorbars
         self.plots = []
@@ -133,6 +146,7 @@ class RadarDisplay(object):
 
     @property
     def radar_name(self):
+        """ Depreciated radar_name attribute. """
         warnings.warn(
             "The 'radar_name' attribute has been depreciated and will be "
             "removed in future versions of Py-ART",
@@ -142,31 +156,35 @@ class RadarDisplay(object):
         else:
             return ''
 
-    def _calculate_localization(self, radar):
-        """ Calculate self.x, self.y, self.z and self.loc. """
-        # x, y, z attributes: cartesian location for a sweep in km.
+    @property
+    def x(self):
+        """ Depreciated x coordinate attribute. """
+        warnings.warn(
+            "The 'x' attribute has been depreciated and will be removed in "
+            "future versions of Py-ART", category=DepreciatedAttribute)
         rg, azg = np.meshgrid(self.ranges, self.azimuths)
         rg, eleg = np.meshgrid(self.ranges, self.elevations)
+        return antenna_to_cartesian(rg / 1000.0, azg, eleg)[0] + self.shift[0]
 
-        self.x, self.y, self.z = antenna_to_cartesian(rg / 1000.0, azg, eleg)
-        self.x = self.x + self.shift[0]
-        self.y = self.y + self.shift[1]
+    @property
+    def y(self):
+        """ Depreciated y coordinate attribute. """
+        warnings.warn(
+            "The 'z' attribute has been depreciated and will be removed in "
+            "future versions of Py-ART", category=DepreciatedAttribute)
+        rg, azg = np.meshgrid(self.ranges, self.azimuths)
+        rg, eleg = np.meshgrid(self.ranges, self.elevations)
+        return antenna_to_cartesian(rg / 1000.0, azg, eleg)[1] + self.shift[1]
 
-        # radar location in latitude and longitude
-        if radar.latitude['data'].size == 1:
-            lat = float(radar.latitude['data'])
-            lon = float(radar.longitude['data'])
-        else:
-            # for moving platforms stores use the median location.
-            # The RadarDisplay object does not give a proper
-            # visualization for moving platform data as the origin
-            # of each ray changes and needs to be calculated individually or
-            # georeferences.  When that is not available the following
-            # gives acceptable results.
-            lat = np.median(radar.latitude['data'])
-            lon = np.median(radar.longitude['data'])
-            warnings.warn('RadarDisplay does not correct for moving platforms')
-        self.loc = (lat, lon)
+    @property
+    def z(self):
+        """ Depreciated z coordinate attribute. """
+        warnings.warn(
+            "The 'z' attribute has been depreciated and will be removed in "
+            "future versions of Py-ART", category=DepreciatedAttribute)
+        rg, azg = np.meshgrid(self.ranges, self.azimuths)
+        rg, eleg = np.meshgrid(self.ranges, self.elevations)
+        return antenna_to_cartesian(rg / 1000.0, azg, eleg)[2]
 
     ####################
     # Plotting methods #

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -254,9 +254,7 @@ class RadarDisplay(object):
         data = self._get_ray_data(field, ray, mask_tuple)
 
         # mask the data where outside the limits
-        if mask_outside:
-            data = np.ma.masked_invalid(data)
-            data = np.ma.masked_outside(data, ray_min, ray_max)
+        _mask_outside(mask_outside, data, ray_min, ray_max)
 
         # plot the data
         line, = ax.plot(self.ranges / 1000., data, format_str)
@@ -349,14 +347,12 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
-                              gatefilter)
+        data = self._get_data(
+            field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, y = self._get_x_y(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
-        if mask_outside:
-            data = np.ma.masked_invalid(data)
-            data = np.ma.masked_outside(data, vmin, vmax)
+        _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
         pm = ax.pcolormesh(x, y, data, vmin=vmin, vmax=vmax, cmap=cmap)
@@ -460,9 +456,7 @@ class RadarDisplay(object):
         x, y, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
-        if mask_outside:
-            data = np.ma.masked_invalid(data)
-            data = np.ma.masked_outside(data, vmin, vmax)
+        _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
         R = np.sqrt(x ** 2 + y ** 2) * np.sign(y)
@@ -592,9 +586,7 @@ class RadarDisplay(object):
             x = datetimes_from_radar(self._radar)
 
         # mask the data where outside the limits
-        if mask_outside:
-            data = np.ma.masked_invalid(data)
-            data = np.ma.masked_outside(data, vmin, vmax)
+        _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
         pm = ax.pcolormesh(x, y, data, vmin=vmin, vmax=vmax, cmap=cmap)
@@ -700,9 +692,7 @@ class RadarDisplay(object):
             filter_transitions, gatefilter)
 
         # mask the data where outside the limits
-        if mask_outside:
-            data = np.ma.masked_invalid(data)
-            data = np.ma.masked_outside(data, vmin, vmax)
+        _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
         R = np.sqrt(x ** 2 + y ** 2) * np.sign(y)
@@ -1317,3 +1307,11 @@ class RadarDisplay(object):
         else:
             units = '?'
         return common.generate_colorbar_label(standard_name, units)
+
+
+def _mask_outside(flag, data, v1, v2):
+    """ Return the data masked outside of v1 and v2 when flag is True.  """
+    if flag:
+        data = np.ma.masked_invalid(data)
+        data = np.ma.masked_outside(data, v1, v2)
+    return data

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -15,11 +15,9 @@ Class for creating plots from Radar objects.
 import warnings
 
 import matplotlib.pyplot as plt
+from matplotlib.dates import DateFormatter
 import numpy as np
 import netCDF4
-from matplotlib.dates import (
-    DateFormatter, SecondLocator, MinuteLocator,
-    HourLocator, DayLocator)
 
 from . import common
 from ..exceptions import DepreciatedAttribute
@@ -106,7 +104,6 @@ class RadarDisplay(object):
         self.shift = shift
         self._calculate_localization(radar)
 
-
         # list to hold plots, plotted fields and plotted colorbars
         self.plots = []
         self.plot_vars = []
@@ -117,7 +114,7 @@ class RadarDisplay(object):
         """ Depreciated starts attribute. """
         warnings.warn(
             "The 'starts' attribute has been depreciated and will be removed"
-            "in future version of Py-ART", category=DepreciatedAttribute)
+            "in future versions of Py-ART", category=DepreciatedAttribute)
         return self._radar.sweep_start_ray_index['data']
 
     @property
@@ -125,7 +122,7 @@ class RadarDisplay(object):
         """ Depreciated starts attribute. """
         warnings.warn(
             "The 'ends' attribute has been depreciated and will be removed"
-            "in future version of Py-ART", category=DepreciatedAttribute)
+            "in future versions of Py-ART", category=DepreciatedAttribute)
         return self._radar.sweep_end_ray_index['data']
 
     @property
@@ -373,9 +370,9 @@ class RadarDisplay(object):
         self.plot_vars.append(field)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orient=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orient=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
     def plot_rhi(self, field, sweep=0, mask_tuple=None, vmin=None, vmax=None,
                  cmap='jet', mask_outside=False, title=None, title_flag=True,
@@ -456,8 +453,8 @@ class RadarDisplay(object):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
-                              gatefilter)
+        data = self._get_data(
+            field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, y, z = self._get_x_y_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -466,7 +463,7 @@ class RadarDisplay(object):
         # plot the data
         R = np.sqrt(x ** 2 + y ** 2) * np.sign(y)
         if reverse_xaxis is None:
-            # reverse if all distances (nearly, up to 1 m) negative.
+            # reverse if all distances are nearly negative (allow up to 1 m)
             reverse_xaxis = np.all(R < 1.)
         if reverse_xaxis:
             R = -R
@@ -483,19 +480,17 @@ class RadarDisplay(object):
         self.plot_vars.append(field)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orient=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orient=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
     def plot_vpt(self, field, mask_tuple=None, vmin=None, vmax=None,
                  cmap='jet', mask_outside=False, title=None, title_flag=True,
                  axislabels=(None, None), axislabels_flag=True,
                  colorbar_flag=True, colorbar_label=None,
                  colorbar_orient='vertical', edges=True,
-                 filter_transitions=True,
-                 time_axis_flag=False,
-                 date_time_form=None, tz=None,
-                 ax=None, fig=None):
+                 filter_transitions=True, time_axis_flag=False,
+                 date_time_form=None, tz=None, ax=None, fig=None):
         """
         Plot a VPT scan.
 
@@ -573,8 +568,7 @@ class RadarDisplay(object):
         # get data for the plot
         data = self._get_vpt_data(field, mask_tuple, filter_transitions)
         if edges:
-            y = np.empty((self.ranges.shape[0] + 1, ),
-                         dtype=self.ranges.dtype)
+            y = np.empty((self.ranges.shape[0] + 1, ), dtype=self.ranges.dtype)
             y[1:-1] = (self.ranges[:-1] + self.ranges[1:]) / 2.
             y[0] = self.ranges[0] - (self.ranges[1] - self.ranges[0]) / 2.
             y[-1] = self.ranges[-1] - (self.ranges[-2] - self.ranges[-1]) / 2.
@@ -607,9 +601,9 @@ class RadarDisplay(object):
         self.plot_vars.append(field)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orient=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orient=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
     def plot_azimuth_to_rhi(self, field, target_azimuth,
                             mask_tuple=None, vmin=None, vmax=None,
@@ -719,12 +713,11 @@ class RadarDisplay(object):
         self.plot_vars.append(field)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orient=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orient=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
-    def plot_range_rings(self, range_rings, ax=None, col='k', ls='-',
-                         lw=2):
+    def plot_range_rings(self, range_rings, ax=None, col='k', ls='-', lw=2):
         """
         Plot a series of range rings.
 
@@ -741,8 +734,8 @@ class RadarDisplay(object):
 
         """
         for range_ring_location_km in range_rings:
-            self.plot_range_ring(range_ring_location_km, ax=ax, col=col,
-                                 ls=ls, lw=lw)
+            self.plot_range_ring(
+                range_ring_location_km, ax=ax, col=col, ls=ls, lw=lw)
 
     @staticmethod
     def plot_range_ring(
@@ -789,8 +782,8 @@ class RadarDisplay(object):
         ax = common.parse_ax(ax)
         ax.grid(c=col, ls=ls)
 
-    def plot_labels(self, labels, locations, symbols='r+', text_color='k',
-                    ax=None):
+    def plot_labels(
+            self, labels, locations, symbols='r+', text_color='k', ax=None):
         """
         Plot symbols and labels at given locations.
 
@@ -823,8 +816,8 @@ class RadarDisplay(object):
         for loc, label, sym in zip(locations, labels, symbols):
             self.plot_label(label, loc, sym, text_color, ax)
 
-    def plot_label(self, label, location, symbol='r+', text_color='k',
-                   ax=None):
+    def plot_label(
+            self, label, location, symbol='r+', text_color='k', ax=None):
         """
         Plot a single symbol and label at a given location.
 
@@ -1065,6 +1058,7 @@ class RadarDisplay(object):
             Format of the time string for x-axis labels.
         tz : str
             Time zone info to use when creating axis labels (see datetime).
+
         """
         if date_time_form is None:
             date_time_form = '%H:%M'
@@ -1276,13 +1270,13 @@ class RadarDisplay(object):
 
     def _get_x_z(self, field, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, y, z = self._get_x_y_z(field, sweep, edges,
+        x, _, z = self._get_x_y_z(field, sweep, edges,
                                   filter_transitions=filter_transitions)
         return x, z
 
     def _get_x_y(self, field, sweep, edges, filter_transitions):
         """ Retrieve and return x and y coordinate in km. """
-        x, y, z = self._get_x_y_z(field, sweep, edges,
+        x, y, _ = self._get_x_y_z(field, sweep, edges,
                                   filter_transitions=filter_transitions)
         return x, y
 

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -1302,21 +1302,12 @@ class RadarDisplay(object):
 
     def _get_x_y_z(self, sweep, edges, filter_transitions):
         """ Retrieve and return x, y, and z coordinate in km. """
-        sweep_slice = self._radar.get_slice(sweep)
-        azimuths = self.azimuths[sweep_slice]
-        elevations = self.elevations[sweep_slice]
-
-        if filter_transitions and self.antenna_transition is not None:
-            in_trans = self.antenna_transition[sweep_slice]
-            azimuths = azimuths[in_trans == 0]
-            elevations = elevations[in_trans == 0]
-
-        x, y, z = antenna_vectors_to_cartesian(
-            self.ranges, azimuths, elevations, edges=edges)
+        x, y, z = self._radar.get_gate_x_y_z(
+            sweep, edges=edges, filter_transitions=filter_transitions)
+        # add shift and convert to km
         x = (x + self.shift[0]) / 1000.0
         y = (y + self.shift[1]) / 1000.0
         z = z / 1000.0
-
         return x, y, z
 
     def _get_colorbar_label(self, field):

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -50,8 +50,6 @@ class AirborneRadarDisplay(RadarDisplay):
         Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
-    time_begin : datetime
-        Beginning time of first radar scan.
     starts : array
         Starting ray index for each sweep.
     ends : array

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -289,19 +289,18 @@ class AirborneRadarDisplay(RadarDisplay):
 
     def _get_x_y_z(self, field, sweep, edges, filter_transitions):
         """ Retrieve and return x, y, and z coordinate in km. """
-        start = self.starts[sweep]
-        end = self.ends[sweep] + 1
+        sweep_slice = self._radar.get_slice(sweep)
 
         if self._radar.metadata['platform_type'] == 'aircraft_belly':
             if filter_transitions and self.antenna_transition is not None:
-                in_trans = self.antenna_transition[start:end]
+                in_trans = self.antenna_transition[sweep_slice]
                 ranges = self.ranges
                 azimuths = self.azimuths[in_trans == 0]
                 elevations = self.elevations[in_trans == 0]
             else:
                 ranges = self.ranges
-                azimuths = self.azimuths[start:end]
-                elevations = self.elevations[start:end]
+                azimuths = self.azimuths[sweep_slice]
+                elevations = self.elevations[sweep_slice]
 
             if edges:
                 if len(ranges) != 1:
@@ -318,7 +317,7 @@ class AirborneRadarDisplay(RadarDisplay):
 
         else:
             if filter_transitions and self.antenna_transition is not None:
-                in_trans = self.antenna_transition[start:end]
+                in_trans = self.antenna_transition[sweep_slice]
                 ranges = self.ranges
                 rotation = self.rotation[in_trans == 0]
                 roll = self.roll[in_trans == 0]
@@ -327,11 +326,11 @@ class AirborneRadarDisplay(RadarDisplay):
                 pitch = self.pitch[in_trans == 0]
             else:
                 ranges = self.ranges
-                rotation = self.rotation[start:end]
-                roll = self.roll[start:end]
-                drift = self.drift[start:end]
-                tilt = self.tilt[start:end]
-                pitch = self.pitch[start:end]
+                rotation = self.rotation[sweep_slice]
+                roll = self.roll[sweep_slice]
+                drift = self.drift[sweep_slice]
+                tilt = self.tilt[sweep_slice]
+                pitch = self.pitch[sweep_slice]
 
             if edges:
                 if len(ranges) != 1:

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -227,7 +227,7 @@ class AirborneRadarDisplay(RadarDisplay):
         # get data for the plot
         data = self._get_data(
             field, sweep, mask_tuple, filter_transitions, gatefilter)
-        x, z = self._get_x_z(field, sweep, edges, filter_transitions)
+        x, z = self._get_x_z(sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
         if mask_outside:
@@ -268,7 +268,7 @@ class AirborneRadarDisplay(RadarDisplay):
         ax = common.parse_ax(ax)
         ax.set_ylabel('Distance Above ' + self.origin + '  (km)')
 
-    def _get_x_y_z(self, field, sweep, edges, filter_transitions):
+    def _get_x_y_z(self, sweep, edges, filter_transitions):
         """ Retrieve and return x, y, and z coordinate in km. """
         sweep_slice = self._radar.get_slice(sweep)
 

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -44,8 +44,6 @@ class AirborneRadarDisplay(RadarDisplay):
         'Origin' or 'Radar'.
     shift : (float, float)
         Shift in meters.
-    x, y, z : array
-        Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
     starts : array

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -40,8 +40,6 @@ class AirborneRadarDisplay(RadarDisplay):
         List of fields plotted, order matches plot list.
     cbs : list
         List of colorbars created.
-    radar_name : str
-        Name of radar.
     origin : str
         'Origin' or 'Radar'.
     shift : (float, float)

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -13,13 +13,13 @@ Class for creating plots from Airborne Radar objects.
 """
 
 import numpy as np
-import netCDF4
 
 from .radardisplay import RadarDisplay
 from . import common
 from ..core.transforms import antenna_to_cartesian
 from ..core.transforms import antenna_to_cartesian_track_relative
 from ..core import transforms
+
 
 class AirborneRadarDisplay(RadarDisplay):
     """
@@ -46,10 +46,6 @@ class AirborneRadarDisplay(RadarDisplay):
         Shift in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
-    starts : array
-        Starting ray index for each sweep.
-    ends : array
-        Ending ray index for each sweep.
     fields : dict
         Radar fields.
     scan_type : str
@@ -77,7 +73,6 @@ class AirborneRadarDisplay(RadarDisplay):
     altitude : array
         Altitude angle in meters.
 
-
     """
 
     def __init__(self, radar, shift=(0.0, 0.0)):
@@ -91,11 +86,7 @@ class AirborneRadarDisplay(RadarDisplay):
         self.pitch = radar.pitch['data']
         self.altitude = radar.altitude['data']
         super(AirborneRadarDisplay, self).__init__(radar, shift)
-
-    def _calculate_localization(self, radar):
-        """ Calculate self.x, self.y, self.z and self.loc. """
         # x, y, z attributes: cartesian location for a sweep in km.
-
         if radar.metadata['platform_type'] == 'aircraft_belly':
             rg, azg = np.meshgrid(self.ranges, self.azimuths)
             rg, eleg = np.meshgrid(self.ranges, self.elevations)
@@ -157,13 +148,12 @@ class AirborneRadarDisplay(RadarDisplay):
             raise ValueError('unknown scan_type % s' % (self.scan_type))
         return
 
-    def plot_sweep_grid(self, field, sweep=0, mask_tuple=None, vmin=None,
-                        vmax=None, cmap='jet', mask_outside=False, title=None,
-                        title_flag=True, axislabels=(None, None),
-                        axislabels_flag=True, colorbar_flag=True,
-                        colorbar_label=None, colorbar_orient='vertical',
-                        edges=True, filter_transitions=True, ax=None,
-                        fig=None, gatefilter=None):
+    def plot_sweep_grid(
+            self, field, sweep=0, mask_tuple=None, vmin=None, vmax=None,
+            cmap='jet', mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
+            colorbar_label=None, colorbar_orient='vertical', edges=True,
+            filter_transitions=True, ax=None, fig=None, gatefilter=None):
         """
         Plot a sweep as a grid.
 
@@ -235,8 +225,8 @@ class AirborneRadarDisplay(RadarDisplay):
         vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
-                              gatefilter)
+        data = self._get_data(
+            field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, z = self._get_x_z(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -246,9 +236,6 @@ class AirborneRadarDisplay(RadarDisplay):
 
         # plot the data
         pm = ax.pcolormesh(x, z, data, vmin=vmin, vmax=vmax, cmap=cmap)
-
-        # Set the aspcet ratio
-        # ax.axis('scaled')
 
         if title_flag:
             self._set_title(field, sweep, title, ax)
@@ -262,9 +249,9 @@ class AirborneRadarDisplay(RadarDisplay):
 
         # colorbar options
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               orient=colorbar_orient,
-                               field=field, ax=ax, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, orient=colorbar_orient,
+                field=field, ax=ax, fig=fig)
 
     def label_xaxis_x(self, ax=None):
         """ Label the xaxis with the default label for x units. """

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -86,24 +86,6 @@ class AirborneRadarDisplay(RadarDisplay):
         self.pitch = radar.pitch['data']
         self.altitude = radar.altitude['data']
         super(AirborneRadarDisplay, self).__init__(radar, shift)
-        # x, y, z attributes: cartesian location for a sweep in km.
-        if radar.metadata['platform_type'] == 'aircraft_belly':
-            rg, azg = np.meshgrid(self.ranges, self.azimuths)
-            rg, eleg = np.meshgrid(self.ranges, self.elevations)
-            self.x, self.y, self.z = antenna_to_cartesian(
-                rg / 1000.0, azg, eleg)
-            self.x = self.x + self.shift[0]
-            self.y = self.y + self.shift[1]
-        else:
-            rg, rotg = np.meshgrid(self.ranges, self.rotation)
-            rg, rollg = np.meshgrid(self.ranges, self.roll)
-            rg, driftg = np.meshgrid(self.ranges, self.drift)
-            rg, tiltg = np.meshgrid(self.ranges, self.tilt)
-            rg, pitchg = np.meshgrid(self.ranges, self.pitch)
-            self.x, self.y, self.z = antenna_to_cartesian_track_relative(
-                rg / 1000.0, rotg, rollg, driftg, tiltg, pitchg)
-            self.x = self.x + self.shift[0]
-            self.y = self.y + self.shift[1]
 
         # radar location in latitude and longitude
         middle_lat = int(radar.latitude['data'].shape[0] / 2)

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -47,18 +47,12 @@ class RadarMapDisplay(RadarDisplay):
         List of fields plotted, order matches plot list.
     cbs : list
         List of colorbars created.
-    radar_name : str
-        Name of radar.
     origin : str
         'Origin' or 'Radar'.
     shift : (float, float)
         Shift in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
-    starts : array
-        Starting ray index for each sweep.
-    ends : array
-        Ending ray index for each sweep.
     fields : dict
         Radar fields.
     scan_type : str
@@ -223,8 +217,8 @@ class RadarMapDisplay(RadarDisplay):
             lon_0 = self.loc[1]
 
         # get data for the plot
-        data = self._get_data(field, sweep, mask_tuple, filter_transitions,
-                              gatefilter)
+        data = self._get_data(
+            field, sweep, mask_tuple, filter_transitions, gatefilter)
         x, y = self._get_x_y(field, sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
@@ -235,30 +229,31 @@ class RadarMapDisplay(RadarDisplay):
         if type(basemap) != Basemap:
             using_corners = (None not in [min_lon, min_lat, max_lon, max_lat])
             if using_corners:
-                basemap = Basemap(llcrnrlon=min_lon, llcrnrlat=min_lat,
-                                  urcrnrlon=max_lon, urcrnrlat=max_lat,
-                                  lat_0=lat_0, lon_0=lon_0,
-                                  projection=projection, area_thresh=area_thresh,
-                                  resolution=resolution, ax=ax, **kwargs)
+                basemap = Basemap(
+                    llcrnrlon=min_lon, llcrnrlat=min_lat,
+                    urcrnrlon=max_lon, urcrnrlat=max_lat,
+                    lat_0=lat_0, lon_0=lon_0, projection=projection,
+                    area_thresh=area_thresh, resolution=resolution, ax=ax,
+                    **kwargs)
             else:   # using width and height
                 # map domain determined from location of radar gates
                 if width is None:
                     width = (x.max() - y.min()) * 1000.
                 if height is None:
                     height = (y.max() - y.min()) * 1000.
-                basemap = Basemap(width=width, height=height,
-                                  lon_0=lon_0, lat_0=lat_0,
-                                  projection=projection, area_thresh=area_thresh,
-                                  resolution=resolution, ax=ax, **kwargs)
+                basemap = Basemap(
+                    width=width, height=height, lon_0=lon_0, lat_0=lat_0,
+                    projection=projection, area_thresh=area_thresh,
+                    resolution=resolution, ax=ax, **kwargs)
 
         # add embelishments
         if embelish is True:
             basemap.drawcoastlines(linewidth=1.25)
             basemap.drawstates()
-            basemap.drawparallels(lat_lines,
-                                  labels=[True, False, False, False])
-            basemap.drawmeridians(lon_lines,
-                                  labels=[False, False, False, True])
+            basemap.drawparallels(
+                lat_lines, labels=[True, False, False, False])
+            basemap.drawmeridians(
+                lon_lines, labels=[False, False, False, True])
         self.basemap = basemap
         self._x0, self._y0 = basemap(self.loc[1], self.loc[0])
 
@@ -280,8 +275,8 @@ class RadarMapDisplay(RadarDisplay):
         self.plot_vars.append(field)
 
         if colorbar_flag:
-            self.plot_colorbar(mappable=pm, label=colorbar_label,
-                               field=field, fig=fig)
+            self.plot_colorbar(
+                mappable=pm, label=colorbar_label, field=field, fig=fig)
         return
 
     def plot_point(self, lon, lat, symbol='ro', label_text=None,
@@ -317,8 +312,8 @@ class RadarMapDisplay(RadarDisplay):
         if label_text is not None:
             # basemap does not have a text method so we must determine
             # the x and y points and plot them on the basemap's axis.
-            x_text, y_text = self.basemap(lon + lon_offset,
-                                          lat + lat_offset)
+            x_text, y_text = self.basemap(
+                lon + lon_offset, lat + lat_offset)
             self.basemap.ax.text(x_text, y_text, label_text)
 
     def plot_line_geo(self, line_lons, line_lats, line_style='r-', **kwargs):
@@ -338,8 +333,8 @@ class RadarMapDisplay(RadarDisplay):
 
         """
         self._check_basemap()
-        self.basemap.plot(line_lons, line_lats, line_style, latlon=True,
-                          **kwargs)
+        self.basemap.plot(
+            line_lons, line_lats, line_style, latlon=True, **kwargs)
 
     def plot_line_xy(self, line_x, line_y, line_style='r-', **kwargs):
         """

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -57,8 +57,6 @@ class RadarMapDisplay(RadarDisplay):
         Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
-    time_begin : datetime
-        Beginning time of first radar scan.
     starts : array
         Starting ray index for each sweep.
     ends : array

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -219,7 +219,7 @@ class RadarMapDisplay(RadarDisplay):
         # get data for the plot
         data = self._get_data(
             field, sweep, mask_tuple, filter_transitions, gatefilter)
-        x, y = self._get_x_y(field, sweep, edges, filter_transitions)
+        x, y = self._get_x_y(sweep, edges, filter_transitions)
 
         # mask the data where outside the limits
         if mask_outside:

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -53,8 +53,6 @@ class RadarMapDisplay(RadarDisplay):
         'Origin' or 'Radar'.
     shift : (float, float)
         Shift in meters.
-    x, y, z : array
-        Cartesian location of a sweep in meters.
     loc : (float, float)
         Latitude and Longitude of radar in degrees.
     starts : array

--- a/pyart/graph/tests/test_cm.py
+++ b/pyart/graph/tests/test_cm.py
@@ -1,0 +1,45 @@
+""" Unit Tests for Py-ART's graph/cm.py module. """
+
+
+import matplotlib
+
+import pyart
+from pyart.graph import cm
+
+
+def test_colormaps_exist():
+    assert isinstance(cm.NWSRef, matplotlib.colors.Colormap)
+    assert isinstance(cm.NWSRef_r, matplotlib.colors.Colormap)
+
+
+def test_colormaps_registered():
+    cmap = matplotlib.cm.get_cmap('pyart_NWSRef')
+    assert isinstance(cmap, matplotlib.colors.Colormap)
+
+    cmap = matplotlib.cm.get_cmap('pyart_NWSRef_r')
+    assert isinstance(cmap, matplotlib.colors.Colormap)
+
+
+def test_tuple_spec():
+    # None of the Py-ART colormaps use the tuple spec, so for coverage in the
+    # unit tests ddefine a colormap using a tuple
+
+    # data borrowed from matplotlib's lib/matplotlib/_cm.py
+    _seismic_data = (
+        (0.0, 0.0, 0.3), (0.0, 0.0, 1.0),
+        (1.0, 1.0, 1.0), (1.0, 0.0, 0.0),
+        (0.5, 0.0, 0.0))
+    spec_reversed = cm._reverse_cmap_spec(_seismic_data)
+
+    spec = ((0, 1), (0, 1))
+    spec_reversed = cm._reverse_cmap_spec(spec)
+
+    cm.datad['foo'] = _seismic_data
+    cmap = cm._generate_cmap('foo', 1)
+    assert isinstance(cm.NWSRef_r, matplotlib.colors.Colormap)
+
+
+def test_revcmap_callable():
+    # reversing a callable is not exercised in Py-ART
+    data_r = cm.revcmap({'foo': lambda x: x})
+    assert data_r['foo'](0) == 1

--- a/pyart/graph/tests/test_common.py
+++ b/pyart/graph/tests/test_common.py
@@ -1,0 +1,233 @@
+""" Unit Tests for Py-ART's graph/common.py module. """
+
+import datetime
+
+from numpy.testing import assert_almost_equal
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+import pyart
+from pyart.graph import common
+
+
+def test_parse_ax():
+    ax = common.parse_ax(None)
+    assert isinstance(ax, matplotlib.axes.Axes)
+
+    ax1 = plt.gca()
+    ax2 = common.parse_ax(ax1)
+    assert ax1 == ax2
+
+
+def test_parse_ax_fig():
+    ax, fig = common.parse_ax_fig(None, None)
+    assert isinstance(ax, matplotlib.axes.Axes)
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+    ax1 = plt.gca()
+    fig1 = plt.gcf()
+    ax2, fig2 = common.parse_ax_fig(ax1, fig1)
+    assert ax1 == ax2
+    assert fig1 == fig2
+
+
+def test_parse_vmin_vmax():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    vmin, vmax = common.parse_vmin_vmax(radar, 'foo', None, None)
+    assert vmin == -6
+    assert vmax == 100
+
+    vmin, vmax = common.parse_vmin_vmax(radar, 'foo', 10, 20)
+    assert vmin == 10
+    assert vmax == 20
+
+    radar.fields['foo']['valid_min'] = 30
+    radar.fields['foo']['valid_max'] = 40
+    vmin, vmax = common.parse_vmin_vmax(radar, 'foo', None, None)
+    assert vmin == 30
+    assert vmax == 40
+
+
+def test_parse_lon_lat():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+
+    lon, lat = common.parse_lon_lat(grid, None, None)
+    assert_almost_equal(lon, -98.1, 2)
+    assert_almost_equal(lat, 36.74, 2)
+
+    lon, lat = common.parse_lon_lat(grid, -12.34, 56.78)
+    assert_almost_equal(lon, -12.34, 2)
+    assert_almost_equal(lat, 56.78, 2)
+
+
+def test_generate_colorbar_label():
+    label = common.generate_colorbar_label('special_name', 'km')
+    assert label == 'special name (km)'
+
+
+def test_generate_field_name():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    field_name = common.generate_field_name(radar, 'foo')
+    assert field_name == 'Foo'
+
+    radar.fields['foo']['long_name'] = 'special_name'
+    field_name = common.generate_field_name(radar, 'foo')
+    assert field_name == 'Special name'
+
+    radar.fields['foo']['standard_name'] = 'other_name'
+    field_name = common.generate_field_name(radar, 'foo')
+    assert field_name == 'Other name'
+
+
+def test_generate_radar_name():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+
+    radar.metadata['instrument_name'] = 'foobar'
+    name = common.generate_radar_name(radar)
+    assert name == 'foobar'
+
+    del radar.metadata['instrument_name']
+    name = common.generate_radar_name(radar)
+    assert name == ''
+
+
+def test_generate_grid_name():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+
+    grid.metadata['instrument_name'] = 'foobar'
+    name = common.generate_grid_name(grid)
+    assert name == 'foobar'
+
+    del grid.metadata['instrument_name']
+    name = common.generate_grid_name(grid)
+    assert name == ''
+
+
+def test_generate_radar_time_begin():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    time = common.generate_radar_time_begin(radar)
+    assert time == datetime.datetime(1989, 1, 1, 0, 0, 1)
+
+
+def test_generate_grid_time_begin():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+
+    time = common.generate_grid_time_begin(grid)
+    assert time == datetime.datetime(2000, 1, 1, 0, 0, 0)
+
+    del grid.time['calendar']
+    time = common.generate_grid_time_begin(grid)
+    assert time == datetime.datetime(2000, 1, 1, 0, 0, 0)
+
+
+def test_generate_filename():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    filename = common.generate_filename(radar, 'foobar', 0)
+    assert filename == 'fake_radar_foobar_00_19890101000001.png'
+
+
+def test_generate_grid_filename():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+    grid.metadata['instrument_name'] = 'foo'
+
+    filename = common.generate_grid_filename(grid, 'bar', 0)
+    assert filename == 'foo_bar_00_20000101000000.png'
+
+
+def test_generate_title():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    title = common.generate_title(radar, 'foo', 0)
+    assert title == 'fake_radar 0.8 Deg. 1989-01-01T00:00:01Z \nFoo'
+
+
+def test_generate_grid_title():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+    grid.metadata['instrument_name'] = 'bar'
+    grid.fields['foo'] = {}
+
+    title = common.generate_grid_title(grid, 'foo', 0)
+    assert title == 'bar 0.0 km 2000-01-01T00:00:00Z \nFoo'
+
+
+def test_generate_longitudinal_level_title():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+    grid.metadata['instrument_name'] = 'bar'
+    grid.fields['foo'] = {}
+
+    title = common.generate_longitudinal_level_title(grid, 'foo', 0)
+    assert title == (
+        'bar 0.0 km east of origin 2000-01-01T00:00:00Z \nFoo')
+
+    grid.x['data'][0] = -1000.
+    title = common.generate_longitudinal_level_title(grid, 'foo', 0)
+    assert title == (
+        'bar 1.0 km west of origin 2000-01-01T00:00:00Z \nFoo')
+
+
+def test_generate_latitudinal_level_title():
+    grid_shape = (1, 1, 1)
+    grid_limits = ((0, 1), (0, 1), (0, 1))
+    grid = pyart.testing.make_empty_grid(grid_shape, grid_limits)
+    grid.metadata['instrument_name'] = 'bar'
+    grid.fields['foo'] = {}
+
+    title = common.generate_latitudinal_level_title(grid, 'foo', 0)
+    assert title == (
+        'bar 0.0 km north of origin 2000-01-01T00:00:00Z \nFoo')
+
+    grid.y['data'][0] = -1000.
+    title = common.generate_latitudinal_level_title(grid, 'foo', 0)
+    assert title == (
+        'bar 1.0 km south of origin 2000-01-01T00:00:00Z \nFoo')
+
+
+def test_generate_vpt_title():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    title = common.generate_vpt_title(radar, 'foo')
+    assert title == 'fake_radar 1989-01-01T00:00:01Z \nFoo'
+
+
+def test_generate_ray_title():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    title = common.generate_ray_title(radar, 'foo', 0)
+    assert title == ('fake_radar 1989-01-01T00:00:01Z\n' +
+                     'Ray: 0  Elevation: 0.0 Azimuth: 0.8\nFoo')
+
+
+def test_generate_az_rhi_title():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    title = common.generate_az_rhi_title(radar, 'foo', 0)
+    assert title == (
+        'fake_radar 1989-01-01T00:00:01Z \nAzimuth: 0.0 deg\nFoo')
+
+
+def test_set_limits():
+    common.set_limits(xlim=(-20, 20), ylim=(-10, 10))
+    ax = plt.gca()
+    assert ax.get_ylim() == (-10, 10)
+    assert ax.get_xlim() == (-20, 20)

--- a/pyart/graph/tests/test_gridmapdisplay.py
+++ b/pyart/graph/tests/test_gridmapdisplay.py
@@ -133,6 +133,7 @@ def test_deprecated_attributes():
 
         assert display.grid_lons.ndim == 2
         assert display.grid_lats.ndim == 2
+        assert callable(display.proj)
 
 
 if __name__ == "__main__":

--- a/pyart/graph/tests/test_gridmapdisplay.py
+++ b/pyart/graph/tests/test_gridmapdisplay.py
@@ -5,8 +5,11 @@
 # in baseline_images directory. Current this test only determines if files can
 # be created, not that they are correct.
 
+import warnings
+
 import matplotlib.pyplot as plt
 import pyart
+from pyart.exceptions import DepreciatedAttribute
 from numpy.testing import assert_raises
 from numpy.testing.decorators import skipif
 
@@ -117,6 +120,19 @@ def test_error_raising():
     # no field
     display.mappables.append(None)  # mock the mappable
     assert_raises(ValueError, display.plot_colorbar)
+
+
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
+def test_deprecated_attributes():
+
+    grid = pyart.testing.make_target_grid()
+    display = pyart.graph.GridMapDisplay(grid)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DepreciatedAttribute)
+
+        assert display.grid_lons.ndim == 2
+        assert display.grid_lats.ndim == 2
 
 
 if __name__ == "__main__":

--- a/pyart/graph/tests/test_gridmapdisplay.py
+++ b/pyart/graph/tests/test_gridmapdisplay.py
@@ -31,30 +31,79 @@ def test_gridmapdisplay_fancy(outfile=None):
     # test a bunch of GridMapDisplay functionality
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplay(grid)
+    display.debug = True
     fig = plt.figure()
 
-    ax = fig.add_subplot(321)
+    ax = fig.add_subplot(331)
     display.plot_basemap(ax=ax, resolution=RESOLUTION)
-    display.plot_grid('reflectivity', vmin=-5., vmax=35)
+    display.plot_grid(
+        'reflectivity', vmin=-5., vmax=35, mask_outside=True,
+        axislabels_flag=True, axislabels=('foo', 'bar'), title='Special title')
     display.plot_crosshairs(line_style='b--')
 
-    ax = fig.add_subplot(322)
+    ax = fig.add_subplot(332)
+    display.plot_grid('reflectivity', axislabels_flag=True)
+
+    ax = fig.add_subplot(333)
     display.plot_colorbar()
 
-    ax = fig.add_subplot(323)
-    display.plot_latitude_slice('reflectivity')  # no vmin/vmax
+    ax = fig.add_subplot(334)
+    display.plot_latitude_slice('reflectivity', mask_outside=True)
 
-    ax = fig.add_subplot(325)
+    ax = fig.add_subplot(335)
+    display.plot_latitude_slice('reflectivity', title='Lat title')
+
+    ax = fig.add_subplot(336)
     grid.fields['reflectivity']['valid_min'] = 0.
     grid.fields['reflectivity']['valid_max'] = 30.
-    display.plot_longitude_slice('reflectivity')
+    display.plot_longitude_slice('reflectivity', mask_outside=True)
 
-    ax = fig.add_subplot(326)
+    ax = fig.add_subplot(337)
+    display.plot_longitude_slice('reflectivity', title='Lon title')
+
+    ax = fig.add_subplot(338)
     del display.grid.fields['reflectivity']['long_name']
     display.plot_colorbar()
 
     if outfile:
         fig.savefig(outfile)
+
+
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
+def test_plot_basemap_not_using_corners(outfile=None):
+    grid = pyart.testing.make_target_grid()
+    display = pyart.graph.GridMapDisplay(grid)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    display.plot_basemap(
+        ax=ax, resolution=RESOLUTION, max_lon=None, auto_range=False)
+
+
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
+def test_generate_filename():
+    grid = pyart.testing.make_target_grid()
+    display = pyart.graph.GridMapDisplay(grid)
+    filename = display.generate_filename('reflectivity', 0)
+    assert isinstance(filename, str)
+
+
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
+def test_generate_titles():
+    grid = pyart.testing.make_target_grid()
+    display = pyart.graph.GridMapDisplay(grid)
+
+    title = display.generate_longitudinal_level_title('reflectivity', 0)
+    assert isinstance(title, str)
+
+    title = display.generate_latitudinal_level_title('reflectivity', 0)
+    assert isinstance(title, str)
+
+
+@skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)
+def test_get_basemap():
+    grid = pyart.testing.make_target_grid()
+    display = pyart.graph.GridMapDisplay(grid)
+    basemap = display.get_basemap()
 
 
 @skipif(not pyart.graph.gridmapdisplay._BASEMAP_AVAILABLE)

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -120,11 +120,7 @@ def test_radardisplay_init():
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
     radar.antenna_transition = {'data': np.zeros((40, ))}
     display = pyart.graph.RadarDisplay(radar)
-    assert display.radar_name == 'xsapr-sgp'
     assert display.antenna_transition is not None
-    del radar.metadata['instrument_name']
-    display = pyart.graph.RadarDisplay(radar)
-    assert display.radar_name == ''
     plt.close()
 
 
@@ -294,6 +290,10 @@ def test_starts_ends():
         assert len(display.starts) == 1
         assert len(display.ends) == 1
         assert display.time_begin == datetime.datetime(1989, 1, 1, 0, 0, 1)
+        assert display.radar_name == 'fake_radar'
+
+        del radar.metadata['instrument_name']
+        assert display.radar_name == ''
 
 
 

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -208,8 +208,7 @@ def test_radardisplay_loc_of_moving_radar():
 def test_radardisplay_get_x_z():
     radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
     display = pyart.graph.RadarDisplay(radar)
-    radar.fields['foo'] = {}
-    x, z = display._get_x_z('foo', 0, False, False)
+    x, z = display._get_x_z(0, False, False)
     assert x.shape == (1, 1)
     assert z.shape == (1, 1)
 

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -193,14 +193,16 @@ def test_radardisplay_user_specified_labels():
     plt.close()
 
 
-def test_radardisplay_calculate_localization():
+def test_radardisplay_loc_of_moving_radar():
     radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
-    display = pyart.graph.RadarDisplay(radar)
 
     radar.latitude['data'] = np.array([35, 45])
     radar.longitude['data'] = np.array([75, 85])
-    assert_warns(UserWarning, display._calculate_localization, radar)
-    assert_almost_equal(display.loc, (40, 80), 0)
+    assert_warns(UserWarning, pyart.graph.RadarDisplay, radar)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        display = pyart.graph.RadarDisplay(radar)
+        assert_almost_equal(display.loc, (40, 80), 0)
 
 
 def test_radardisplay_get_x_z():
@@ -295,6 +297,9 @@ def test_starts_ends():
         del radar.metadata['instrument_name']
         assert display.radar_name == ''
 
+        assert display.x.shape == (1, 1)
+        assert display.y.shape == (1, 1)
+        assert display.z.shape == (1, 1)
 
 
 if __name__ == "__main__":

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -7,12 +7,15 @@
 
 from __future__ import print_function
 
+import warnings
+
 import matplotlib.pyplot as plt
 
 import numpy as np
 from numpy.testing import assert_raises, assert_almost_equal, assert_warns
 
 import pyart
+from pyart.exceptions import DepreciatedAttribute
 
 
 # Top level Figure generating tests
@@ -277,6 +280,18 @@ def test_radardisplay_get_colorbar_label():
     assert (display._get_colorbar_label('reflectivity_horizontal') ==
             'reflectivity horizontal (?)')
     plt.close()
+
+
+# These attribute have been Depreciated, remove this test when these
+# attribute are removed
+def test_starts_ends():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    display = pyart.graph.RadarDisplay(radar)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DepreciatedAttribute)
+        assert len(display.starts) == 1
+        assert len(display.ends) == 1
 
 
 if __name__ == "__main__":

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -8,8 +8,11 @@
 from __future__ import print_function
 
 import matplotlib.pyplot as plt
+
+import numpy as np
+from numpy.testing import assert_raises, assert_almost_equal, assert_warns
+
 import pyart
-from numpy.testing import assert_raises
 
 
 # Top level Figure generating tests
@@ -18,7 +21,7 @@ def test_radardisplay_rhi(outfile=None):
     display = pyart.graph.RadarDisplay(radar)
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    display.plot('reflectivity_horizontal', 0, ax=ax)
+    display.plot('reflectivity_horizontal', 0, ax=ax, mask_outside=True)
     if outfile:
         fig.savefig(outfile)
     plt.close()
@@ -26,16 +29,22 @@ def test_radardisplay_rhi(outfile=None):
 
 def test_radardisplay_ppi(outfile=None):
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    radar.antenna_transition = {'data': np.zeros(radar.nrays)}
     display = pyart.graph.RadarDisplay(radar, shift=(0.1, 0.0))
     fig = plt.figure()
     ax = fig.add_subplot(111)
+
+    gatefilter = pyart.filters.GateFilter(radar)
     display.plot('reflectivity_horizontal', 0, colorbar_flag=True,
-                 title="Fancy PPI Plot",
-                 mask_tuple=('reflectivity_horizontal', -100))
+                 title="Fancy PPI Plot", mask_outside=True,
+                 mask_tuple=('reflectivity_horizontal', -100),
+                 gatefilter=gatefilter)
     display.plot_colorbar()
     display.plot_range_rings([10, 20, 30, 40], ax=ax)
     display.plot_labels(['tree'], [(36.68, -97.62)], symbols='k+', ax=ax)
     display.plot_cross_hair(2)
+    display.plot_grid_lines()
+    display.set_aspect_ratio()
     display.set_limits(ylim=[-50, 50], xlim=[-50, 50])
     if outfile:
         fig.savefig(outfile)
@@ -47,9 +56,9 @@ def test_radardisplay_ray(outfile=None):
     display = pyart.graph.RadarDisplay(radar)
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    display.plot_ray('reflectivity_horizontal', 0, ray_min=15, ray_max=40,
-                     mask_outside=True, ax=ax,
-                     mask_tuple=('reflectivity_horizontal', -10))
+    display.plot_ray(
+        'reflectivity_horizontal', 0, ray_min=15, ray_max=40,
+        mask_outside=True, ax=ax, mask_tuple=('reflectivity_horizontal', -10))
     if outfile:
         fig.savefig(outfile)
     plt.close()
@@ -57,12 +66,14 @@ def test_radardisplay_ray(outfile=None):
 
 def test_radardisplay_vpt(outfile=None):
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    radar.antenna_transition = {'data': np.zeros(radar.nrays)}
     pyart.util.to_vpt(radar)      # hack to make the data a VPT
     display = pyart.graph.RadarDisplay(radar)
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    display.plot('reflectivity_horizontal', colorbar_flag=True,
-                 mask_tuple=('reflectivity_horizontal', -100), ax=ax)
+    display.plot(
+        'reflectivity_horizontal', colorbar_flag=True, mask_outside=True,
+        mask_tuple=('reflectivity_horizontal', -100), ax=ax)
     if outfile:
         fig.savefig(outfile)
     plt.close()
@@ -75,7 +86,7 @@ def test_radardisplay_vpt_time(outfile=None):
     fig = plt.figure()
     ax = fig.add_subplot(111)
     display.plot('reflectivity_horizontal', colorbar_flag=True,
-                 time_axis_flag=True,
+                 time_axis_flag=True, edges=False,
                  mask_tuple=('reflectivity_horizontal', -100), ax=ax)
     if outfile:
         fig.savefig(outfile)
@@ -84,12 +95,15 @@ def test_radardisplay_vpt_time(outfile=None):
 
 def test_radardisplay_azimuth_to_rhi(outfile=None):
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    radar.antenna_transition = {'data': np.zeros(radar.nrays)}
+    gatefilter = pyart.filters.GateFilter(radar)
     display = pyart.graph.RadarDisplay(radar)
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    display.plot_azimuth_to_rhi('reflectivity_horizontal', 45.,
-                                colorbar_flag=True, ax=ax,
-                                mask_tuple=('reflectivity_horizontal', -100))
+    display.plot_azimuth_to_rhi(
+        'reflectivity_horizontal', 45., colorbar_flag=True, ax=ax,
+        mask_tuple=('reflectivity_horizontal', -100), mask_outside=True,
+        gatefilter=gatefilter)
     if outfile:
         fig.savefig(outfile)
     plt.close()
@@ -100,11 +114,32 @@ def test_radardisplay_azimuth_to_rhi(outfile=None):
 def test_radardisplay_init():
     # test that a display object can be created with and without
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    radar.antenna_transition = {'data': np.zeros((40, ))}
     display = pyart.graph.RadarDisplay(radar)
     assert display.radar_name == 'xsapr-sgp'
+    assert display.antenna_transition is not None
     del radar.metadata['instrument_name']
     display = pyart.graph.RadarDisplay(radar)
     assert display.radar_name == ''
+    plt.close()
+
+
+def test_radardisplay_plot_rhi_reverse():
+    radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_RHI_FILE)
+    display = pyart.graph.RadarDisplay(radar)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    display.plot('reflectivity_horizontal', 0, ax=ax, reverse_xaxis=True)
+    plt.close()
+
+
+def test_radardisplay_plot_azimuth_to_rhi_reverse(outfile=None):
+    radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    display = pyart.graph.RadarDisplay(radar)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    display.plot_azimuth_to_rhi(
+        'reflectivity_horizontal', 45., reverse_xaxis=True)
     plt.close()
 
 
@@ -158,6 +193,36 @@ def test_radardisplay_user_specified_labels():
     plt.close()
 
 
+def test_radardisplay_calculate_localization():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    display = pyart.graph.RadarDisplay(radar)
+
+    radar.latitude['data'] = np.array([35, 45])
+    radar.longitude['data'] = np.array([75, 85])
+    assert_warns(UserWarning, display._calculate_localization, radar)
+    assert_almost_equal(display.loc, (40, 80), 0)
+
+
+def test_radardisplay_get_x_z():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    display = pyart.graph.RadarDisplay(radar)
+    radar.fields['foo'] = {}
+    x, z = display._get_x_z('foo', 0, False, False)
+    assert x.shape == (1, 1)
+    assert z.shape == (1, 1)
+
+
+def test_set_title():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+    display = pyart.graph.RadarDisplay(radar)
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    display._set_az_rhi_title('foo', 0, 'special title', ax)
+    assert ax.get_title() == 'special title'
+
+
 def test_radardisplay_misc():
     # misc methods which are not tested above
     radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
@@ -170,15 +235,18 @@ def test_radardisplay_misc():
     assert ax.get_title() == 'title_string'
 
     # _generate_field_name method
-    fn = pyart.graph.common.generate_field_name(radar, 'reflectivity_horizontal')
+    fn = pyart.graph.common.generate_field_name(
+        radar, 'reflectivity_horizontal')
     assert fn == 'Equivalent reflectivity factor'
 
     display.fields['reflectivity_horizontal'].pop('standard_name')
-    fn = pyart.graph.common.generate_field_name(radar, 'reflectivity_horizontal')
+    fn = pyart.graph.common.generate_field_name(
+        radar, 'reflectivity_horizontal')
     assert fn == 'Reflectivity'
 
     display.fields['reflectivity_horizontal'].pop('long_name')
-    fn = pyart.graph.common.generate_field_name(radar, 'reflectivity_horizontal')
+    fn = pyart.graph.common.generate_field_name(
+        radar, 'reflectivity_horizontal')
     assert fn == 'Reflectivity horizontal'
 
     plt.close()

--- a/pyart/graph/tests/test_radardisplay.py
+++ b/pyart/graph/tests/test_radardisplay.py
@@ -8,6 +8,7 @@
 from __future__ import print_function
 
 import warnings
+import datetime
 
 import matplotlib.pyplot as plt
 
@@ -292,6 +293,8 @@ def test_starts_ends():
         warnings.simplefilter("ignore", category=DepreciatedAttribute)
         assert len(display.starts) == 1
         assert len(display.ends) == 1
+        assert display.time_begin == datetime.datetime(1989, 1, 1, 0, 0, 1)
+
 
 
 if __name__ == "__main__":

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -22,7 +22,8 @@ def test_radarmapdisplay_ppi(outfile=None):
     display.plot_ppi_map(
         'reflectivity_horizontal', 0, colorbar_flag=True,
         title="Fancy PPI Map", mask_tuple=('reflectivity_horizontal', -100),
-        resolution='c', min_lon=-100, max_lon=-93, min_lat=33, max_lat=38)
+        resolution='c', min_lon=-100, max_lon=-93, min_lat=33, max_lat=38,
+        mask_outside=True)
     display.plot_point(-95, 35, label_text='TEXT')
     display.plot_range_ring(30)
     display.plot_line_geo(np.array([-95, -95]), np.array([33, 38]))


### PR DESCRIPTION
Refactor of **RadarDisplay**, **RadarMapDisplay**, **GridMapDisplay** and **AirborneRadarDisplay** to take into account the new layout and attribute of the **Grid** and **Radar** classes.  

Depreciate multiple unnecessary attributes of the **RadarDisplay** class:
    * x, y, z
    * starts, ends
    * time_begin
    * radar_name

Modification and additional unit tests for better coverage of the modules in the graph sub-package.