### PR TITLE
BUG: Prevent nan being returned from transform

### DIFF
--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -463,8 +463,13 @@ def geographic_to_cartesian_aeqd(lon, lat, lon_0, lat_0, R=6370997.):
     lon_0_rad = np.deg2rad(lon_0)
 
     lon_diff_rad = lon_rad - lon_0_rad
-    c = np.arccos(np.sin(lat_0_rad) * np.sin(lat_rad) +
+
+    # calculate the arccos after ensuring all values in valid domain, [-1, 1]
+    arg_arccos = (np.sin(lat_0_rad) * np.sin(lat_rad) +
                   np.cos(lat_0_rad) * np.cos(lat_rad) * np.cos(lon_diff_rad))
+    arg_arccos[arg_arccos > 1] = 1
+    arg_arccos[arg_arccos < -1] = -1
+    c = np.arccos(arg_arccos)
     with warnings.catch_warnings():
         # division by zero may occur here but is properly addressed below so
         # the warnings can be ignored


### PR DESCRIPTION
The geographic_to_cartesian_aeqd function in the transforms module would return
arrays contains nan when numerical imprecision caused the argument of the
arccos function to be out of the valid domain [-1, 1]. Add logic to catch and
correct these cases.