### PR TITLE
BUG: Writing grids with empty radar names

### DIFF
--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -207,7 +207,8 @@ def write_grid(filename, grid, format='NETCDF4',
     if grid.nradar != 0:
         dset.createDimension('nradar', grid.nradar)
         if grid.radar_name is not None:
-            nradar_str_length = len(grid.radar_name['data'][0])
+            # a length of at least 1 is required for the dimension
+            nradar_str_length = max(len(grid.radar_name['data'][0]), 1)
             dset.createDimension('nradar_str_length', nradar_str_length)
 
     # required variables

--- a/pyart/io/tests/test_grid_io.py
+++ b/pyart/io/tests/test_grid_io.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import netCDF4
+import numpy as np
 from numpy.testing import assert_almost_equal, assert_warns
 
 import pyart
@@ -307,3 +308,18 @@ def test_make_coordinate_system_dict():
     grid.projection['proj'] = 'null'
     dic = pyart.io.grid_io._make_coordinatesystem_dict(grid)
     assert dic is None
+
+
+def test_write_grid_empty_radar_names():
+    # GitHub issue #537
+    grid1 = pyart.testing.make_target_grid()
+    grid1.nradar = 2
+    grid1.radar_name['data'] = np.array(['', ''])
+    grid1.radar_latitude = None
+    grid1.radar_longitude = None
+    grid1.radar_altitude = None
+    grid1.radar_time = None
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = 'tmp_grid.nc'
+        pyart.io.write_grid(tmpfile, grid1)


### PR DESCRIPTION
Allow writing of Py-ART Grid objects using write_grid where the radar_name
attribute of the grid contains empty strings.

closes #537