### PR TITLE
ENH: Add norm parameter to plotting methods

### DIFF
--- a/pyart/graph/common.py
+++ b/pyart/graph/common.py
@@ -9,6 +9,7 @@ Common graphing routines.
 
     parse_ax
     parse_ax_fig
+    parse_norm_vmin_vmax
     parse_vmin_vmax
     parse_lon_lat
     generate_colorbar_label
@@ -64,6 +65,16 @@ def parse_ax_fig(ax, fig):
     if fig is None:
         fig = plt.gcf()
     return ax, fig
+
+
+def parse_norm_vmin_vmax(norm, container, field, vmin, vmax):
+    """ Parse and return norm, vmin and vmax parameters. """
+    if norm is None:
+        vmin, vmax = parse_vmin_vmax(container, field, vmin, vmax)
+    else:
+        vmin = None
+        vmax = None
+    return norm, vmin, vmax
 
 
 def parse_vmin_vmax(container, field, vmin, vmax):

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -151,7 +151,8 @@ class GridMapDisplay(object):
             lon_lines, labels=[False, False, False, True])
 
     def plot_grid(
-            self, field, level=0, vmin=None, vmax=None, cmap='jet',
+            self, field, level=0,
+            vmin=None, vmax=None, norm=None, cmap='jet',
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=False,
             colorbar_flag=True, colorbar_label=None,
@@ -169,6 +170,11 @@ class GridMapDisplay(object):
             Lower and upper range for the colormesh.  If either parameter is
             None, a value will be determined from the field attributes (if
             available) or the default values of -8, 64 will be used.
+            Parameters are ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name or colormap object.
         mask_outside : bool
@@ -209,7 +215,8 @@ class GridMapDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self.grid, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self.grid, field, vmin, vmax)
 
         basemap = self.get_basemap()
 
@@ -223,7 +230,8 @@ class GridMapDisplay(object):
         # plot the grid
         lons, lats = self.grid.get_point_longitude_latitude(edges=edges)
         pm = basemap.pcolormesh(
-            lons, lats, data, vmin=vmin, vmax=vmax, cmap=cmap, latlon=True)
+            lons, lats, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm,
+            latlon=True)
         self.mappables.append(pm)
         self.fields.append(field)
 
@@ -297,6 +305,11 @@ class GridMapDisplay(object):
             Lower and upper range for the colormesh.  If either parameter is
             None, a value will be determined from the field attributes (if
             available) or the default values of -8, 64 will be used.
+            Parameters are ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name or colormap object.
         mask_outside : bool
@@ -345,7 +358,8 @@ class GridMapDisplay(object):
             colorbar_orient=colorbar_orient, edges=edges, ax=ax, fig=fig)
 
     def plot_latitudinal_level(
-            self, field, y_index, vmin=None, vmax=None, cmap='jet',
+            self, field, y_index,
+            vmin=None, vmax=None, norm=None, cmap='jet',
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
             colorbar_label=None, colorbar_orient='vertical', edges=True,
@@ -363,6 +377,11 @@ class GridMapDisplay(object):
             Lower and upper range for the colormesh.  If either parameter is
             None, a value will be determined from the field attributes (if
             available) or the default values of -8, 64 will be used.
+            Parameters are ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name or colormap object.
         mask_outside : bool
@@ -403,7 +422,8 @@ class GridMapDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self.grid, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self.grid, field, vmin, vmax)
 
         data = self.grid.fields[field]['data'][:, y_index, :]
 
@@ -421,7 +441,8 @@ class GridMapDisplay(object):
             if len(z_1d) > 1:
                 z_1d = _interpolate_axes_edges(z_1d)
         xd, yd = np.meshgrid(x_1d, z_1d)
-        pm = ax.pcolormesh(xd, yd, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            xd, yd, data, vmin=vmin, vmax=vmax, norm=norm, cmap=cmap)
         self.mappables.append(pm)
         self.fields.append(field)
 
@@ -442,7 +463,8 @@ class GridMapDisplay(object):
         return
 
     def plot_longitude_slice(
-            self, field, lon=None, lat=None, vmin=None, vmax=None, cmap='jet',
+            self, field, lon=None, lat=None,
+            vmin=None, vmax=None, norm=None, cmap='jet',
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
             colorbar_label=None, colorbar_orient='vertical', edges=True,
@@ -461,6 +483,11 @@ class GridMapDisplay(object):
             Lower and upper range for the colormesh.  If either parameter is
             None, a value will be determined from the field attributes (if
             available) or the default values of -8, 64 will be used.
+            Parameters are ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name or colormap object.
         mask_outside : bool
@@ -501,14 +528,16 @@ class GridMapDisplay(object):
         """
         x_index, _ = self._find_nearest_grid_indices(lon, lat)
         self.plot_longitudinal_level(
-            field=field, x_index=x_index, vmin=vmin, vmax=vmax, cmap=cmap,
+            field=field, x_index=x_index,
+            vmin=vmin, vmax=vmax, norm=norm, cmap=cmap,
             mask_outside=mask_outside, title=title, title_flag=title_flag,
             axislabels=axislabels, axislabels_flag=axislabels_flag,
             colorbar_flag=colorbar_flag, colorbar_label=colorbar_label,
             colorbar_orient=colorbar_orient, edges=edges, ax=ax, fig=fig)
 
     def plot_longitudinal_level(
-            self, field, x_index, vmin=None, vmax=None, cmap='jet',
+            self, field, x_index,
+            vmin=None, vmax=None, norm=None, cmap='jet',
             mask_outside=False, title=None, title_flag=True,
             axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
             colorbar_label=None, colorbar_orient='vertical', edges=True,
@@ -526,6 +555,11 @@ class GridMapDisplay(object):
             Lower and upper range for the colormesh.  If either parameter is
             None, a value will be determined from the field attributes (if
             available) or the default values of -8, 64 will be used.
+            Parameters are ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name or colormap object.
         mask_outside : bool
@@ -566,7 +600,8 @@ class GridMapDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self.grid, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self.grid, field, vmin, vmax)
 
         data = self.grid.fields[field]['data'][:, :, x_index]
 
@@ -584,7 +619,8 @@ class GridMapDisplay(object):
             if len(z_1d) > 1:
                 z_1d = _interpolate_axes_edges(z_1d)
         xd, yd = np.meshgrid(y_1d, z_1d)
-        pm = ax.pcolormesh(xd, yd, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            xd, yd, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
         self.mappables.append(pm)
         self.fields.append(field)
 

--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -294,12 +294,14 @@ class RadarDisplay(object):
         self.plots.append(line)
         self.plot_vars.append(field)
 
-    def plot_ppi(self, field, sweep=0, mask_tuple=None, vmin=None, vmax=None,
-                 cmap='jet', mask_outside=False, title=None, title_flag=True,
-                 axislabels=(None, None), axislabels_flag=True,
-                 colorbar_flag=True, colorbar_label=None,
-                 colorbar_orient='vertical', edges=True, gatefilter=None,
-                 filter_transitions=True, ax=None, fig=None):
+    def plot_ppi(
+            self, field, sweep=0, mask_tuple=None,
+            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True,
+            colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True, gatefilter=None,
+            filter_transitions=True, ax=None, fig=None):
         """
         Plot a PPI.
 
@@ -318,8 +320,14 @@ class RadarDisplay(object):
             NCP < 0.5 set mask_tuple to ['NCP', 0.5]. None performs no masking.
         vmin : float
             Luminance minimum value, None for default value.
+            Parameter is ignored is norm is not None.
         vmax : float
             Luminance maximum value, None for default value.
+            Parameter is ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name.
         mask_outside : bool
@@ -368,7 +376,8 @@ class RadarDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self._radar, field, vmin, vmax)
 
         # get data for the plot
         data = self._get_data(
@@ -379,7 +388,8 @@ class RadarDisplay(object):
         _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
-        pm = ax.pcolormesh(x, y, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            x, y, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
 
         if title_flag:
             self._set_title(field, sweep, title, ax)
@@ -396,13 +406,14 @@ class RadarDisplay(object):
                 mappable=pm, label=colorbar_label, orient=colorbar_orient,
                 field=field, ax=ax, fig=fig)
 
-    def plot_rhi(self, field, sweep=0, mask_tuple=None, vmin=None, vmax=None,
-                 cmap='jet', mask_outside=False, title=None, title_flag=True,
-                 axislabels=(None, None), axislabels_flag=True,
-                 reverse_xaxis=None, colorbar_flag=True, colorbar_label=None,
-                 colorbar_orient='vertical', edges=True,
-                 gatefilter=None,
-                 filter_transitions=True, ax=None, fig=None):
+    def plot_rhi(
+            self, field, sweep=0, mask_tuple=None,
+            vmin=None, vmax=None, norm=None, cmap='jet',
+            mask_outside=False, title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True,
+            reverse_xaxis=None, colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True, gatefilter=None,
+            filter_transitions=True, ax=None, fig=None):
         """
         Plot a RHI.
 
@@ -421,8 +432,14 @@ class RadarDisplay(object):
             NCP < 0.5 set mask to ['NCP', 0.5]. None performs no masking.
         vmin : float
             Luminance minimum value, None for default value.
+            Parameter is ignored is norm is not None.
         vmax : float
             Luminance maximum value, None for default value.
+            Parameter is ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name.
         title : str
@@ -472,7 +489,8 @@ class RadarDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self._radar, field, vmin, vmax)
 
         # get data for the plot
         data = self._get_data(
@@ -489,7 +507,8 @@ class RadarDisplay(object):
             reverse_xaxis = np.all(R < 1.)
         if reverse_xaxis:
             R = -R
-        pm = ax.pcolormesh(R, z, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            R, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
 
         if title_flag:
             self._set_title(field, sweep, title, ax)
@@ -506,13 +525,15 @@ class RadarDisplay(object):
                 mappable=pm, label=colorbar_label, orient=colorbar_orient,
                 field=field, ax=ax, fig=fig)
 
-    def plot_vpt(self, field, mask_tuple=None, vmin=None, vmax=None,
-                 cmap='jet', mask_outside=False, title=None, title_flag=True,
-                 axislabels=(None, None), axislabels_flag=True,
-                 colorbar_flag=True, colorbar_label=None,
-                 colorbar_orient='vertical', edges=True,
-                 filter_transitions=True, time_axis_flag=False,
-                 date_time_form=None, tz=None, ax=None, fig=None):
+    def plot_vpt(
+            self, field, mask_tuple=None,
+            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True,
+            colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True,
+            filter_transitions=True, time_axis_flag=False,
+            date_time_form=None, tz=None, ax=None, fig=None):
         """
         Plot a VPT scan.
 
@@ -529,8 +550,14 @@ class RadarDisplay(object):
             NCP < 0.5 set mask_tuple to ['NCP', 0.5]. None performs no masking.
         vmin : float
             Luminance minimum value, None for default value.
+            Parameter is ignored is norm is not None.
         vmax : float
             Luminance maximum value, None for default value.
+            Parameter is ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name.
         mask_outside : bool
@@ -585,7 +612,8 @@ class RadarDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self._radar, field, vmin, vmax)
 
         # get data for the plot
         data = self._get_vpt_data(field, mask_tuple, filter_transitions)
@@ -610,7 +638,8 @@ class RadarDisplay(object):
         _mask_outside(mask_outside, data, vmin, vmax)
 
         # plot the data
-        pm = ax.pcolormesh(x, y, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            x, y, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
 
         if title_flag:
             self._set_vpt_title(field, title, ax)
@@ -627,15 +656,14 @@ class RadarDisplay(object):
                 mappable=pm, label=colorbar_label, orient=colorbar_orient,
                 field=field, ax=ax, fig=fig)
 
-    def plot_azimuth_to_rhi(self, field, target_azimuth,
-                            mask_tuple=None, vmin=None, vmax=None,
-                            cmap='jet', mask_outside=False,
-                            title=None, title_flag=True,
-                            axislabels=(None, None), axislabels_flag=True,
-                            reverse_xaxis=None, colorbar_flag=True,
-                            colorbar_label=None, colorbar_orient='vertical',
-                            edges=True, gatefilter=None,
-                            filter_transitions=True, ax=None, fig=None):
+    def plot_azimuth_to_rhi(
+            self, field, target_azimuth, mask_tuple=None,
+            vmin=None, vmax=None, norm=None, cmap='jet', mask_outside=False,
+            title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True,
+            colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True, gatefilter=None,
+            reverse_xaxis=None, filter_transitions=True, ax=None, fig=None):
         """
         Plot pseudo-RHI scan by extracting the vertical field associated
         with the given azimuth.
@@ -655,8 +683,14 @@ class RadarDisplay(object):
             NCP < 0.5 set mask to ['NCP', 0.5]. None performs no masking.
         vmin : float
             Luminance minimum value, None for default value.
+            Parameter is ignored is norm is not None.
         vmax : float
             Luminance maximum value, None for default value.
+            Parameter is ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name.
         title : str
@@ -706,7 +740,8 @@ class RadarDisplay(object):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self._radar, field, vmin, vmax)
 
         data, x, y, z = self._get_azimuth_rhi_data_x_y_z(
             field, target_azimuth, edges, mask_tuple,
@@ -722,7 +757,8 @@ class RadarDisplay(object):
             reverse_xaxis = np.all(R < 1.)
         if reverse_xaxis:
             R = -R
-        pm = ax.pcolormesh(R, z, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            R, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
 
         if title_flag:
             self._set_az_rhi_title(field, target_azimuth, title, ax)

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -131,11 +131,13 @@ class AirborneRadarDisplay(RadarDisplay):
         return
 
     def plot_sweep_grid(
-            self, field, sweep=0, mask_tuple=None, vmin=None, vmax=None,
-            cmap='jet', mask_outside=False, title=None, title_flag=True,
-            axislabels=(None, None), axislabels_flag=True, colorbar_flag=True,
-            colorbar_label=None, colorbar_orient='vertical', edges=True,
-            filter_transitions=True, ax=None, fig=None, gatefilter=None):
+            self, field, sweep=0, mask_tuple=None,
+            vmin=None, vmax=None, cmap='jet', norm=None, mask_outside=False,
+            title=None, title_flag=True,
+            axislabels=(None, None), axislabels_flag=True,
+            colorbar_flag=True, colorbar_label=None,
+            colorbar_orient='vertical', edges=True, filter_transitions=True,
+            ax=None, fig=None, gatefilter=None):
         """
         Plot a sweep as a grid.
 
@@ -154,8 +156,14 @@ class AirborneRadarDisplay(RadarDisplay):
             NCP < 0.5 set mask_tuple to ['NCP', 0.5]. None performs no masking.
         vmin : float
             Luminance minimum value, None for default value.
+            Parameter is ignored is norm is not None.
         vmax : float
             Luminance maximum value, None for default value.
+            Parameter is ignored is norm is not None.
+        norm : Normalize or None, optional
+            matplotlib Normalize instance used to scale luminance data.  If not
+            None the vmax and vmin parameters are ignored.  If None, vmin and
+            vmax are used for luminance scaling.
         cmap : str
             Matplotlib colormap name.
         mask_outside : bool
@@ -204,7 +212,8 @@ class AirborneRadarDisplay(RadarDisplay):
         """
         # parse parameters
         ax, fig = common.parse_ax_fig(ax, fig)
-        vmin, vmax = common.parse_vmin_vmax(self._radar, field, vmin, vmax)
+        norm, vmin, vmax = common.parse_norm_vmin_vmax(
+            norm, self._radar, field, vmin, vmax)
 
         # get data for the plot
         data = self._get_data(
@@ -217,7 +226,8 @@ class AirborneRadarDisplay(RadarDisplay):
             data = np.ma.masked_outside(data, vmin, vmax)
 
         # plot the data
-        pm = ax.pcolormesh(x, z, data, vmin=vmin, vmax=vmax, cmap=cmap)
+        pm = ax.pcolormesh(
+            x, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
 
         if title_flag:
             self._set_title(field, sweep, title, ax)

--- a/pyart/graph/tests/test_common.py
+++ b/pyart/graph/tests/test_common.py
@@ -32,6 +32,23 @@ def test_parse_ax_fig():
     assert fig1 == fig2
 
 
+def test_parse_norm_vmin_vmax():
+    radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
+    radar.fields['foo'] = {}
+
+    norm, vmin, vmax = common.parse_norm_vmin_vmax(None, radar, 'foo', 10, 20)
+    assert vmin == 10
+    assert vmax == 20
+    assert norm is None
+
+    normalize = matplotlib.colors.Normalize()
+    norm, vmin, vmax = common.parse_norm_vmin_vmax(
+        normalize, radar, 'foo', 10, 20)
+    assert vmin is None
+    assert vmax is None
+    assert norm is not None
+
+
 def test_parse_vmin_vmax():
     radar = pyart.testing.make_empty_ppi_radar(1, 1, 1)
     radar.fields['foo'] = {}


### PR DESCRIPTION
The plotting method of the RadarDisplay, RadarMapDisplay, GridMapDisplay and
RadarDisplay_Airborne classes now accept a norm parameter which is passed to
the Matplotlib pcolormesh function as the norm parameter allowing for
customized scaling of the luminance data.