### PR TITLE
BUG: Better error message of unsupported MDV proj

### DIFF
--- a/pyart/io/mdv_common.py
+++ b/pyart/io/mdv_common.py
@@ -1089,10 +1089,14 @@ class MdvFile(object):
         if self.field_headers[0]['proj_type'] == PROJ_RHI_RADAR:
             el_deg = grid_miny + np.arange(nrays) * grid_dy
             az_deg = self.vlevel_headers[0]['level'][0:nsweeps]
-
-        if self.field_headers[0]['proj_type'] == PROJ_POLAR_RADAR:
+        elif self.field_headers[0]['proj_type'] == PROJ_POLAR_RADAR:
             az_deg = grid_miny + np.arange(nrays) * grid_dy
             el_deg = self.vlevel_headers[0]['level'][0:nsweeps]
+        else:
+            proj_type = self.field_headers[0]['proj_type']
+            message = ("Unsupported projection type: %i, " % (proj_type) +
+                       "is MDV file in antenna coordinates?")
+            raise NotImplementedError(message)
 
         return az_deg, range_km, el_deg
 

--- a/pyart/io/tests/test_mdv_common.py
+++ b/pyart/io/tests/test_mdv_common.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from io import BytesIO
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_raises
 
 import pyart
 from pyart.io.mdv_common import MdvFile
@@ -240,6 +240,11 @@ def test_geometry():
     assert_almost_equal(range_km[10], 1.32, 2)
     assert len(el_deg) == 1
     assert el_deg[0] == 0.75
+
+
+def test_geometry_raises():
+    mdvfile = MdvFile(pyart.testing.MDV_GRID_FILE)
+    assert_raises(NotImplementedError, mdvfile._calc_geometry)
 
 
 def test_mdv_time():


### PR DESCRIPTION
A more informative error message is raised when trying to determine the
azimuth, elevation and range values for a MDV file in a projection type not
supported by Py-ART.