### PR TITLE
Various fixed for read ODIM H5 files

### DIFF
--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -240,28 +240,23 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
     # azimuth
     azimuth = filemetadata('azimuth')
     az_data = np.ones((total_rays, ), dtype='float32')
-    if ('startazA' in ds1_how) and ('stopazA' in ds1_how):
-        # average between start and stop azimuth angles
-        for dset, start, stop in zip(datasets, ssri, seri):
+    for dset, start, stop in zip(datasets, ssri, seri):
+        if odim_object == 'ELEV':
+            # all azimuth angles are the sweep azimuth angle
+            sweep_az = hfile[dset]['where'].attrs['az_angle']
+        elif ('startazA' in ds1_how) and ('stopazA' in ds1_how):
+            # average between start and stop azimuth angles
             startaz = hfile[dset]['how'].attrs['startazA']
             stopaz = hfile[dset]['how'].attrs['stopazA']
             sweep_az = np.angle(
                 (np.exp(1.j*np.deg2rad(startaz)) +
                  np.exp(1.j*np.deg2rad(stopaz))) / 2., deg=True)
-            az_data[start:stop+1] = sweep_az
-    else:
-        if odim_object == 'ELEV':
-            # all azimuth angles are the sweep azimuth angle
-            for dset, start, stop in zip(datasets, ssri, seri):
-                sweep_azimuth = hfile[dset]['where'].attrs['az_angle']
-                az_data[start:stop+1] = sweep_azimuth
         else:
             # according to section 5.1 the first ray points north (0 degrees)
             # and proceeds clockwise for a complete 360 rotation.
-            for dset, start, stop in zip(datasets, ssri, seri):
-                nrays = stop - start + 1
-                sweep_az = np.linspace(0, 360, nrays, endpoint=False)
-                az_data[start:stop+1] = sweep_az
+            nrays = stop - start + 1
+            sweep_az = np.linspace(0, 360, nrays, endpoint=False)
+        az_data[start:stop+1] = sweep_az
     azimuth['data'] = az_data
 
     # time

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -230,12 +230,12 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
             az_data[start:stop+1] = sweep_az
         azimuth['data'] = az_data
     else:
-        # assume 1 degree per ray, starting at where/a1gate
+        # according to section 5.1 the first ray points north (0 degrees)
+        # and proceeds clockwise for a complete 360 rotation.
         az_data = np.ones((total_rays, ), dtype='float32')
         for dset, start, stop in zip(datasets, ssri, seri):
-            start_az = hfile[dset]['where'].attrs['a1gate']
             nrays = stop - start + 1
-            sweep_az = np.fmod(start_az + np.arange(nrays), 360.)
+            sweep_az = np.linspace(0, 360, nrays, endpoint=False)
             az_data[start:stop+1] = sweep_az
         azimuth['data'] = az_data
 


### PR DESCRIPTION
* Better Python 3 support for reading strings from ODIM H5 files.
* Bug fix effecting the azimuth angles reported for ODIM H5 files.
* Fallback for range determination in ODIM H5 files.
* ODIM H5 RHI files correctly report the azimuth angles and scan_type.

closes #530 