### PR TITLE
BUG: RadarMapDisplay.plot_range_rings

### DIFF
--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -381,6 +381,11 @@ class RadarMapDisplay(RadarDisplay):
             style of the ring.
 
         """
+        # The RadarDisplay.plot_range_rings uses a col parameter to specify
+        # the line color, deal with this here.
+        if 'col' in kwargs:
+            color = kwargs.pop('col')
+            kwargs['c'] = color
         self._check_basemap()
         angle = np.linspace(0., 2.0 * np.pi, npts)
         xpts = range_ring_location_km * 1000. * np.sin(angle)

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -25,7 +25,7 @@ def test_radarmapdisplay_ppi(outfile=None):
         resolution='c', min_lon=-100, max_lon=-93, min_lat=33, max_lat=38,
         mask_outside=True)
     display.plot_point(-95, 35, label_text='TEXT')
-    display.plot_range_ring(30)
+    display.plot_range_rings([15, 30])
     display.plot_line_geo(np.array([-95, -95]), np.array([33, 38]))
     if outfile:
         fig.savefig(outfile)


### PR DESCRIPTION
Fix bug causing RadarMapDisplay.plot_range_rings to error due to an undefined
col parameter being passed to basemap.plot method.