### PR TITLE
ENH: Read NEXRAD Level 3 with NOAAPORT seperator

### DIFF
--- a/pyart/io/auto_read.py
+++ b/pyart/io/auto_read.py
@@ -229,6 +229,11 @@ def determine_filetype(filename):
     if begin[:4] == b'SDUS':
         return "NEXRADL3"
 
+    # NEXRAD LEVEL 3 with NOAAPORT record seperator
+    # Start of heading (x01) \r\r\nXXX \r\r\nSDUSXX KXXX
+    if begin[:4] == b'\x01\r\r\n':
+        return "NEXRADL3"
+
     # Other files should be read with read_rsl
     # WSR-88D begin with ARCHIVE2. or AR2V000
     if begin[:9] == b'ARCHIVE2.' or begin[:7] == b'AR2V000':

--- a/pyart/io/nexrad_level3.py
+++ b/pyart/io/nexrad_level3.py
@@ -124,8 +124,12 @@ class NEXRADLevel3File(object):
 
         # Text header
         # Format of Text header is SDUSXX KYYYY DDHHMM\r\r\nAAABBB\r\r\n
-        self.text_header = buf[:30]
-        bpos = 30       # current reading position in buffer
+        # Sometime additional padding is present before the Text header
+        record_padding = buf.find(b'SDUS')
+        if record_padding == -1:
+            raise ValueError('Not a valid NEXRAD Level 3 file.')
+        self.text_header = buf[:30 + record_padding]
+        bpos = 30 + record_padding      # current reading position in buffer
 
         # Read and decode 18 byte Message Header Block
         self.msg_header = _unpack_from_buf(buf, bpos, MESSAGE_HEADER)


### PR DESCRIPTION
Add the ability to read the NEXRAD Level 3 files which contain a NOAAPORT
record seperator.