### PR TITLE
DOC: Building of examples opt-in

### DIFF
--- a/doc/rebuild_docs.sh
+++ b/doc/rebuild_docs.sh
@@ -1,7 +1,5 @@
-# script to rebuild documentation aftter removing intermediates
+# script to rebuild documentation after removing intermediates
 rm -r build
 rm source/user_reference/generated/*
 rm source/dev_reference/generated/*
-rm -r source/auto_examples/*
 make html
-

--- a/doc/rebuild_examples.sh
+++ b/doc/rebuild_examples.sh
@@ -1,5 +1,5 @@
-# script to rebuild documentation aftter removing intermediates
+# script to rebuild Py-ART example after removing intermediates
 rm -r build
 rm -r source/auto_examples/*
-make html
+BUILD_PYART_EXAMPLES=1 make html
 

--- a/doc/rebuild_full_docs.sh
+++ b/doc/rebuild_full_docs.sh
@@ -1,0 +1,7 @@
+# script to rebuild complete documentation include examples after removing
+# intermediates
+rm -r build
+rm source/user_reference/generated/*
+rm source/dev_reference/generated/*
+rm -r source/auto_examples/*
+BUILD_PYART_EXAMPLES=1 make html

--- a/doc/rebuild_guides.sh
+++ b/doc/rebuild_guides.sh
@@ -1,6 +1,0 @@
-# script to rebuild documentation aftter removing intermediates
-rm -r build
-rm source/user_reference/generated/*
-rm source/dev_reference/generated/*
-make html
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,10 +26,10 @@ except:
     pass
 
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
-              'sphinx.ext.autosummary', 'numpydoc', 'gen_rst']
-# don't include examples in CI builds
-if 'CI' in os.environ and os.environ['CI'] == 'true':
-    extensions.remove('gen_rst')
+              'sphinx.ext.autosummary', 'numpydoc']
+# only include examples if the BUILD_PYART_EXAMPLES env. variable is set
+if 'BUILD_PYART_EXAMPLES' in os.environ:
+    extensions.append('gen_rst')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
The default behavior when build the Py-ART documentation is to not build the
documentation for the examples. This can be changed by setting a
BUILD_PYART_EXAMPLES environment variables.  Alternatively one of the three
rebuild_ scripts in the docs folder can be used:

 * rebuild_docs.sh : Rebuild standard docs, examples built only if variable set.
 * rebuild_example.sh : Rebuild the example (and the other docs).
 * rebuild_full_docs.sh : Rebuild the full docs including the examples.

If the examples have never been built a single warning will be raised about the
lack of examples.  This can be ignored.