### PR TITLE
Python 3 support for building the documentation

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -2,7 +2,7 @@
 Example generation for Py-ART
 
 Generate the rst files for the examples by iterating over the Python
-example files.  
+example files.
 
 Files that generate images should state with 'plot'
 
@@ -10,10 +10,10 @@ Files that generate images should state with 'plot'
 
 # This files was adapted from the scikit-learn file of the same name:
 # https://github.com/scikit-learn/scikit-learn/blob/master/doc/sphinxext/gen_rst.py
-# 
+#
 # The scikit-learn project uses this following License which applies to this
 # file.
-# 
+#
 # New BSD License
 #
 # Copyright (c) 2007-2013 The scikit-learn developers.
@@ -46,6 +46,8 @@ Files that generate images should state with 'plot'
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 # DAMAGE.
 
+from __future__ import division, print_function
+
 from time import time
 import os
 import re
@@ -53,11 +55,36 @@ import shutil
 import traceback
 import glob
 import sys
-from StringIO import StringIO
-import cPickle
-import urllib2
 import gzip
 import posixpath
+
+# Try Python 2 first, otherwise load from Python 3
+try:
+    from StringIO import StringIO
+    import cPickle as pickle
+    import urllib2 as urllib
+    from urllib2 import HTTPError, URLError
+except:
+    from io import StringIO
+    import pickle
+    import urllib.request
+    import urllib.error
+    import urllib.parse
+    from urllib.error import HTTPError, URLError
+
+try:
+    # Python 2 built-in
+    execfile
+except NameError:
+    def execfile(filename, global_vars=None, local_vars=None):
+        with open(filename, encoding='utf-8') as f:
+            code = compile(f.read(), filename, 'exec')
+            exec(code, global_vars, local_vars)
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 try:
     from PIL import Image
@@ -96,7 +123,7 @@ class Tee(object):
 def get_data(url):
     """Helper function to get data over http or from a local file"""
     if url.startswith('http://'):
-        resp = urllib2.urlopen(url)
+        resp = urllib.urlopen(url)
         encoding = resp.headers.dict.get('content-encoding', 'plain')
         data = resp.read()
         if encoding == 'plain':
@@ -397,14 +424,18 @@ SINGLE_IMAGE = """
 def extract_docstring(filename, ignore_heading=False):
     """ Extract a module-level docstring, if any
     """
-    lines = file(filename).readlines()
+    if sys.version_info >= (3, 0):
+        lines = open(filename, encoding='utf-8').readlines()
+    else:
+        lines = open(filename).readlines()
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
         start_row = 1
     docstring = ''
     first_par = ''
-    tokens = tokenize.generate_tokens(iter(lines).next)
+    line_iterator = iter(lines)
+    tokens = tokenize.generate_tokens(lambda: next(line_iterator))
     for tok_type, tok_content, _, (erow, _), _ in tokens:
         tok_type = token.tok_name[tok_type]
         if tok_type in ('NEWLINE', 'COMMENT', 'NL', 'INDENT', 'DEDENT'):
@@ -449,7 +480,7 @@ def generate_example_rst(app):
         os.makedirs(root_dir)
 
     # we create an index.rst with all examples
-    fhindex = file(os.path.join(root_dir, 'index.rst'), 'w')
+    fhindex = open(os.path.join(root_dir, 'index.rst'), 'w')
     fhindex.write("""\
 
 
@@ -595,12 +626,16 @@ Examples
 def extract_line_count(filename, target_dir):
     # Extract the line count of a file
     example_file = os.path.join(target_dir, filename)
-    lines = file(example_file).readlines()
+    if sys.version_info >= (3, 0):
+        lines = open(example_file, encoding='utf-8').readlines()
+    else:
+        lines = open(example_file).readlines()
     start_row = 0
     if lines and lines[0].startswith('#!'):
         lines.pop(0)
         start_row = 1
-    tokens = tokenize.generate_tokens(lines.__iter__().next)
+    line_iterator = iter(lines)
+    tokens = tokenize.generate_tokens(lambda: next(line_iterator))
     check_docstring = True
     erow_docstring = 0
     for tok_type, _, _, (erow, _), _ in tokens:
@@ -615,7 +650,7 @@ def extract_line_count(filename, target_dir):
 
 def line_count_sort(file_list, target_dir):
     # Sort the list of examples by line-count
-    new_list = filter(lambda x: x.endswith('.py'), file_list)
+    new_list = [x for x in file_list if x.endswith('.py')]
     unsorted = np.zeros(shape=(len(new_list), 2))
     unsorted = unsorted.astype(np.object)
     for count, exmpl in enumerate(new_list):
@@ -639,11 +674,11 @@ def generate_dir_rst(dir, fhindex, example_dir, root_dir, plot_gallery):
         target_dir = root_dir
         src_dir = example_dir
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
-        print 80 * '_'
-        print ('Example directory %s does not have a README.txt file' %
-               src_dir)
-        print 'Skipping this directory'
-        print 80 * '_'
+        print(80 * '_')
+        print('Example directory %s does not have a README.txt file' %
+              src_dir)
+        print('Skipping this directory')
+        print(80 * '_')
         return
     fhindex.write("""
 
@@ -651,7 +686,7 @@ def generate_dir_rst(dir, fhindex, example_dir, root_dir, plot_gallery):
 %s
 
 
-""" % file(os.path.join(src_dir, 'README.txt')).read())
+""" % open(os.path.join(src_dir, 'README.txt')).read())
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
     sorted_listdir = line_count_sort(os.listdir(src_dir),
@@ -731,7 +766,7 @@ def make_thumbnail(in_fname, out_fname, width, height):
 
     # insert centered
     thumb = Image.new('RGB', (width, height), (255, 255, 255))
-    pos_insert = ((width - width_sc) / 2, (height - height_sc) / 2)
+    pos_insert = ((width - width_sc) // 2, (height - height_sc) // 2)
     thumb.paste(img, pos_insert)
 
     thumb.save(out_fname)
@@ -801,7 +836,7 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
         if not os.path.exists(first_image_file) or \
            os.stat(first_image_file).st_mtime <= os.stat(src_file).st_mtime:
             # We need to execute the code
-            print 'plotting %s' % fname
+            print('plotting %s' % fname)
             t0 = time()
             import matplotlib.pyplot as plt
             plt.close('all')
@@ -822,7 +857,7 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
 
                 # get variables so we can later add links to the documentation
                 example_code_obj = {}
-                for var_name, var in my_globals.iteritems():
+                for var_name, var in my_globals.items():
                     if not hasattr(var, '__module__'):
                         continue
                     if not isinstance(var.__module__, basestring):
@@ -890,8 +925,8 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
                     # save the dictionary, so we can later add hyperlinks
                     codeobj_fname = example_file[:-3] + '_codeobj.pickle'
                     with open(codeobj_fname, 'wb') as fid:
-                        cPickle.dump(example_code_obj, fid,
-                                     cPickle.HIGHEST_PROTOCOL)
+                        pickle.dump(example_code_obj, fid,
+                                    pickle.HIGHEST_PROTOCOL)
                     fid.close()
 
                 if '__doc__' in my_globals:
@@ -922,15 +957,15 @@ def generate_file_rst(fname, target_dir, src_dir, plot_gallery):
                     plt.savefig(image_path % fig_num)
                     figure_list.append(image_fname % fig_num)
             except:
-                print 80 * '_'
-                print '%s is not compiling:' % fname
+                print(80 * '_')
+                print('%s is not compiling:' % fname)
                 traceback.print_exc()
-                print 80 * '_'
+                print(80 * '_')
             finally:
                 os.chdir(cwd)
                 sys.stdout = orig_stdout
 
-            print " - time elapsed : %.2g sec" % time_elapsed
+            print(" - time elapsed : %.2g sec" % time_elapsed)
         else:
             figure_list = [f[len(image_dir):]
                             for f in glob.glob(image_path % '[1-9]')]
@@ -967,7 +1002,7 @@ def embed_code_links(app, exception):
     try:
         if exception is not None:
             return
-        print 'Embedding documentation hyperlinks in examples..'
+        print('Embedding documentation hyperlinks in examples..')
 
         # Add resolvers for the packages for which we want to show links
         doc_resolvers = {}
@@ -994,7 +1029,7 @@ def embed_code_links(app, exception):
 
         for dirpath, _, filenames in os.walk(html_example_dir):
             for fname in filenames:
-                print '\tprocessing: %s' % fname
+                print('\tprocessing: %s' % fname)
                 full_fname = os.path.join(html_example_dir, dirpath, fname)
                 subpath = dirpath[len(html_example_dir) + 1:]
                 pickle_fname = os.path.join(example_dir, subpath,
@@ -1003,7 +1038,7 @@ def embed_code_links(app, exception):
                 if os.path.exists(pickle_fname):
                     # we have a pickle file with the objects to embed links for
                     with open(pickle_fname, 'rb') as fid:
-                        example_code_obj = cPickle.load(fid)
+                        example_code_obj = pickle.load(fid)
                     fid.close()
                     str_repl = {}
                     # generate replacement strings with the links
@@ -1031,16 +1066,16 @@ def embed_code_links(app, exception):
                                 for name, link in str_repl.iteritems():
                                     line = line.replace(name, link)
                                 fid.write(line.encode('utf-8'))
-    except urllib2.HTTPError, e:
-        print ("The following HTTP Error has occurred:\n")
-        print e.code
-    except urllib2.URLError, e:
-        print ("\n...\n"
-               "Warning: Embedding the documentation hyperlinks requires "
-               "internet access.\nPlease check your network connection.\n"
-               "Unable to continue embedding due to a URL Error: \n")
-        print e.args
-    print '[done]'
+    except HTTPError as e:
+        print("The following HTTP Error has occurred:\n")
+        print(e.code)
+    except URLError as e:
+        print("\n...\n"
+              "Warning: Embedding the documentation hyperlinks requires "
+              "internet access.\nPlease check your network connection.\n"
+              "Unable to continue embedding due to a URL Error: \n")
+        print(e.args)
+    print('[done]')
 
 
 def setup(app):

--- a/doc/sphinxext/numpydoc/comment_eater.py
+++ b/doc/sphinxext/numpydoc/comment_eater.py
@@ -106,7 +106,7 @@ class CommentBlocker(object):
 
     def new_comment(self, string, start, end, line):
         """ Possibly add a new comment.
-        
+
         Only adds a new comment if this comment is the only thing on the line.
         Otherwise, it extends the noncomment block.
         """

--- a/doc/sphinxext/numpydoc/compiler_unparse.py
+++ b/doc/sphinxext/numpydoc/compiler_unparse.py
@@ -18,7 +18,7 @@ from compiler.ast import Const, Name, Tuple, Div, Mul, Sub, Add
 if sys.version_info[0] >= 3:
     from io import StringIO
 else:
-    from io import StringIO
+    from StringIO import StringIO
 
 def unparse(ast, single_line_functions=False):
     s = StringIO()
@@ -106,13 +106,13 @@ class UnparseCompilerAst:
             if i != len(t.nodes)-1:
                 self._write(") and (")
         self._write(")")
-               
+
     def _AssAttr(self, t):
         """ Handle assigning an attribute of an object
         """
         self._dispatch(t.expr)
         self._write('.'+t.attrname)
- 
+
     def _Assign(self, t):
         """ Expression Assignment such as "a = 1".
 
@@ -150,36 +150,36 @@ class UnparseCompilerAst:
     def _AugAssign(self, t):
         """ +=,-=,*=,/=,**=, etc. operations
         """
-        
+
         self._fill()
         self._dispatch(t.node)
         self._write(' '+t.op+' ')
         self._dispatch(t.expr)
         if not self._do_indent:
             self._write(';')
-            
+
     def _Bitand(self, t):
         """ Bit and operation.
         """
-        
+
         for i, node in enumerate(t.nodes):
             self._write("(")
             self._dispatch(node)
             self._write(")")
             if i != len(t.nodes)-1:
                 self._write(" & ")
-                
+
     def _Bitor(self, t):
         """ Bit or operation
         """
-        
+
         for i, node in enumerate(t.nodes):
             self._write("(")
             self._dispatch(node)
             self._write(")")
             if i != len(t.nodes)-1:
                 self._write(" | ")
-                
+
     def _CallFunc(self, t):
         """ Function call.
         """
@@ -254,7 +254,7 @@ class UnparseCompilerAst:
             self._write(name)
             if asname is not None:
                 self._write(" as "+asname)
-                
+
     def _Function(self, t):
         """ Handle function definitions
         """

--- a/doc/sphinxext/numpydoc/docscrape.py
+++ b/doc/sphinxext/numpydoc/docscrape.py
@@ -9,6 +9,7 @@ import re
 import pydoc
 from warnings import warn
 import collections
+import sys
 
 
 class Reader(object):
@@ -23,10 +24,10 @@ class Reader(object):
            String with lines separated by '\n'.
 
         """
-        if isinstance(data,list):
+        if isinstance(data, list):
             self._str = data
         else:
-            self._str = data.split('\n') # store string as list of lines
+            self._str = data.split('\n')  # store string as list of lines
 
         self.reset()
 
@@ -34,7 +35,7 @@ class Reader(object):
         return self._str[n]
 
     def reset(self):
-        self._l = 0 # current line nr
+        self._l = 0  # current line nr
 
     def read(self):
         if not self.eof():
@@ -66,8 +67,10 @@ class Reader(object):
 
     def read_to_next_empty_line(self):
         self.seek_next_non_empty_line()
+
         def is_empty(line):
             return not line.strip()
+
         return self.read_to_condition(is_empty)
 
     def read_to_next_unindented_line(self):
@@ -75,7 +78,7 @@ class Reader(object):
             return (line.strip() and (len(line.lstrip()) == len(line)))
         return self.read_to_condition(is_unindented)
 
-    def peek(self,n=0):
+    def peek(self, n=0):
         if self._l + n < len(self._str):
             return self[self._l + n]
         else:
@@ -85,8 +88,17 @@ class Reader(object):
         return not ''.join(self._str).strip()
 
 
-class NumpyDocString(object):
+class ParseError(Exception):
+    def __str__(self):
+        message = self.message
+        if hasattr(self, 'docstring'):
+            message = "%s in %r" % (message, self.docstring)
+        return message
+
+
+class NumpyDocString(collections.Mapping):
     def __init__(self, docstring, config={}):
+        orig_docstring = docstring
         docstring = textwrap.dedent(docstring).split('\n')
 
         self._doc = Reader(docstring)
@@ -96,6 +108,7 @@ class NumpyDocString(object):
             'Extended Summary': [],
             'Parameters': [],
             'Returns': [],
+            'Yields': [],
             'Raises': [],
             'Warns': [],
             'Other Parameters': [],
@@ -109,16 +122,26 @@ class NumpyDocString(object):
             'index': {}
             }
 
-        self._parse()
+        try:
+            self._parse()
+        except ParseError as e:
+            e.docstring = orig_docstring
+            raise
 
-    def __getitem__(self,key):
+    def __getitem__(self, key):
         return self._parsed_data[key]
 
-    def __setitem__(self,key,val):
+    def __setitem__(self, key, val):
         if key not in self._parsed_data:
             warn("Unknown section %s" % key)
         else:
             self._parsed_data[key] = val
+
+    def __iter__(self):
+        return iter(self._parsed_data)
+
+    def __len__(self):
+        return len(self._parsed_data)
 
     def _is_at_section(self):
         self._doc.seek_next_non_empty_line()
@@ -131,17 +154,19 @@ class NumpyDocString(object):
         if l1.startswith('.. index::'):
             return True
 
-        l2 = self._doc.peek(1).strip() #    ---------- or ==========
+        l2 = self._doc.peek(1).strip()  # ---------- or ==========
         return l2.startswith('-'*len(l1)) or l2.startswith('='*len(l1))
 
-    def _strip(self,doc):
+    def _strip(self, doc):
         i = 0
         j = 0
-        for i,line in enumerate(doc):
-            if line.strip(): break
+        for i, line in enumerate(doc):
+            if line.strip():
+                break
 
-        for j,line in enumerate(doc[::-1]):
-            if line.strip(): break
+        for j, line in enumerate(doc[::-1]):
+            if line.strip():
+                break
 
         return doc[i:len(doc)-j]
 
@@ -149,7 +174,7 @@ class NumpyDocString(object):
         section = self._doc.read_to_next_empty_line()
 
         while not self._is_at_section() and not self._doc.eof():
-            if not self._doc.peek(-1).strip(): # previous line was empty
+            if not self._doc.peek(-1).strip():  # previous line was empty
                 section += ['']
 
             section += self._doc.read_to_next_empty_line()
@@ -161,14 +186,14 @@ class NumpyDocString(object):
             data = self._read_to_next_section()
             name = data[0].strip()
 
-            if name.startswith('..'): # index section
+            if name.startswith('..'):  # index section
                 yield name, data[1:]
             elif len(data) < 2:
                 yield StopIteration
             else:
                 yield name, self._strip(data[2:])
 
-    def _parse_param_list(self,content):
+    def _parse_param_list(self, content):
         r = Reader(content)
         params = []
         while not r.eof():
@@ -181,13 +206,13 @@ class NumpyDocString(object):
             desc = r.read_to_next_unindented_line()
             desc = dedent_lines(desc)
 
-            params.append((arg_name,arg_type,desc))
+            params.append((arg_name, arg_type, desc))
 
         return params
 
-
     _name_rgx = re.compile(r"^\s*(:(?P<role>\w+):`(?P<name>[a-zA-Z0-9_.-]+)`|"
                            r" (?P<name2>[a-zA-Z0-9_.-]+))\s*", re.X)
+
     def _parse_see_also(self, content):
         """
         func_name : Descriptive text
@@ -207,7 +232,7 @@ class NumpyDocString(object):
                     return g[3], None
                 else:
                     return g[2], g[1]
-            raise ValueError("%s is not a item name" % text)
+            raise ParseError("%s is not a item name" % text)
 
         def push_item(name, rest):
             if not name:
@@ -220,7 +245,8 @@ class NumpyDocString(object):
         rest = []
 
         for line in content:
-            if not line.strip(): continue
+            if not line.strip():
+                continue
 
             m = self._name_rgx.match(line)
             if m and line[m.end():].strip().startswith(':'):
@@ -287,11 +313,23 @@ class NumpyDocString(object):
         self._doc.reset()
         self._parse_summary()
 
-        for (section,content) in self._read_sections():
+        sections = list(self._read_sections())
+        section_names = set([section for section, content in sections])
+
+        has_returns = 'Returns' in section_names
+        has_yields = 'Yields' in section_names
+        # We could do more tests, but we are not. Arbitrarily.
+        if has_returns and has_yields:
+            msg = 'Docstring contains both a Returns and Yields section.'
+            raise ValueError(msg)
+
+        for (section, content) in sections:
             if not section.startswith('..'):
-                section = ' '.join([s.capitalize() for s in section.split(' ')])
-            if section in ('Parameters', 'Returns', 'Raises', 'Warns',
-                           'Other Parameters', 'Attributes', 'Methods'):
+                section = (s.capitalize() for s in section.split(' '))
+                section = ' '.join(section)
+            if section in ('Parameters', 'Returns', 'Yields', 'Raises',
+                           'Warns', 'Other Parameters', 'Attributes',
+                           'Methods'):
                 self[section] = self._parse_param_list(content)
             elif section.startswith('.. index::'):
                 self['index'] = self._parse_index(section, content)
@@ -313,7 +351,7 @@ class NumpyDocString(object):
 
     def _str_signature(self):
         if self['Signature']:
-            return [self['Signature'].replace('*','\*')] + ['']
+            return [self['Signature'].replace('*', '\*')] + ['']
         else:
             return ['']
 
@@ -333,8 +371,11 @@ class NumpyDocString(object):
         out = []
         if self[name]:
             out += self._str_header(name)
-            for param,param_type,desc in self[name]:
-                out += ['%s : %s' % (param, param_type)]
+            for param, param_type, desc in self[name]:
+                if param_type:
+                    out += ['%s : %s' % (param, param_type)]
+                else:
+                    out += [param]
                 out += self._str_indent(desc)
             out += ['']
         return out
@@ -348,7 +389,8 @@ class NumpyDocString(object):
         return out
 
     def _str_see_also(self, func_role):
-        if not self['See Also']: return []
+        if not self['See Also']:
+            return []
         out = []
         out += self._str_header("See Also")
         last_had_desc = True
@@ -375,7 +417,7 @@ class NumpyDocString(object):
     def _str_index(self):
         idx = self['index']
         out = []
-        out += ['.. index:: %s' % idx.get('default','')]
+        out += ['.. index:: %s' % idx.get('default', '')]
         for section, references in idx.items():
             if section == 'default':
                 continue
@@ -387,12 +429,12 @@ class NumpyDocString(object):
         out += self._str_signature()
         out += self._str_summary()
         out += self._str_extended_summary()
-        for param_list in ('Parameters', 'Returns', 'Other Parameters',
-                           'Raises', 'Warns'):
+        for param_list in ('Parameters', 'Returns', 'Yields',
+                           'Other Parameters', 'Raises', 'Warns'):
             out += self._str_param_list(param_list)
         out += self._str_section('Warnings')
         out += self._str_see_also(func_role)
-        for s in ('Notes','References','Examples'):
+        for s in ('Notes', 'References', 'Examples'):
             out += self._str_section(s)
         for param_list in ('Attributes', 'Methods'):
             out += self._str_param_list(param_list)
@@ -400,16 +442,18 @@ class NumpyDocString(object):
         return '\n'.join(out)
 
 
-def indent(str,indent=4):
+def indent(str, indent=4):
     indent_str = ' '*indent
     if str is None:
         return indent_str
     lines = str.split('\n')
     return '\n'.join(indent_str + l for l in lines)
 
+
 def dedent_lines(lines):
     """Deindent a list of lines maximally"""
     return textwrap.dedent("\n".join(lines)).split("\n")
+
 
 def header(text, style='-'):
     return text + '\n' + style*len(text) + '\n'
@@ -418,7 +462,7 @@ def header(text, style='-'):
 class FunctionDoc(NumpyDocString):
     def __init__(self, func, role='func', doc=None, config={}):
         self._f = func
-        self._role = role # e.g. "func" or "meth"
+        self._role = role  # e.g. "func" or "meth"
 
         if doc is None:
             if func is None:
@@ -429,12 +473,17 @@ class FunctionDoc(NumpyDocString):
         if not self['Signature'] and func is not None:
             func, func_name = self.get_func()
             try:
-                # try to read signature
-                argspec = inspect.getargspec(func)
-                argspec = inspect.formatargspec(*argspec)
-                argspec = argspec.replace('*','\*')
-                signature = '%s%s' % (func_name, argspec)
-            except TypeError as e:
+                try:
+                    signature = str(inspect.signature(func))
+                except (AttributeError, ValueError):
+                    # try to read signature, backward compat for older Python
+                    if sys.version_info[0] >= 3:
+                        argspec = inspect.getfullargspec(func)
+                    else:
+                        argspec = inspect.getargspec(func)
+                    signature = inspect.formatargspec(*argspec)
+                signature = '%s%s' % (func_name, signature.replace('*', '\*'))
+            except TypeError:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -458,7 +507,7 @@ class FunctionDoc(NumpyDocString):
         if self._role:
             if self._role not in roles:
                 print("Warning: invalid role %s" % self._role)
-            out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
+            out += '.. %s:: %s\n    \n\n' % (roles.get(self._role, ''),
                                              func_name)
 
         out += super(FunctionDoc, self).__str__(func_role=self._role)
@@ -474,6 +523,9 @@ class ClassDoc(NumpyDocString):
         if not inspect.isclass(cls) and cls is not None:
             raise ValueError("Expected a class or None, but got %r" % cls)
         self._cls = cls
+
+        self.show_inherited_members = config.get(
+                    'show_inherited_class_members', True)
 
         if modulename and not modulename.endswith('.'):
             modulename += '.'
@@ -496,25 +548,38 @@ class ClassDoc(NumpyDocString):
             for field, items in [('Methods', self.methods),
                                  ('Attributes', self.properties)]:
                 if not self[field]:
-                    self[field] = [
-                        (name, '',
-                         splitlines_x(pydoc.getdoc(getattr(self._cls, name))))
-                        for name in sorted(items)]
+                    doc_list = []
+                    for name in sorted(items):
+                        try:
+                            doc_item = pydoc.getdoc(getattr(self._cls, name))
+                            doc_list.append((name, '', splitlines_x(doc_item)))
+                        except AttributeError:
+                            pass  # method doesn't exist
+                    self[field] = doc_list
 
     @property
     def methods(self):
         if self._cls is None:
             return []
-        return [name for name,func in inspect.getmembers(self._cls)
+        return [name for name, func in inspect.getmembers(self._cls)
                 if ((not name.startswith('_')
                      or name in self.extra_public_methods)
-                    and isinstance(func, collections.Callable))]
+                    and isinstance(func, collections.Callable)
+                    and self._is_show_member(name))]
 
     @property
     def properties(self):
         if self._cls is None:
             return []
-        return [name for name,func in inspect.getmembers(self._cls)
-                if not name.startswith('_') and
-                (func is None or isinstance(func, property) or
-                 inspect.isgetsetdescriptor(func))]
+        return [name for name, func in inspect.getmembers(self._cls)
+                if (not name.startswith('_') and
+                    (func is None or isinstance(func, property) or
+                     inspect.isgetsetdescriptor(func))
+                    and self._is_show_member(name))]
+
+    def _is_show_member(self, name):
+        if self.show_inherited_members:
+            return True  # show all class members
+        if name not in self._cls.__dict__:
+            return False  # class member is inherited, we do not show it
+        return True

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -10,58 +10,71 @@ It will:
 - Convert Parameters etc. sections to field lists.
 - Convert See Also section to a See also entry.
 - Renumber references.
-- Extract the signature from the docstring, if it can't be determined otherwise.
+- Extract the signature from the docstring, if it can't be determined
+  otherwise.
 
 .. [1] https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
 
 """
 from __future__ import division, absolute_import, print_function
 
+import sys
+import re
+import pydoc
 import sphinx
+import inspect
 import collections
 
 if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
-import os, sys, re, pydoc
 from .docscrape_sphinx import get_doc_object, SphinxDocString
 from sphinx.util.compat import Directive
-import inspect
+
+if sys.version_info[0] >= 3:
+    sixu = lambda s: s
+else:
+    sixu = lambda s: unicode(s, 'unicode_escape')
+
 
 def mangle_docstrings(app, what, name, obj, options, lines,
                       reference_offset=[0]):
 
-    cfg = dict(use_plots=app.config.numpydoc_use_plots,
-               show_class_members=app.config.numpydoc_show_class_members)
+    cfg = {'use_plots': app.config.numpydoc_use_plots,
+           'show_class_members': app.config.numpydoc_show_class_members,
+           'show_inherited_class_members':
+           app.config.numpydoc_show_inherited_class_members,
+           'class_members_toctree': app.config.numpydoc_class_members_toctree}
 
+    u_NL = sixu('\n')
     if what == 'module':
         # Strip top title
-        title_re = re.compile(u'^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*',
-                              re.I|re.S)
-        lines[:] = title_re.sub(u'', u"\n".join(lines)).split(u"\n")
+        pattern = '^\\s*[#*=]{4,}\\n[a-z0-9 -]+\\n[#*=]{4,}\\s*'
+        title_re = re.compile(sixu(pattern), re.I | re.S)
+        lines[:] = title_re.sub(sixu(''), u_NL.join(lines)).split(u_NL)
     else:
-        doc = get_doc_object(obj, what, u"\n".join(lines), config=cfg)
+        doc = get_doc_object(obj, what, u_NL.join(lines), config=cfg)
         if sys.version_info[0] >= 3:
             doc = str(doc)
         else:
-            doc = str(doc).decode('utf-8')
-        lines[:] = doc.split(u"\n")
+            doc = unicode(doc)
+        lines[:] = doc.split(u_NL)
 
-    if app.config.numpydoc_edit_link and hasattr(obj, '__name__') and \
-           obj.__name__:
+    if (app.config.numpydoc_edit_link and hasattr(obj, '__name__') and
+            obj.__name__):
         if hasattr(obj, '__module__'):
-            v = dict(full_name=u"%s.%s" % (obj.__module__, obj.__name__))
+            v = dict(full_name=sixu("%s.%s") % (obj.__module__, obj.__name__))
         else:
             v = dict(full_name=obj.__name__)
-        lines += [u'', u'.. htmlonly::', u'']
-        lines += [u'    %s' % x for x in
+        lines += [sixu(''), sixu('.. htmlonly::'), sixu('')]
+        lines += [sixu('    %s') % x for x in
                   (app.config.numpydoc_edit_link % v).split("\n")]
 
     # replace reference numbers so that there are no duplicates
     references = []
     for line in lines:
         line = line.strip()
-        m = re.match(u'^.. \\[([a-z0-9_.-])\\]', line, re.I)
+        m = re.match(sixu('^.. \\[([a-z0-9_.-])\\]'), line, re.I)
         if m:
             references.append(m.group(1))
 
@@ -70,35 +83,41 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     if references:
         for i, line in enumerate(lines):
             for r in references:
-                if re.match(u'^\\d+$', r):
-                    new_r = u"R%d" % (reference_offset[0] + int(r))
+                if re.match(sixu('^\\d+$'), r):
+                    new_r = sixu("R%d") % (reference_offset[0] + int(r))
                 else:
-                    new_r = u"%s%d" % (r, reference_offset[0])
-                lines[i] = lines[i].replace(u'[%s]_' % r,
-                                            u'[%s]_' % new_r)
-                lines[i] = lines[i].replace(u'.. [%s]' % r,
-                                            u'.. [%s]' % new_r)
+                    new_r = sixu("%s%d") % (r, reference_offset[0])
+                lines[i] = lines[i].replace(sixu('[%s]_') % r,
+                                            sixu('[%s]_') % new_r)
+                lines[i] = lines[i].replace(sixu('.. [%s]') % r,
+                                            sixu('.. [%s]') % new_r)
 
     reference_offset[0] += len(references)
+
 
 def mangle_signature(app, what, name, obj, options, sig, retann):
     # Do not try to inspect classes that don't define `__init__`
     if (inspect.isclass(obj) and
         (not hasattr(obj, '__init__') or
-        'initializes x; see ' in pydoc.getdoc(obj.__init__))):
+            'initializes x; see ' in pydoc.getdoc(obj.__init__))):
         return '', ''
 
-    if not (isinstance(obj, collections.Callable) or hasattr(obj, '__argspec_is_invalid_')): return
-    if not hasattr(obj, '__doc__'): return
+    if not (isinstance(obj, collections.Callable) or
+            hasattr(obj, '__argspec_is_invalid_')):
+        return
+
+    if not hasattr(obj, '__doc__'):
+        return
 
     doc = SphinxDocString(pydoc.getdoc(obj))
     if doc['Signature']:
-        sig = re.sub(u"^[^(]*", u"", doc['Signature'])
-        return sig, u''
+        sig = re.sub(sixu("^[^(]*"), sixu(""), doc['Signature'])
+        return sig, sixu('')
+
 
 def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):
-        return # probably called by nose, better bail out
+        return  # probably called by nose, better bail out
 
     global get_doc_object
     get_doc_object = get_doc_object_
@@ -108,18 +127,24 @@ def setup(app, get_doc_object_=get_doc_object):
     app.add_config_value('numpydoc_edit_link', None, False)
     app.add_config_value('numpydoc_use_plots', None, False)
     app.add_config_value('numpydoc_show_class_members', True, True)
+    app.add_config_value('numpydoc_show_inherited_class_members', True, True)
+    app.add_config_value('numpydoc_class_members_toctree', True, True)
 
     # Extra mangling domains
     app.add_domain(NumpyPythonDomain)
     app.add_domain(NumpyCDomain)
+    
+    metadata = {'parallel_read_safe': True}
+    return metadata
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Docstring-mangling domains
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 from docutils.statemachine import ViewList
 from sphinx.domains.c import CDomain
 from sphinx.domains.python import PythonDomain
+
 
 class ManglingDomainBase(object):
     directive_mangling_map = {}
@@ -133,6 +158,7 @@ class ManglingDomainBase(object):
             self.directives[name] = wrap_mangling_directive(
                 self.directives[name], objtype)
 
+
 class NumpyPythonDomain(ManglingDomainBase, PythonDomain):
     name = 'np'
     directive_mangling_map = {
@@ -144,6 +170,8 @@ class NumpyPythonDomain(ManglingDomainBase, PythonDomain):
         'staticmethod': 'function',
         'attribute': 'attribute',
     }
+    indices = []
+
 
 class NumpyCDomain(ManglingDomainBase, CDomain):
     name = 'np-c'
@@ -154,6 +182,7 @@ class NumpyCDomain(ManglingDomainBase, CDomain):
         'type': 'class',
         'var': 'object',
     }
+
 
 def wrap_mangling_directive(base_directive, objtype):
     class directive(base_directive):
@@ -175,4 +204,3 @@ def wrap_mangling_directive(base_directive, objtype):
             return base_directive.run(self)
 
     return directive
-

--- a/doc/sphinxext/numpydoc/tests/test_phantom_import.py
+++ b/doc/sphinxext/numpydoc/tests/test_phantom_import.py
@@ -1,5 +1,12 @@
 from __future__ import division, absolute_import, print_function
 
-import numpydoc.phantom_import
+import sys
+from nose import SkipTest
+
+def test_import():
+    if sys.version_info[0] >= 3:
+        raise SkipTest("phantom_import not ported to Py3")
+
+    import numpydoc.phantom_import
 
 # No tests at the moment...

--- a/doc/sphinxext/numpydoc/tests/test_plot_directive.py
+++ b/doc/sphinxext/numpydoc/tests/test_plot_directive.py
@@ -1,5 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import numpydoc.plot_directive
+import sys
+from nose import SkipTest
+
+def test_import():
+    if sys.version_info[0] >= 3:
+        raise SkipTest("plot_directive not ported to Python 3 (use the one from Matplotlib instead)")
+    import numpydoc.plot_directive
 
 # No tests at the moment...

--- a/doc/sphinxext/numpydoc/tests/test_traitsdoc.py
+++ b/doc/sphinxext/numpydoc/tests/test_traitsdoc.py
@@ -1,5 +1,11 @@
 from __future__ import division, absolute_import, print_function
 
-import numpydoc.traitsdoc
+import sys
+from nose import SkipTest
+
+def test_import():
+    if sys.version_info[0] >= 3:
+        raise SkipTest("traitsdoc not ported to Python3")
+    import numpydoc.traitsdoc
 
 # No tests at the moment...

--- a/doc/sphinxext/numpydoc/traitsdoc.py
+++ b/doc/sphinxext/numpydoc/traitsdoc.py
@@ -18,6 +18,7 @@ from __future__ import division, absolute_import, print_function
 import inspect
 import os
 import pydoc
+import collections
 
 from . import docscrape
 from . import docscrape_sphinx
@@ -60,6 +61,7 @@ class SphinxTraitsDoc(SphinxClassDoc):
             'Extended Summary': [],
             'Parameters': [],
             'Returns': [],
+            'Yields': [],
             'Raises': [],
             'Warns': [],
             'Other Parameters': [],
@@ -88,7 +90,7 @@ class SphinxTraitsDoc(SphinxClassDoc):
         out += self._str_summary()
         out += self._str_extended_summary()
         for param_list in ('Parameters', 'Traits', 'Methods',
-                           'Returns','Raises'):
+                           'Returns', 'Yields', 'Raises'):
             out += self._str_param_list(param_list)
         out += self._str_see_also("obj")
         out += self._str_section('Notes')

--- a/examples/correct/plot_attenuation.py
+++ b/examples/correct/plot_attenuation.py
@@ -7,7 +7,7 @@ In this example the reflectivity attenuation is calculated and then corrected
 for a polarimetric radar using a Z-PHI method implemented in Py-ART.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/correct/plot_dealias.py
+++ b/examples/correct/plot_dealias.py
@@ -8,7 +8,7 @@ Washington FourDD algorithm implemented in Py-ART.  Sounding data is
 used for the initial condition of the dealiasing.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/correct/plot_lp_phase_proc.py
+++ b/examples/correct/plot_lp_phase_proc.py
@@ -7,7 +7,7 @@ An example of using linear processing to process the differential phase
 fields of a ARM C-SAPR radar.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/mapping/plot_map_one_radar_to_grid.py
+++ b/examples/mapping/plot_map_one_radar_to_grid.py
@@ -7,7 +7,7 @@ Map the reflectivity field of a single radar from Antenna coordinates to a
 Cartesian grid.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/mapping/plot_map_two_radars_to_grid.py
+++ b/examples/mapping/plot_map_two_radars_to_grid.py
@@ -7,7 +7,7 @@ Map the reflectivity field of two nearby ARM XSARP radars from antenna
 coordinates to a Cartesian grid.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -9,7 +9,7 @@ North American regional reanalysis (NARR) pressure is plotted on top of the
 grid.
 
 """
-print __doc__
+print(__doc__)
 
 # Author Jonathan J. Helmus
 # License: BSD 3 clause

--- a/examples/plotting/plot_nexrad_reflectivity.py
+++ b/examples/plotting/plot_nexrad_reflectivity.py
@@ -7,7 +7,7 @@ An example which creates a plot containing the first collected scan from a
 NEXRAD file.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_ppi_basemap_with_rings.py
+++ b/examples/plotting/plot_ppi_basemap_with_rings.py
@@ -7,7 +7,7 @@ An example which creates a PPI plot of a file with a basemap background
 and range rings
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Scott Collis (scollis@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_ppi_sigmet.py
+++ b/examples/plotting/plot_ppi_sigmet.py
@@ -6,7 +6,7 @@ Create a PPI plot from a Sigmet file
 An example which creates a PPI plot of a Sigmet file.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_rhi_cfradial.py
+++ b/examples/plotting/plot_rhi_cfradial.py
@@ -7,7 +7,7 @@ An example which creates a multiple panel RHI plot of a CF/Radial file using
 a RadarDisplay object.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_rhi_contours_differential_reflectivity.py
+++ b/examples/plotting/plot_rhi_contours_differential_reflectivity.py
@@ -7,7 +7,7 @@ An example which creates an RHI plot of reflectivity using a RadarDisplay object
 and adding differnential Reflectivity contours from the same MDV file.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Cory Weber (cweber@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_rhi_data_overlay.py
+++ b/examples/plotting/plot_rhi_data_overlay.py
@@ -7,7 +7,7 @@ An example which creates an RHI plot of velocity using a RadarDisplay object
 and adding Reflectivity contours from the same MDV file.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Cory Weber (cweber@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_rhi_mdv.py
+++ b/examples/plotting/plot_rhi_mdv.py
@@ -6,7 +6,7 @@ Create a RHI plot from a MDV file
 An example which creates a RHI plot of a MDV file using a RadarDisplay object.
 
 """
-print __doc__
+print(__doc__)
 
 # Author: Jonathan J. Helmus (jhelmus@anl.gov)
 # License: BSD 3 clause

--- a/examples/plotting/plot_rhi_sigmet.py
+++ b/examples/plotting/plot_rhi_sigmet.py
@@ -25,7 +25,7 @@ display = pyart.graph.RadarDisplay(radar)
 fig = plt.figure(figsize=[10, 4])
 ax = fig.add_subplot(111)
 
-instrument_name = radar.metadata['instrument_name']
+instrument_name = radar.metadata['instrument_name'].decode('utf-8')
 time_start = netCDF4.num2date(radar.time['data'][0], radar.time['units'])
 time_text = ' ' + time_start.isoformat() + 'Z '
 azimuth = radar.fixed_angle['data'][0]

--- a/examples/plotting/plot_rhi_two_panel.py
+++ b/examples/plotting/plot_rhi_two_panel.py
@@ -31,7 +31,7 @@ nplots = len(fields_to_plot)
 plt.figure(figsize=[5 * nplots, 4])
 
 # plot each field
-for plot_num in xrange(nplots):
+for plot_num in range(nplots):
     field = fields_to_plot[plot_num]
     vmin, vmax = ranges[plot_num]
 
@@ -40,7 +40,7 @@ for plot_num in xrange(nplots):
     display.set_limits(ylim=[0, 17])
 
 # set the figure title and show
-instrument_name = radar.metadata['instrument_name']
+instrument_name = radar.metadata['instrument_name'].decode('utf-8')
 time_start = netCDF4.num2date(radar.time['data'][0], radar.time['units'])
 time_text = ' ' + time_start.isoformat() + 'Z '
 azimuth = radar.fixed_angle['data'][0]

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -622,8 +622,12 @@ def cartesian_to_geographic_aeqd(x, y, lon_0, lat_0, R=6370997.):
     rho = np.sqrt(x*x + y*y)
     c = rho / R
 
-    lat_rad = np.arcsin(np.cos(c) * np.sin(lat_0_rad) +
-                        y * np.sin(c) * np.cos(lat_0_rad) / rho)
+    with warnings.catch_warnings():
+        # division by zero may occur here but is properly addressed below so
+        # the warnings can be ignored
+        warnings.simplefilter("ignore", RuntimeWarning)
+        lat_rad = np.arcsin(np.cos(c) * np.sin(lat_0_rad) +
+                            y * np.sin(c) * np.cos(lat_0_rad) / rho)
     lat_deg = np.rad2deg(lat_rad)
     # fix cases where the distance from the center of the projection is zero
     lat_deg[rho == 0] = lat_0


### PR DESCRIPTION
The Py-ART documentation including the examples can now be build on Python 2 or Python 3.

closes #503 