### PR TITLE
API: Add transform function to pyart.core

### DIFF
--- a/pyart/core/__init__.py
+++ b/pyart/core/__init__.py
@@ -16,10 +16,30 @@ Core classes
     Radar
     Grid
 
+Coordinate transformations
+==========================
+
+.. autosummary::
+    :toctree: generated/
+
+    antenna_to_cartesian
+    antenna_vectors_to_cartesian
+    cartesian_to_geographic
+    cartesian_vectors_to_geographic
+    cartesian_to_geographic_aeqd
+    geographic_to_cartesian_aeqd
+
 """
 
 from .radar import Radar
 from .grid import Grid
+
+from .transforms import antenna_to_cartesian
+from .transforms import antenna_vectors_to_cartesian
+from .transforms import cartesian_to_geographic
+from .transforms import cartesian_vectors_to_geographic
+from .transforms import cartesian_to_geographic_aeqd
+from .transforms import geographic_to_cartesian_aeqd
 
 # Deprecated function names in this name space
 from ..exceptions import _deprecated_alias

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -48,7 +48,7 @@ PI = np.pi
 
 def antenna_to_cartesian(ranges, azimuths, elevations, debug=False):
     """
-    Return cartesian coordinates from antenna coordinates.
+    Return Cartesian coordinates from antenna coordinates.
 
     Parameters
     ----------
@@ -191,7 +191,7 @@ def _half_angle_complex(complex_angle1, complex_angle2):
     Parameters
     ----------
     complex_angle1, complex_angle2 : complex
-        Complex numbers represeting unit vectors on the unit circle
+        Complex numbers representing unit vectors on the unit circle
 
     Returns
     -------

--- a/pyart/io/__init__.py
+++ b/pyart/io/__init__.py
@@ -63,7 +63,6 @@ Special use
 .. autosummary::
     :toctree: generated/
 
-    add_2d_latlon_axis
     prepare_for_read
 
 """


### PR DESCRIPTION
Add functions from the transforms module to the `pyart.core` namespace so that they are in the public API.  Remove the deprecated `add_2d_latlon_axis` function from the User Reference Guide.