### PR TITLE
MAINT: Prefer importing pyproj over basemap

### DIFF
--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -39,10 +39,14 @@ from ..exceptions import MissingOptionalDependency
 
 import numpy as np
 try:
-    from mpl_toolkits.basemap import pyproj
+    import pyproj
     _PYPROJ_AVAILABLE = True
 except ImportError:
-    _PYPROJ_AVAILABLE = False
+    try:
+        from mpl_toolkits.basemap import pyproj
+        _PYPROJ_AVAILABLE = True
+    except ImportError:
+        _PYPROJ_AVAILABLE = False
 
 PI = np.pi
 


### PR DESCRIPTION
Prefer importing pyproj directly over the version of the library included with
basemap. The fallback is still to use the version included with basemap.