### PR TITLE
BUG: Docs can be build in Sphinx 1.3

### DIFF
--- a/continuous_integration/build_docs.sh
+++ b/continuous_integration/build_docs.sh
@@ -6,7 +6,7 @@ set -e
 cd "$TRAVIS_BUILD_DIR"
 
 echo "Building Docs"
-conda install --yes sphinx=1.2.3 pil
+conda install --yes sphinx pil
 
 mv "$TRAVIS_BUILD_DIR"/doc /tmp
 cd /tmp/doc

--- a/doc/source/_static/scipy.css
+++ b/doc/source/_static/scipy.css
@@ -1,4 +1,4 @@
-@import "default.css";
+@import "classic.css";
 
 /**
  * Spacing fixes

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Py-ART'
-copyright = u'2013, Py-ART developers'
+copyright = u'2013-2016, Py-ART developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -97,6 +97,7 @@ pygments_style = 'sphinx'
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
+html_theme = 'classic'
 html_style = 'scipy.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to


### PR DESCRIPTION
Documentation can be build using Sphinx 1.3.x, tested with 1.3.5

closes #375