### PR TITLE
BUG: instrument parameter skipped if dim not known

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -548,9 +548,13 @@ def write_cfradial(filename, radar, format='NETCDF4', time_reference=None,
         for k in radar.instrument_parameters.keys():
             if k in _INSTRUMENT_PARAMS_DIMS:
                 dim = _INSTRUMENT_PARAMS_DIMS[k]
+                _create_ncvar(radar.instrument_parameters[k], dataset, k, dim)
             else:
-                dim = ()
-            _create_ncvar(radar.instrument_parameters[k], dataset, k, dim)
+                # Do not try to write instrument parameter whose dimensions are
+                # not known, rather issue a warning and skip the parameter
+                message = ("Unknown instrument parameter: %s, " % (k) +
+                           "not written to file.")
+                warnings.warn(message)
 
     # radar_calibration variables
     if radar.radar_calibration is not None and radar.radar_calibration != {}:

--- a/pyart/io/tests/test_cfradial.py
+++ b/pyart/io/tests/test_cfradial.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 from numpy.ma.core import MaskedArray
 from numpy.testing import assert_array_equal, assert_almost_equal
-from numpy.testing import assert_raises
+from numpy.testing import assert_raises, assert_warns
 import netCDF4
 
 import pyart
@@ -303,6 +303,19 @@ def test_write_ppi_U1():
         # force the sweep mode array to be a masked U1 array
         radar.sweep_mode['data'] = radar.sweep_mode['data'].astype('U')
         pyart.io.write_cfradial(tmpfile, radar)
+        ref = netCDF4.Dataset(pyart.testing.CFRADIAL_PPI_FILE)
+        dset = netCDF4.Dataset(tmpfile)
+        check_dataset_to_ref(dset, ref)
+        dset.close()
+
+
+def test_write_ppi_unknown_instrument_parameter_element():
+    # CF/Radial example file -> Radar object -> netCDF file
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_ppi_unknonw_ip.nc'
+        radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+        radar.instrument_parameters['foobar'] = {'data': np.zeros(40)}
+        assert_warns(UserWarning, pyart.io.write_cfradial, tmpfile, radar)
         ref = netCDF4.Dataset(pyart.testing.CFRADIAL_PPI_FILE)
         dset = netCDF4.Dataset(tmpfile)
         check_dataset_to_ref(dset, ref)


### PR DESCRIPTION
Elements of the instrument_parameter dictionary whose dimensions are not know
are skipped when writing Cf/Radial files using the write_cfradial function.