### PR TITLE
Advection calculation and shifting of grids

### DIFF
--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -28,7 +28,7 @@ from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
 
 try:
-    from .advection import  grid_displacememt_pc, grid_shift
+    from .advection import  grid_displacement_pc, grid_shift
     _ADVECTION_AVAILABLE = True
 except:
     _ADVECTION_AVAILABLE = False

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -27,4 +27,12 @@ from .echo_class import steiner_conv_strat
 from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
 
+try:
+    from .advection import  grid_displacememt_pc
+    _ADVECTION_AVAILABLE = True
+except:
+    _ADVECTION_AVAILABLE = False
+
+
+
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -26,11 +26,6 @@ from .kdp_proc import kdp_maesaka
 from .echo_class import steiner_conv_strat
 from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
-
-try:
-    from .advection import  grid_displacement_pc, grid_shift
-    _ADVECTION_AVAILABLE = True
-except:
-    _ADVECTION_AVAILABLE = False
+from .advection import  grid_displacement_pc, grid_shift
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -33,6 +33,4 @@ try:
 except:
     _ADVECTION_AVAILABLE = False
 
-
-
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -28,7 +28,7 @@ from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
 
 try:
-    from .advection import  grid_displacememt_pc
+    from .advection import  grid_displacememt_pc, grid_shift
     _ADVECTION_AVAILABLE = True
 except:
     _ADVECTION_AVAILABLE = False

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -1,0 +1,109 @@
+"""
+pyart.retrieve.advection
+=========================
+
+
+.. autosummary::
+    :toctree: generated/
+
+"""
+
+import numpy as np
+from netCDF4 import datetime
+from skimage.transform import warp, AffineTransform
+
+#Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>
+def grid_displacememt_pc(grid1, grid2, var, level, return_value = 'pixels'):
+    """
+    Calculate the grid displacement using Phase correlation.
+    See:
+    http://en.wikipedia.org/wiki/Phase_correlation
+    implimentation inspired by Christoph Gohlke:
+    http://www.lfd.uci.edu/~gohlke/code/imreg.py.html
+
+    Notes: Make sure valid min is set to something sensible.
+    missing values are set to valid_min. Works best on fields which have
+    background areas set to a constant area, eg rain rate, correlation etc..
+
+     Parameters
+    ----------
+    grid1,grid2 : Grids
+        Py-ART Grid objects seperated in time and be square in x/y.
+    var : string
+        Variable to calculate advection from. var must be in both grid1
+        and grid2.fields.keys()
+    level : integer
+        The level of the 3D grid to use in the calculation
+    return_value : string
+        'pixels', 'distance' or 'velocity'. Distance in pixels (default)
+        or meters or velocity vector in m/s
+
+    Returns
+    -------
+    displacement : two-tuple
+         integers if pixels, otherwise floats. Result of the calculation
+
+
+    """
+    #create copies of the data
+
+    ige1 = copy.deepcopy(grid2.fields[var]['data'][level,:,:])
+    ige2 = copy.deepcopy(grid1.fields[var]['data'][level,:,:])
+
+    #set anything below valid min to valid min, this helps nuke _fill_values
+
+    ige1[np.where(ige1 < grid1.fields[var]['valid_min'])] = \
+                                                  grid1.fields[var]['valid_min']
+    ige2[np.where(ige2 < grid2.fields[var]['valid_min'])] = \
+                                                  grid2.fields[var]['valid_min']
+
+    # discrete fast fourier transformation and complex conjugation of image 2
+
+    image1FFT = np.fft.fft2(ige1)
+    image2FFT = np.conjugate(np.fft.fft2(ige2))
+
+    # inverse fourier transformation of product -> equal to cross correlation
+
+    imageCCor = np.real( np.fft.ifft2( (image1FFT*image2FFT) ) )
+
+    # Shift the zero-frequency component to the center of the spectrum
+
+    imageCCorShift = np.fft.fftshift(imageCCor)
+    # determine the distance of the maximum from the center
+
+    row, col = ige1.shape
+
+    #find the peak in the correlation
+
+    yShift, xShift = np.unravel_index( np.argmax(imageCCorShift), (row,col) )
+
+    yShift -= int(row/2)
+    xShift -= int(col/2)
+
+    if return_value == 'pixels':
+        tbr = (xShift, yShift)
+    elif return_value == 'distance':
+        dx = grid1.axes['x_disp']['data'][1] - grid1.axes['x_disp']['data'][0]
+        dy = grid1.axes['y_disp']['data'][1] - grid1.axes['y_disp']['data'][0]
+        x_movement = xShift * dx
+        y_movement = yShift * dy
+        tbr = (x_movement, y_movement)
+    elif return_value == 'velocity':
+        dx = grid1.axes['x_disp']['data'][1] - grid1.axes['x_disp']['data'][0]
+        dy = grid1.axes['y_disp']['data'][1] - grid1.axes['y_disp']['data'][0]
+        x_movement = xShift * dx
+        y_movement = yShift * dy
+        t1 = netCDF4.num2date(grid1.axes['time']['data'][0],
+                grid1.axes['time']['units'])
+        t2 = netCDF4.num2date(grid2.axes['time']['data'][0],
+                grid2.axes['time']['units'])
+        dt = (t2 - t1).seconds
+        u = x_movement/dt
+        v = y_movement/dt
+        tbr = (u, v)
+    else:
+        tbr = (xShift, yShift)
+    return tbr
+
+
+

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -14,7 +14,7 @@ import scipy
 import copy
 
 #Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>
-def grid_displacememt_pc(grid1, grid2, var, level, return_value = 'pixels'):
+def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
     """
     Calculate the grid displacement using Phase correlation.
     See:

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -18,8 +18,9 @@ import copy
 from ..config import get_fillvalue
 
 
-#Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>
-def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
+# Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>
+
+def grid_displacement_pc(grid1, grid2, var, level, return_value='pixels'):
     """
     Calculate the grid displacement using Phase correlation.
     See:
@@ -51,26 +52,44 @@ def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
 
 
     """
-    #create copies of the data
+    # create copies of the data
 
-    ige1 = copy.deepcopy(grid2.fields[var]['data'][level,:,:])
-    ige2 = copy.deepcopy(grid1.fields[var]['data'][level,:,:])
+    ige1 = copy.deepcopy(grid2.fields[var]['data'][level, :, :])
+    ige2 = copy.deepcopy(grid1.fields[var]['data'][level, :, :])
 
-    #set anything below valid min to valid min, this helps nuke _fill_values
+    # set anything below valid min to valid min,
+    # this helps nuke _fill_values
 
-    ige1[np.where(ige1 < grid1.fields[var]['valid_min'])] = \
-                                                  grid1.fields[var]['valid_min']
-    ige2[np.where(ige2 < grid2.fields[var]['valid_min'])] = \
-                                                  grid2.fields[var]['valid_min']
+    try:
+        ige1[np.where(ige1 < grid1.fields[var]['valid_min'])] = \
+            grid1.fields[var]['valid_min']
+        ige2[np.where(ige2 < grid2.fields[var]['valid_min'])] = \
+            grid2.fields[var]['valid_min']
+    except KeyError:
 
-    # discrete fast fourier transformation and complex conjugation of image 2
+        # This could probably be done better
+        # Work out where we have fill values and fill with min
+
+        is_not_filled_1 = np.where(ige1 != get_fillvalue())
+        is_not_filled_2 = np.where(ige2 != get_fillvalue())
+        is_filled_1 = np.where(ige1 == get_fillvalue())
+        is_filled_2 = np.where(ige2 == get_fillvalue())
+
+        ige1_min = ige1[is_not_filled_1].min()
+        ige2_min = ige2[is_not_filled_2].min()
+
+        ige1[is_filled_1] = ige1_min
+        ige2[is_filled_2] = ige2_min
+
+    # discrete fast fourier transformation and
+    # complex conjugation of image 2
 
     image1FFT = np.fft.fft2(ige1)
     image2FFT = np.conjugate(np.fft.fft2(ige2))
 
     # inverse fourier transformation of product -> equal to cross correlation
 
-    imageCCor = np.real( np.fft.ifft2( (image1FFT*image2FFT) ) )
+    imageCCor = np.real(np.fft.ifft2((image1FFT*image2FFT)))
 
     # Shift the zero-frequency component to the center of the spectrum
 
@@ -79,9 +98,9 @@ def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
 
     row, col = ige1.shape
 
-    #find the peak in the correlation
+    # find the peak in the correlation
 
-    yShift, xShift = np.unravel_index( np.argmax(imageCCorShift), (row,col) )
+    yShift, xShift = np.unravel_index(np.argmax(imageCCorShift), (row, col))
 
     yShift -= int(row/2)
     xShift -= int(col/2)
@@ -100,9 +119,9 @@ def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
         x_movement = xShift * dx
         y_movement = yShift * dy
         t1 = netCDF4.num2date(grid1.axes['time']['data'][0],
-                grid1.axes['time']['units'])
+                              grid1.axes['time']['units'])
         t2 = netCDF4.num2date(grid2.axes['time']['data'][0],
-                grid2.axes['time']['units'])
+                              grid2.axes['time']['units'])
         dt = (t2 - t1).seconds
         u = x_movement/dt
         v = y_movement/dt
@@ -111,7 +130,8 @@ def grid_displacement_pc(grid1, grid2, var, level, return_value = 'pixels'):
         tbr = (xShift, yShift)
     return tbr
 
-def grid_shift(grid, advection, trim_edges = 0., field_list=None):
+
+def grid_shift(grid, advection, trim_edges=0., field_list=None):
     """
     Use scipy.ndimage to shift a grid by a certain number of pixels
      Parameters
@@ -131,21 +151,21 @@ def grid_shift(grid, advection, trim_edges = 0., field_list=None):
 
     new_grid = copy.deepcopy(grid)
 
-    #grab the x and y axis and trim
+    # grab the x and y axis and trim
 
     x_g = grid.axes['x_disp']['data'].copy()
     y_g = grid.axes['y_disp']['data'].copy()
-    if trim_edges !=0.:
+    if trim_edges != 0.:
         new_grid.axes['x_disp']['data'] = x_g[trim_edges:-trim_edges]
         new_grid.axes['y_disp']['data'] = y_g[trim_edges:-trim_edges]
     else:
         new_grid.axes['x_disp']['data'] = x_g
         new_grid.axes['y_disp']['data'] = y_g
 
-    #now shift each field. Replacing masking is tricky..
-    #either use valid min and max or use  user set
-    if field_list == None:
-        field_list =  grid.fields.keys()
+    # now shift each field. Replacing masking is tricky..
+    # either use valid min and max or use  user set
+    if field_list is None:
+        field_list = grid.fields.keys()
 
     for field in field_list:
         image_data = grid.fields[field]['data'].copy()
@@ -154,15 +174,16 @@ def grid_shift(grid, advection, trim_edges = 0., field_list=None):
             image_data = image_data.filled(np.nan)
         except:
             ndv = get_fillvalue()
-        new_image = scipy.ndimage.interpolation.shift(image_data,
-                [0,advection[0],advection[1]], prefilter=False)
+        new_image = \
+            scipy.ndimage.interpolation.shift(image_data,
+                                              [0, advection[0], advection[1]],
+                                              prefilter=False)
         image_masked = np.ma.fix_invalid(new_image, copy=False)
         image_masked.set_fill_value(ndv)
         if trim_edges != 0.:
-            new_grid.fields[field]['data'] = image_masked[:,
-                    trim_edges:-trim_edges, trim_edges:-trim_edges]
+            new_grid.fields[field]['data'] = \
+                    image_masked[:, trim_edges:-trim_edges,
+                                 trim_edges:-trim_edges]
         else:
             new_grid.fields[field]['data'] = image_masked
     return new_grid
-
-

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -6,6 +6,9 @@ pyart.retrieve.advection
 .. autosummary::
     :toctree: generated/
 
+    grid_displacement_pc
+    grid_shift
+
 """
 
 import numpy as np

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -11,6 +11,7 @@ pyart.retrieve.advection
 import numpy as np
 from netCDF4 import datetime
 from skimage.transform import warp, AffineTransform
+import copy
 
 #Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>
 def grid_displacememt_pc(grid1, grid2, var, level, return_value = 'pixels'):
@@ -105,7 +106,8 @@ def grid_displacememt_pc(grid1, grid2, var, level, return_value = 'pixels'):
         tbr = (xShift, yShift)
     return tbr
 
-def grid_shift(grid, advection, trim_edges = 0., mask_range = None):
+def grid_shift(grid, advection, trim_edges = 0.,
+        mask_range = None, field_list=None):
     """
     Use scipy.ndimage to shift a grid by a certain number of pixels
      Parameters
@@ -138,8 +140,10 @@ def grid_shift(grid, advection, trim_edges = 0., mask_range = None):
 
     #now shift each field. Replacing masking is tricky..
     #either use valid min and max or use  user set
+    if field_list == None:
+        field_list =  grid.fields.keys()
 
-    for field in grid.fields.keys():
+    for field in field_list:
         if mask_range == None:
             mask_range = [grid.fields[field]['valid_min'],
                     grid.fields[field]['valid_max'] ]

--- a/pyart/retrieve/advection.py
+++ b/pyart/retrieve/advection.py
@@ -10,7 +10,7 @@ pyart.retrieve.advection
 
 import numpy as np
 from netCDF4 import datetime
-from skimage.transform import warp, AffineTransform
+import scipy
 import copy
 
 #Based off work by Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/>

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -1,0 +1,24 @@
+""" Unit Tests for Py-ART's retrieve/advection.py module. """
+
+import numpy as np
+from numpy.testing.decorators import skipif
+
+import pyart
+
+def test_grid_displacememt_pc():
+    test_storm = pyart.testing.make_storm_grid()
+    test_storm_2.fields['reflectivity']['data'] =\
+            test_storm_2.fields['reflectivity']['data'][:, 9:-11, 9:-1]
+    test_storm.fields['reflectivity']['data'] =\
+            test_storm.fields['reflectivity']['data'][:, 5:-5, :]
+    test_storm_2 = pyart.testing.make_storm_grid()
+    test_storm_2.fields['reflectivity']['data'] =\
+            test_storm_2.fields['reflectivity']['data'][:, 0:-10, :]
+    test_storm_2.fields['reflectivity']['data'][:,:,4:-3] =\
+            test_storm_2.fields['reflectivity']['data'][:, :, 1:-6]
+    test_storm_2.fields['reflectivity']['valid_min']=0.0
+    test_storm.fields['reflectivity']['valid_min']=0.0
+    assert pyart.retrieve.grid_displacememt(test_storm,
+            test_storm_2, 'reflectivity', 0) == (3,5)
+
+

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -27,9 +27,9 @@ def test_grid_shift():
     tgrid0 = pyart.testing.make_normal_storm(10.0, [0.0,0.0])
     tgrid1 = pyart.testing.make_normal_storm(10.0, [5.0,5.0])
     #trim one, trim and shift the other
-    tgrid1_reduced = grid_shift(tgrid1, [0.0, 0.0],
+    tgrid1_reduced = pyart.retrieve.grid_shift(tgrid1, [0.0, 0.0],
             trim_edges = 10, mask_range = [400, -9000])
-    tgrid0_shifted = grid_shift(tgrid0, [5.0, 5.0],
+    tgrid0_shifted = pyart.retrieve.grid_shift(tgrid0, [5.0, 5.0],
             trim_edges = 10, mask_range = [400, -9000])
     #take the difference
     diff = tgrid0_shifted.fields['reflectivity']['data'][0,:,:]\

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -22,3 +22,21 @@ def test_grid_displacememt_pc():
             test_storm_2, 'reflectivity', 0) == (3,5)
 
 
+def test_grid_shift():
+    #create two guassian storms
+    tgrid0 = pyart.testing.make_normal_storm(10.0, [0.0,0.0])
+    tgrid1 = pyart.testing.make_normal_storm(10.0, [5.0,5.0])
+    #trim one, trim and shift the other
+    tgrid1_reduced = grid_shift(tgrid1, [0.0, 0.0],
+            trim_edges = 10, mask_range = [400, -9000])
+    tgrid0_shifted = grid_shift(tgrid0, [5.0, 5.0],
+            trim_edges = 10, mask_range = [400, -9000])
+    #take the difference
+    diff = tgrid0_shifted.fields['reflectivity']['data'][0,:,:]\
+            - tgrid1_reduced.fields['reflectivity']['data'][0,:,:]
+    #Assert that the difference is basically digital noise.
+    #This actual value on my MB Air is -1.65633898546e-21
+    assert diff.mean() < 1.0e-10
+
+
+

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -26,9 +26,9 @@ def test_grid_shift():
     tgrid1 = pyart.testing.make_normal_storm(10.0, [5.0,5.0])
     #trim one, trim and shift the other
     tgrid1_reduced = pyart.retrieve.grid_shift(tgrid1, [0.0, 0.0],
-            trim_edges = 10, mask_range = [400, -9000])
+            trim_edges = 10)
     tgrid0_shifted = pyart.retrieve.grid_shift(tgrid0, [5.0, 5.0],
-            trim_edges = 10, mask_range = [400, -9000])
+            trim_edges = 10)
     #take the difference
     diff = tgrid0_shifted.fields['reflectivity']['data'][0,:,:]\
             - tgrid1_reduced.fields['reflectivity']['data'][0,:,:]

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -8,18 +8,16 @@ import pyart
 def test_grid_displacement_pc():
     test_storm = pyart.testing.make_storm_grid()
     test_storm.fields['reflectivity']['data'] =\
-            test_storm.fields['reflectivity']['data'][:, 9:-11, 9:-1]
-    test_storm.fields['reflectivity']['data'] =\
             test_storm.fields['reflectivity']['data'][:, 5:-5, :]
-    test_storm = pyart.testing.make_storm_grid()
-    test_storm.fields['reflectivity']['data'] =\
-            test_storm.fields['reflectivity']['data'][:, 0:-10, :]
-    test_storm.fields['reflectivity']['data'][:,:,4:-3] =\
-            test_storm.fields['reflectivity']['data'][:, :, 1:-6]
-    test_storm.fields['reflectivity']['valid_min']=0.0
+    test_storm_2 = pyart.testing.make_storm_grid()
+    test_storm_2.fields['reflectivity']['data'] =\
+            test_storm_2.fields['reflectivity']['data'][:, 0:-10, :]
+    test_storm_2.fields['reflectivity']['data'][:,:,4:-3] =\
+            test_storm_2.fields['reflectivity']['data'][:, :, 1:-6]
+    test_storm_2.fields['reflectivity']['valid_min']=0.0
     test_storm.fields['reflectivity']['valid_min']=0.0
     assert pyart.retrieve.grid_displacement_pc(test_storm,
-            test_storm, 'reflectivity', 0) == (3,5)
+            test_storm_2, 'reflectivity', 0) == (3,5)
 
 
 def test_grid_shift():

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -5,7 +5,7 @@ from numpy.testing.decorators import skipif
 
 import pyart
 
-def test_grid_displacememt_pc():
+def test_grid_displacement_pc():
     test_storm = pyart.testing.make_storm_grid()
     test_storm_2.fields['reflectivity']['data'] =\
             test_storm_2.fields['reflectivity']['data'][:, 9:-11, 9:-1]
@@ -18,7 +18,7 @@ def test_grid_displacememt_pc():
             test_storm_2.fields['reflectivity']['data'][:, :, 1:-6]
     test_storm_2.fields['reflectivity']['valid_min']=0.0
     test_storm.fields['reflectivity']['valid_min']=0.0
-    assert pyart.retrieve.grid_displacememt(test_storm,
+    assert pyart.retrieve.grid_displacement_pc(test_storm,
             test_storm_2, 'reflectivity', 0) == (3,5)
 
 

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -8,14 +8,14 @@ import pyart
 def test_grid_displacement_pc():
     test_storm = pyart.testing.make_storm_grid()
     test_storm.fields['reflectivity']['data'] =\
-            test_storm_2.fields['reflectivity']['data'][:, 9:-11, 9:-1]
+            test_storm.fields['reflectivity']['data'][:, 9:-11, 9:-1]
     test_storm.fields['reflectivity']['data'] =\
             test_storm.fields['reflectivity']['data'][:, 5:-5, :]
     test_storm = pyart.testing.make_storm_grid()
     test_storm.fields['reflectivity']['data'] =\
-            test_storm_2.fields['reflectivity']['data'][:, 0:-10, :]
+            test_storm.fields['reflectivity']['data'][:, 0:-10, :]
     test_storm.fields['reflectivity']['data'][:,:,4:-3] =\
-            test_storm_2.fields['reflectivity']['data'][:, :, 1:-6]
+            test_storm.fields['reflectivity']['data'][:, :, 1:-6]
     test_storm.fields['reflectivity']['valid_min']=0.0
     test_storm.fields['reflectivity']['valid_min']=0.0
     assert pyart.retrieve.grid_displacement_pc(test_storm,

--- a/pyart/retrieve/tests/test_advection.py
+++ b/pyart/retrieve/tests/test_advection.py
@@ -7,19 +7,19 @@ import pyart
 
 def test_grid_displacement_pc():
     test_storm = pyart.testing.make_storm_grid()
-    test_storm_2.fields['reflectivity']['data'] =\
+    test_storm.fields['reflectivity']['data'] =\
             test_storm_2.fields['reflectivity']['data'][:, 9:-11, 9:-1]
     test_storm.fields['reflectivity']['data'] =\
             test_storm.fields['reflectivity']['data'][:, 5:-5, :]
-    test_storm_2 = pyart.testing.make_storm_grid()
-    test_storm_2.fields['reflectivity']['data'] =\
+    test_storm = pyart.testing.make_storm_grid()
+    test_storm.fields['reflectivity']['data'] =\
             test_storm_2.fields['reflectivity']['data'][:, 0:-10, :]
-    test_storm_2.fields['reflectivity']['data'][:,:,4:-3] =\
+    test_storm.fields['reflectivity']['data'][:,:,4:-3] =\
             test_storm_2.fields['reflectivity']['data'][:, :, 1:-6]
-    test_storm_2.fields['reflectivity']['valid_min']=0.0
+    test_storm.fields['reflectivity']['valid_min']=0.0
     test_storm.fields['reflectivity']['valid_min']=0.0
     assert pyart.retrieve.grid_displacement_pc(test_storm,
-            test_storm_2, 'reflectivity', 0) == (3,5)
+            test_storm, 'reflectivity', 0) == (3,5)
 
 
 def test_grid_shift():

--- a/pyart/testing/__init__.py
+++ b/pyart/testing/__init__.py
@@ -47,6 +47,6 @@ from .sample_objects import make_target_grid, make_storm_grid
 from .sample_objects import make_empty_rhi_radar
 from .sample_objects import make_velocity_aliased_rhi_radar
 from .tmpdirs import InTemporaryDirectory
-from .sample_objects import make_target_grid, make_storm_grid, make_normal_storm
+from .sample_objects import make_normal_storm
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/testing/__init__.py
+++ b/pyart/testing/__init__.py
@@ -19,6 +19,7 @@ Testing functions
     make_velocity_aliased_radar
     make_empty_grid
     make_target_grid
+    make_normal_storm
 
 Testing classes
 ===============
@@ -46,5 +47,6 @@ from .sample_objects import make_target_grid, make_storm_grid
 from .sample_objects import make_empty_rhi_radar
 from .sample_objects import make_velocity_aliased_rhi_radar
 from .tmpdirs import InTemporaryDirectory
+from .sample_objects import make_target_grid, make_storm_grid, make_normal_storm
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -346,7 +346,7 @@ def make_normal_storm(sigma, mu):
     """
     Make a sample Grid with a gaussian storm target.
     """
-    test_grid = pyart.testing.make_empty_grid([101,101,1],
+    test_grid = make_empty_grid([101,101,1],
             [(-50,50),(-50,50), (1,1)])
     x = test_grid.axes['x_disp']['data']
     y = test_grid.axes['y_disp']['data']

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -13,6 +13,7 @@ Functions for creating sample Radar and Grid objects.
     make_single_ray_radar
     make_empty_grid
     make_target_grid
+    make_normal_storm
 
 """
 

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -346,8 +346,8 @@ def make_normal_storm(sigma, mu):
     """
     Make a sample Grid with a gaussian storm target.
     """
-    test_grid = make_empty_grid([101,101,1],
-            [(-50,50),(-50,50), (1,1)])
+    test_grid = make_empty_grid([1, 101, 101],
+            [(1,1), (-50,50),(-50,50)])
     x = test_grid.axes['x_disp']['data']
     y = test_grid.axes['y_disp']['data']
     z = test_grid.axes['z_disp']['data']

--- a/pyart/testing/sample_objects.py
+++ b/pyart/testing/sample_objects.py
@@ -341,3 +341,25 @@ def make_storm_grid():
         'units': 'dBz'}
     grid.fields = {'reflectivity': rdic}
     return grid
+
+def make_normal_storm(sigma, mu):
+    """
+    Make a sample Grid with a gaussian storm target.
+    """
+    test_grid = pyart.testing.make_empty_grid([101,101,1],
+            [(-50,50),(-50,50), (1,1)])
+    x = test_grid.axes['x_disp']['data']
+    y = test_grid.axes['y_disp']['data']
+    z = test_grid.axes['z_disp']['data']
+    zg, yg, xg = np.meshgrid(z,y,x, indexing='ij')
+    r = np.sqrt((xg- mu[0])**2+(yg -mu[1])**2)
+    term1 = 1.0/(sigma * np.sqrt(2.0*np.pi))
+    term2 = -1.0*(r**2/(2.0*sigma**2))
+    data = term1 * np.exp(term2)
+    rdic = {
+        'data': data,
+        'long_name': 'reflectivity',
+        'units': 'dBz'}
+    test_grid.fields.update({'reflectivity': rdic})
+    return test_grid
+


### PR DESCRIPTION
This pull request covers the calculation of the displacement between two grids using phase correlation and treating the grid as an image. The user must pick the field and the level. The code can return a number of pixels (tuple) or, using the time difference, a velocity. 
It also contains code to shift, using ndimage, a grid by a certain number of pixels and trim the edges. 

This is the first of two pull requests aimed at implementing advection correction into Py-ART. The next pull request will enable the addition of two grids by advecting them to a common time step. 

More detailed examples and cookbook recipes will also follow  