### PR TITLE
BUG: Set _FillValue in dealias routines

### DIFF
--- a/pyart/correct/tests/test_region_dealias.py
+++ b/pyart/correct/tests/test_region_dealias.py
@@ -148,6 +148,24 @@ def test_dealias_outside():
     assert_almost_equal(dealias_vel['data'][270, 25], -0.10, 2)
 
 
+def test_fillvalue(**kwargs):
+    radar = pyart.testing.make_velocity_aliased_radar()
+    radar.fields['velocity']['_FillValue'] = 8888.0
+
+    # ensure that at least one gate is excluded and should be masked
+    radar.fields['velocity']['data'][100, 25] = 44
+    gf = pyart.filters.GateFilter(radar)
+    gf.exclude_above('velocity', 40)
+
+    dealias_vel = pyart.correct.dealias_region_based(radar, gatefilter=gf)
+    assert isinstance(dealias_vel['data'], np.ma.MaskedArray)
+    assert np.ma.is_masked(dealias_vel['data'][100, 25])
+
+    assert '_FillValue' in dealias_vel
+    assert dealias_vel['_FillValue'] == 8888.0
+    assert dealias_vel['data'].fill_value == 8888.0
+
+
 def main():
 
     radar, dealias_vel = perform_dealias()

--- a/pyart/correct/unwrap.py
+++ b/pyart/correct/unwrap.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from ..config import get_metadata
+from ..config import get_metadata, get_fillvalue
 from ._common_dealias import _parse_fields, _parse_gatefilter, _set_limits
 from ._common_dealias import _parse_rays_wrap_around, _parse_nyquist_vel
 
@@ -146,9 +146,13 @@ def dealias_unwrap_phase(
                    "'ray', 'sweep', or 'volume'")
         raise ValueError(message)
 
+    # fill_value from the velocity dictionary if present
+    fill_value = radar.fields[vel_field].get(
+        '_FillValue', get_fillvalue())
+
     # mask filtered gates
     if np.any(gfilter):
-        data = np.ma.array(data, mask=gfilter)
+        data = np.ma.array(data, mask=gfilter, fill_value=fill_value)
 
     # restore original values where dealiasing not applied
     if keep_original:
@@ -157,6 +161,7 @@ def dealias_unwrap_phase(
     # return field dictionary containing dealiased Doppler velocities
     corr_vel = get_metadata(corr_vel_field)
     corr_vel['data'] = data
+    corr_vel['_FillValue'] = fill_value
 
     if set_limits:
         # set valid_min and valid_max in corr_vel


### PR DESCRIPTION
Correctly set the field dictionary _FillValue entry and the MaskedArray fill_value attribute from the input velocity field in the dealiasing routines.