### PR TITLE
BUG: Do not set valid_min/max if all data masked

### DIFF
--- a/pyart/correct/_common_dealias.py
+++ b/pyart/correct/_common_dealias.py
@@ -68,6 +68,9 @@ def _parse_rays_wrap_around(rays_wrap_around, radar):
 def _set_limits(data, nyquist_vel, dic):
     """ Set the valid_min and valid_max keys in dic from dealiased data. """
     max_abs_vel = np.ma.max(np.ma.abs(data))
+    if max_abs_vel is np.ma.masked:
+        # all velocities are masked, do not set valid_min and valid_max
+        return
     max_nyq_vel = np.ma.max(nyquist_vel)
     max_nyq_int = 2. * max_nyq_vel
     added_intervals = np.ceil((max_abs_vel - max_nyq_vel) / (max_nyq_int))

--- a/pyart/correct/tests/test_region_dealias.py
+++ b/pyart/correct/tests/test_region_dealias.py
@@ -36,6 +36,8 @@ def test_all_masked():
         radar.fields['velocity']['data'], mask=True)
     dealias_vel = pyart.correct.dealias_region_based(radar)
     assert np.all(np.ma.getmaskarray(dealias_vel['data']))
+    assert 'valid_min' not in dealias_vel
+    assert 'valid_max' not in dealias_vel
 
 
 def test_no_edges():


### PR DESCRIPTION
Do not set the valid_min and valid_max entries in the dealiasing velocities
dictionary when all the velocities are masked.