### PR TITLE
ENH: Radar and Grid classes can be pickled and unpickled

### DIFF
--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -157,6 +157,25 @@ class Grid(object):
 
         return
 
+    def __getstate__(self):
+        """ Return object's state which can be pickled. """
+        state = self.__dict__.copy()  # copy the objects state
+        # Remove unpicklable entries (those which are lazily loaded
+        del state['point_x']
+        del state['point_y']
+        del state['point_z']
+        del state['point_latitude']
+        del state['point_longitude']
+        del state['point_altitude']
+        return state
+
+    def __setstate__(self, state):
+        """ Restore unpicklable entries from pickled object. """
+        self.__dict__.update(state)
+        self.init_point_x_y_z()
+        self.init_point_longitude_latitude()
+        self.init_point_altitude()
+
     @classmethod
     def from_legacy_parameters(cls, fields, axes, metadata):
         """

--- a/pyart/core/radar.py
+++ b/pyart/core/radar.py
@@ -244,6 +244,27 @@ class Radar(object):
         self.init_gate_longitude_latitude()
         self.init_gate_altitude()
 
+    def __getstate__(self):
+        """ Return object's state which can be pickled. """
+        state = self.__dict__.copy()  # copy the objects state
+        # Remove unpicklable entries (those which are lazily loaded
+        del state['rays_per_sweep']
+        del state['gate_x']
+        del state['gate_y']
+        del state['gate_z']
+        del state['gate_longitude']
+        del state['gate_latitude']
+        del state['gate_altitude']
+        return state
+
+    def __setstate__(self, state):
+        """ Restore unpicklable entries from pickled object. """
+        self.__dict__.update(state)
+        self.init_rays_per_sweep()
+        self.init_gate_x_y_z()
+        self.init_gate_longitude_latitude()
+        self.init_gate_altitude()
+
     # Attribute init/reset method
     def init_rays_per_sweep(self):
         """ Initialize or reset the rays_per_sweep attribute. """

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import functools
+import pickle
 import warnings
 
 import numpy as np
@@ -17,6 +18,14 @@ except ImportError:
 
 import pyart
 from pyart.lazydict import LazyLoadDict
+
+
+def test_grid_picklable():
+    grid = pyart.testing.make_target_grid()
+    picklestring = pickle.dumps(grid)
+    grid_new = pickle.loads(picklestring)
+    assert 'data' in grid.point_x
+    assert 'data' in grid_new.point_x
 
 
 def test_grid_write_method():

--- a/pyart/core/tests/test_radar.py
+++ b/pyart/core/tests/test_radar.py
@@ -1,5 +1,6 @@
 """ Unit Tests for Py-ART's core/radar.py module. """
 
+import pickle
 import sys
 # we need a class which excepts str for writing in Python 2 and 3
 try:
@@ -12,6 +13,15 @@ import numpy as np
 from numpy.testing import assert_raises, assert_allclose, assert_almost_equal
 import pyart
 from pyart.lazydict import LazyLoadDict
+
+
+def test_radar_picklable():
+    # verify that Radar instances are picklable
+    radar = pyart.testing.make_empty_ppi_radar(5, 4, 2)
+    picklestring = pickle.dumps(radar)
+    radar_new = pickle.loads(picklestring)
+    assert 'data' in radar.gate_x
+    assert 'data' in radar_new.gate_x
 
 
 def test_gate_longitude_latitude():


### PR DESCRIPTION
Enhancements to the Radar and Grid classes made in version 1.6.0 causes these classes to become non-picklable.  Being able to pickled these objects is a requirement for their use in multiprocessing.  These changes allows these objects to once again be pickled and adds unit tests to verify this characteristic.