### PR TITLE
ENH: NEXRAD VCP included in radar metadata

### DIFF
--- a/pyart/io/nexrad_archive.py
+++ b/pyart/io/nexrad_archive.py
@@ -128,6 +128,9 @@ def read_nexrad_archive(filename, field_names=None, additional_metadata=None,
     # metadata
     metadata = filemetadata('metadata')
     metadata['original_container'] = 'NEXRAD Level II'
+    vcp_pattern = nfile.get_vcp_pattern()
+    if vcp_pattern is not None:
+        metadata['vcp_pattern'] = vcp_pattern
 
     # scan_type
     scan_type = 'ppi'

--- a/pyart/io/nexrad_level2.py
+++ b/pyart/io/nexrad_level2.py
@@ -248,6 +248,15 @@ class NEXRADLevel2File(object):
                 'moments': moments})
         return info
 
+    def get_vcp_pattern(self):
+        """
+        Return the numerical volume coverage pattern (VCP) or None if unknown.
+        """
+        if self.vcp is None:
+            return None
+        else:
+            return self.vcp['msg5_header']['pattern_number']
+
     def get_nrays(self, scan):
         """
         Return the number of rays in a given scan.

--- a/pyart/io/tests/test_nexrad_archive_msg1.py
+++ b/pyart/io/tests/test_nexrad_archive_msg1.py
@@ -56,6 +56,7 @@ def test_range():
 def test_metadata():
     assert 'instrument_name' in radar.metadata
     assert 'source' in radar.metadata
+    assert 'vcp_pattern' not in radar.metadata
 
 
 # scan_type attribute

--- a/pyart/io/tests/test_nexrad_archive_msg31.py
+++ b/pyart/io/tests/test_nexrad_archive_msg31.py
@@ -47,6 +47,8 @@ def test_range():
 def test_metadata():
     assert 'instrument_name' in radar.metadata
     assert 'source' in radar.metadata
+    assert 'vcp_pattern' in radar.metadata
+    assert radar.metadata['vcp_pattern'] == 11
 
 
 # scan_type attribute


### PR DESCRIPTION
The NEXRAD volume coverage pattern (VCP) is included in the radar.metadata
dictionary when NEXRAD Level 2 files which contain this information are read.