### PR TITLE
ENH: Default field specific colormaps and luminosity when plotting

### DIFF
--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -1313,32 +1313,45 @@ DEFAULT_FIELD_COLORMAP = {
     reflectivity: 'pyart_NWSRef',
     corrected_reflectivity: 'pyart_NWSRef',
     total_power: 'pyart_NWSRef',
-    velocity: 'pyart_NWSVel',
-    corrected_velocity: 'pyart_NWSVel',
-    spectrum_width: 'pyart_NWS_SPW',
-    differential_reflectivity: 'pyart_BrBu12',
-    corrected_differential_reflectivity: 'pyart_BrBu12',
-    cross_correlation_ratio: 'pyart_BrBu12',
-    normalized_coherent_power: 'pyart_Carbone17',
-    differential_phase: 'hsv',
-    unfolded_differential_phase: 'pyart_BlueBrown11',
-    corrected_differential_phase: 'pyart_BlueBrown11',
-    specific_differential_phase: 'pyart_BrBu12',
-    corrected_specific_differential_phase: 'pyart_BrBu12',
-    linear_depolarization_ratio: 'pyart_Carbone17',
-    linear_depolarization_ratio_h: 'pyart_Carbone17',
-    linear_depolarization_ratio_v: 'pyart_Carbone17',
     signal_to_noise_ratio: 'pyart_Carbone17',
+
+    velocity: 'pyart_BuDRd18',
+    corrected_velocity: 'pyart_BuDRd18',
+    eastward_wind_component: 'pyart_BuDRd18',
+    northward_wind_component: 'pyart_BuDRd18',
+    vertical_wind_component: 'pyart_BuDRd18',
+
+    spectrum_width: 'pyart_NWS_SPW',
+
+    normalized_coherent_power: 'pyart_Carbone17',
+
+    differential_reflectivity: 'pyart_RefDiff',
+    corrected_differential_reflectivity: 'pyart_RefDiff',
+
+    cross_correlation_ratio: 'pyart_RefDiff',
+
+    differential_phase: 'pyart_Wild25',
+    unfolded_differential_phase: 'pyart_Wild25',
+    corrected_differential_phase: 'pyart_Wild25',
+
+    specific_differential_phase: 'pyart_Theodore16',
+    corrected_specific_differential_phase: 'pyart_Theodore16',
+
+    linear_depolarization_ratio: 'pyart_SCook18',
+    linear_depolarization_ratio_h: 'pyart_SCook18',
+    linear_depolarization_ratio_v: 'pyart_SCook18',
+
     rain_rate: 'pyart_RRate11',
     radar_estimated_rain_rate: 'pyart_RRate11',
-    radar_echo_classification: 'pyart_EWilson17',
-    specific_attenuation: 'pyart_NWSVel',
+
+    radar_echo_classification: 'pyart_LangRainbow12',
+
+    specific_attenuation: 'pyart_Carbone17',
+
     differential_phase_texture: 'pyart_BlueBrown11',
-    eastward_wind_component: 'pyart_NWSVel',
-    northward_wind_component: 'pyart_NWSVel',
-    vertical_wind_component: 'pyart_NWSVel',
     height: 'pyart_SCook18',
     interpolated_profile: 'pyart_SCook18',
+
     # Additional reflectivity like fields
     'CZ': 'pyart_NWSRef',
     'DZ': 'pyart_NWSRef',
@@ -1358,35 +1371,49 @@ DEFAULT_FIELD_COLORMAP = {
 
 DEFAULT_FIELD_LIMITS = {
     # field name : limits
-    reflectivity: (-10., 65.),
-    corrected_reflectivity: (-10., 65.),
-    total_power: (-200., 100.),
+    reflectivity: (-30., 75.),
+    corrected_reflectivity: (-30., 75.),
+    total_power: (-30., 75.),
+    signal_to_noise_ratio: (-20, 30.),
+
     velocity: velocity_limit,
     corrected_velocity: velocity_limit,
-    spectrum_width: spectrum_width_limit,
-    differential_reflectivity: (-5., 5.),
-    corrected_differential_reflectivity: (-5., 5.),
-    cross_correlation_ratio: (0.8, 1.),
-    normalized_coherent_power: (0., 1.),
-    differential_phase: (-180, 180.),
-    unfolded_differential_phase: (-360, 360.),
-    corrected_differential_phase: (-360, 360.),
-    specific_differential_phase: (-2., 5.),
-    corrected_specific_differential_phase: (-2., 5.),
-    linear_depolarization_ratio: (-40., 0.),
-    linear_depolarization_ratio_h: (-40., 0.),
-    linear_depolarization_ratio_v: (-40., 0.),
-    signal_to_noise_ratio: (-0, 90.),
-    rain_rate: (0., 150.),
-    radar_estimated_rain_rate: (0., 150.),
-    radar_echo_classification: (0, 12),
-    specific_attenuation: (-10., 65.),
-    differential_phase_texture: (-180, 180.),
     eastward_wind_component: velocity_limit,
     northward_wind_component: velocity_limit,
     vertical_wind_component: velocity_limit,
+
+    spectrum_width: spectrum_width_limit,
+
+    normalized_coherent_power: (0., 1.),
+
+    differential_reflectivity: (-1., 8.),
+    corrected_differential_reflectivity: (-1., 8.),
+
+    cross_correlation_ratio: (0.5, 1.05),
+
+    differential_phase: (-180, 180.),
+    unfolded_differential_phase: (-360, 360.),
+    corrected_differential_phase: (-360, 360.),
+
+    specific_differential_phase: (-2., 5.),
+    corrected_specific_differential_phase: (-2., 5.),
+
+    linear_depolarization_ratio: (-40., 0.),
+    linear_depolarization_ratio_h: (-40., 0.),
+    linear_depolarization_ratio_v: (-40., 0.),
+
+    rain_rate: (0., 50.),
+    radar_estimated_rain_rate: (0., 50.),
+
+    radar_echo_classification: (0, 11),
+
+    specific_attenuation: (0., 10.),
+
+    differential_phase_texture: (0, 180.),
+
     height: (0, 20000),
     interpolated_profile: (0, 10000),
+
     # Additional reflectivity like fields
     'CZ': (-10., 65.),
     'DZ': (-10., 65.),

--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -10,6 +10,7 @@ Common graphing routines.
     parse_ax
     parse_ax_fig
     parse_norm_vmin_vmax
+    parse_cmap
     parse_vmin_vmax
     parse_lon_lat
     generate_colorbar_label
@@ -35,6 +36,7 @@ from netCDF4 import num2date
 
 # Deprecated function names in this name space
 from ..exceptions import _deprecated_alias
+from ..config import get_field_colormap
 from ..core import transforms as _transforms
 radar_coords_to_cart = _deprecated_alias(
     _transforms.antenna_to_cartesian,
@@ -75,6 +77,13 @@ def parse_norm_vmin_vmax(norm, container, field, vmin, vmax):
         vmin = None
         vmax = None
     return norm, vmin, vmax
+
+
+def parse_cmap(cmap, field=None):
+    """ Parse and return the cmap parameter. """
+    if cmap is None:
+        cmap = get_field_colormap(field)
+    return cmap
 
 
 def parse_vmin_vmax(container, field, vmin, vmax):

--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -36,7 +36,7 @@ from netCDF4 import num2date
 
 # Deprecated function names in this name space
 from ..exceptions import _deprecated_alias
-from ..config import get_field_colormap
+from ..config import get_field_colormap, get_field_limits
 from ..core import transforms as _transforms
 radar_coords_to_cart = _deprecated_alias(
     _transforms.antenna_to_cartesian,
@@ -89,16 +89,17 @@ def parse_cmap(cmap, field=None):
 def parse_vmin_vmax(container, field, vmin, vmax):
     """ Parse and return vmin and vmax parameters. """
     field_dict = container.fields[field]
+    field_default_vmin, field_default_vmax = get_field_limits(field)
     if vmin is None:
         if 'valid_min' in field_dict:
             vmin = field_dict['valid_min']
         else:
-            vmin = -6   # default value
+            vmin = field_default_vmin
     if vmax is None:
         if 'valid_max' in field_dict:
             vmax = field_dict['valid_max']
         else:
-            vmax = 100
+            vmax = field_default_vmax
     return vmin, vmax
 
 

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -152,7 +152,7 @@ class GridMapDisplay(object):
 
     def plot_grid(
             self, field, level=0,
-            vmin=None, vmax=None, norm=None, cmap='jet',
+            vmin=None, vmax=None, norm=None, cmap=None,
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=False,
             colorbar_flag=True, colorbar_label=None,
@@ -178,8 +178,9 @@ class GridMapDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name or colormap object.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -220,6 +221,7 @@ class GridMapDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self.grid, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         basemap = self.get_basemap()
 
@@ -310,7 +312,7 @@ class GridMapDisplay(object):
 
     def plot_latitudinal_level(
             self, field, y_index,
-            vmin=None, vmax=None, norm=None, cmap='jet',
+            vmin=None, vmax=None, norm=None, cmap=None,
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
             colorbar_label=None, colorbar_orient='vertical', edges=True,
@@ -335,8 +337,9 @@ class GridMapDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name or colormap object.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -377,6 +380,7 @@ class GridMapDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self.grid, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         data = self.grid.fields[field]['data'][:, y_index, :]
 
@@ -436,7 +440,7 @@ class GridMapDisplay(object):
 
     def plot_longitudinal_level(
             self, field, x_index,
-            vmin=None, vmax=None, norm=None, cmap='jet',
+            vmin=None, vmax=None, norm=None, cmap=None,
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
             colorbar_label=None, colorbar_orient='vertical', edges=True,
@@ -461,8 +465,9 @@ class GridMapDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name or colormap object.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -503,6 +508,7 @@ class GridMapDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self.grid, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         data = self.grid.fields[field]['data'][:, :, x_index]
 

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -296,7 +296,7 @@ class RadarDisplay(object):
 
     def plot_ppi(
             self, field, sweep=0, mask_tuple=None,
-            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            vmin=None, vmax=None, norm=None, cmap=None, mask_outside=False,
             title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True,
             colorbar_flag=True, colorbar_label=None,
@@ -330,8 +330,9 @@ class RadarDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -380,6 +381,7 @@ class RadarDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         # get data for the plot
         data = self._get_data(
@@ -410,7 +412,7 @@ class RadarDisplay(object):
 
     def plot_rhi(
             self, field, sweep=0, mask_tuple=None,
-            vmin=None, vmax=None, norm=None, cmap='jet',
+            vmin=None, vmax=None, norm=None, cmap=None,
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True,
             reverse_xaxis=None, colorbar_flag=True, colorbar_label=None,
@@ -444,8 +446,9 @@ class RadarDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         title : str
             Title to label plot with, None to use default title generated from
             the field and sweep parameters. Parameter is ignored if title_flag
@@ -495,6 +498,7 @@ class RadarDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         # get data for the plot
         data = self._get_data(
@@ -531,7 +535,7 @@ class RadarDisplay(object):
 
     def plot_vpt(
             self, field, mask_tuple=None,
-            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            vmin=None, vmax=None, norm=None, cmap=None, mask_outside=False,
             title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True,
             colorbar_flag=True, colorbar_label=None,
@@ -564,8 +568,9 @@ class RadarDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -620,6 +625,7 @@ class RadarDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         # get data for the plot
         data = self._get_vpt_data(field, mask_tuple, filter_transitions)
@@ -664,7 +670,7 @@ class RadarDisplay(object):
 
     def plot_azimuth_to_rhi(
             self, field, target_azimuth, mask_tuple=None,
-            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            vmin=None, vmax=None, norm=None, cmap=None, mask_outside=False,
             title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True,
             colorbar_flag=True, colorbar_label=None,
@@ -700,8 +706,9 @@ class RadarDisplay(object):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         title : str
             Title to label plot with, None to use default title generated from
             the field and sweep parameters. Parameter is ignored if title_flag
@@ -751,6 +758,7 @@ class RadarDisplay(object):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         data, x, y, z = self._get_azimuth_rhi_data_x_y_z(
             field, target_azimuth, edges, mask_tuple,

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -132,7 +132,7 @@ class AirborneRadarDisplay(RadarDisplay):
 
     def plot_sweep_grid(
             self, field, sweep=0, mask_tuple=None,
-            vmin=None, vmax=None, cmap='jet', norm=None, mask_outside=False,
+            vmin=None, vmax=None, cmap=None, norm=None, mask_outside=False,
             title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True,
             colorbar_flag=True, colorbar_label=None,
@@ -166,8 +166,9 @@ class AirborneRadarDisplay(RadarDisplay):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -216,6 +217,7 @@ class AirborneRadarDisplay(RadarDisplay):
         ax, fig = common.parse_ax_fig(ax, fig)
         norm, vmin, vmax = common.parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = common.parse_cmap(cmap, field)
 
         # get data for the plot
         data = self._get_data(

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -20,7 +20,7 @@ except ImportError:
     _BASEMAP_AVAILABLE = False
 
 from .radardisplay import RadarDisplay
-from .common import parse_ax_fig, parse_norm_vmin_vmax
+from .common import parse_ax_fig, parse_norm_vmin_vmax, parse_cmap
 from ..exceptions import MissingOptionalDependency
 
 
@@ -98,7 +98,7 @@ class RadarMapDisplay(RadarDisplay):
 
     def plot_ppi_map(
             self, field, sweep=0, mask_tuple=None,
-            vmin=None, vmax=None, cmap='jet', norm=None, mask_outside=False,
+            vmin=None, vmax=None, cmap=None, norm=None, mask_outside=False,
             title=None, title_flag=True,
             colorbar_flag=True, colorbar_label=None, ax=None, fig=None,
             lat_lines=None, lon_lines=None,
@@ -135,8 +135,9 @@ class RadarMapDisplay(RadarDisplay):
             matplotlib Normalize instance used to scale luminance data.  If not
             None the vmax and vmin parameters are ignored.  If None, vmin and
             vmax are used for luminance scaling.
-        cmap : str
-            Matplotlib colormap name.
+        cmap : str or None
+            Matplotlib colormap name. None will use the default colormap for
+            the field being plotted as specified by the Py-ART configuration.
         mask_outside : bool
             True to mask data outside of vmin, vmax.  False performs no
             masking.
@@ -213,6 +214,7 @@ class RadarMapDisplay(RadarDisplay):
         ax, fig = parse_ax_fig(ax, fig)
         norm, vmin, vmax = parse_norm_vmin_vmax(
             norm, self._radar, field, vmin, vmax)
+        cmap = parse_cmap(cmap, field)
         if lat_lines is None:
             lat_lines = np.arange(30, 46, 1)
         if lon_lines is None:

--- a/pyart/graph/tests/test_common.py
+++ b/pyart/graph/tests/test_common.py
@@ -49,6 +49,11 @@ def test_parse_norm_vmin_vmax():
     assert norm is not None
 
 
+def test_parse_cmap():
+    assert common.parse_cmap('jet', 'foo') == 'jet'
+    assert common.parse_cmap(None, 'reflectivity') == 'pyart_NWSRef'
+
+
 def test_parse_vmin_vmax():
     radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
     radar.fields['foo'] = {}

--- a/pyart/graph/tests/test_common.py
+++ b/pyart/graph/tests/test_common.py
@@ -59,8 +59,8 @@ def test_parse_vmin_vmax():
     radar.fields['foo'] = {}
 
     vmin, vmax = common.parse_vmin_vmax(radar, 'foo', None, None)
-    assert vmin == -6
-    assert vmax == 100
+    assert vmin is None
+    assert vmax is None
 
     vmin, vmax = common.parse_vmin_vmax(radar, 'foo', 10, 20)
     assert vmin == 10


### PR DESCRIPTION
When plotting radar fields using the various **Display** classes if the colormap (cmap) and luminosity limits (vmin, vmax) are not specified then the defaults for these parameters will be determined by locating the field being plotted in a list of default colormaps and luminosity limits in the Py-ART configuration file.  

These parameters can still be explicitly specified.