### PR TITLE
MAINT: Raise error when cyl projections used

### DIFF
--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -168,10 +168,12 @@ class RadarMapDisplay(RadarDisplay):
             North America.
         projection : str
             Map projection supported by basemap.  The use of cylindrical
-            projections (mill, merc, cyl, etc) is not recommended as they
+            projections (mill, merc, etc) is not recommended as they
             exhibit large distortions at high latitudes.  Equal area
             (aea, laea), conformal (lcc, tmerc, stere) or equidistant
             projection (aeqd, cass) work well even at high latitudes.
+            The cylindrical equidistant projection (cyl) is not supported as
+            coordinate transformations cannot be performed.
         area_thresh : float
             Coastline or lake with an area smaller than area_thresh in
             km^2 will not be plotted.
@@ -258,6 +260,13 @@ class RadarMapDisplay(RadarDisplay):
                     width=width, height=height, lon_0=lon_0, lat_0=lat_0,
                     projection=projection, area_thresh=area_thresh,
                     resolution=resolution, ax=ax, **kwargs)
+
+        # The cylindrical equidistant projection does not support conversions
+        # from geographic (lon/lat) to map projection (x/y) coordinates and
+        # therefore cannot be used.
+        if basemap.projection == 'cyl':
+            raise ValueError(
+                'The cylindrical equidistant projection is not supported')
 
         # add embelishments
         if embelish is True:

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -56,5 +56,15 @@ def test_error_raising():
     assert_raises(ValueError, display.plot_range_ring, 10)
 
 
+@skipif(not pyart.graph.radarmapdisplay._BASEMAP_AVAILABLE)
+def test_radardisplay_cylindrical_proj_error():
+    radar = pyart.io.read_cfradial(pyart.testing.CFRADIAL_PPI_FILE)
+    display = pyart.graph.RadarMapDisplay(radar)
+    assert_raises(
+        ValueError,
+        display.plot_ppi_map, 'reflectivity_horizontal', projection='cyl',
+        resolution='c')
+
+
 if __name__ == "__main__":
     test_radarmapdisplay_ppi('figure_radarmapdisplay_ppi.png')


### PR DESCRIPTION
Raise a ValueError when a cylindrical equidistant projection is used when
plotting data using the RadarMapDisplay class.  This projection does not
support coordinate transformations.

closes #556