### PR TITLE
New gate filter based on texture of polarimetric variables

### DIFF
--- a/pyart/filters/__init__.py
+++ b/pyart/filters/__init__.py
@@ -15,10 +15,11 @@ Filtering radar data
 
     GateFilter
     moment_based_gate_filter
+    moment_and_texture_based_gate_filter
 
 """
 
 from .gatefilter import GateFilter, moment_based_gate_filter
-from .gatefilter import moment_based_gate_filter2
+from .gatefilter import moment_and_texture_based_gate_filter
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/filters/__init__.py
+++ b/pyart/filters/__init__.py
@@ -19,5 +19,6 @@ Filtering radar data
 """
 
 from .gatefilter import GateFilter, moment_based_gate_filter
+from .gatefilter import moment_based_gate_filter2
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -9,6 +9,7 @@ corrections routines in Py-ART.
     :toctree: generated/
 
     moment_based_gate_filter
+    moment_and_texture_based_gate_filter
 
 .. autosummary::
     :toctree: generated/
@@ -108,11 +109,11 @@ def moment_based_gate_filter(
     return gatefilter
 
 
-def moment_based_gate_filter2(
+def moment_and_texture_based_gate_filter(
         radar, zdr_field=None, rhv_field=None, phi_field=None, refl_field=None,
         textzdr_field=None, textrhv_field=None, textphi_field=None,
-        textrefl_field=None, wind_size=7, min_valid=3, max_textphi=20.,
-        max_textrhv=0.3, max_textzdr=2.85, max_textrefl=8., min_rhv=0.6):
+        textrefl_field=None, wind_size=7, max_textphi=20., max_textrhv=0.3,
+        max_textzdr=2.85, max_textrefl=8., min_rhv=0.6):
     """
     Create a filter which removes undesired gates based on texture of moments.
 
@@ -144,8 +145,6 @@ def moment_based_gate_filter2(
         as defined in the Py-ART configuration file
     wind_size : int
         Size of the moving window used to compute the ray texture.
-    min_valid : int
-        Minimum number of valid range gates to compute the ray texture.
     max_textphi, max_textrhv, max_textzdr, max_textrefl : float
         Maximum value for the texture of the differential phase, texture of
         RhoHV, texture of Zdr and texture of reflectivity. Gates in these
@@ -194,29 +193,26 @@ def moment_based_gate_filter2(
 
     # compute the textures of the moments and add them into radar object
     if (max_textphi is not None) and (phi_field in radar_aux.fields):
-        textphi = texture_along_ray(radar_aux, phi_field,
-                                    wind_size=wind_size, min_valid=min_valid)
+        textphi = texture_along_ray(radar_aux, phi_field, wind_size=wind_size)
         tphi = get_metadata(textphi_field)
         tphi['data'] = textphi
         radar_aux.add_field(textphi_field, tphi)
 
     if (max_textrhv is not None) and (rhv_field in radar_aux.fields):
-        textrho = texture_along_ray(radar_aux, rhv_field,
-                                    wind_size=wind_size, min_valid=min_valid)
+        textrho = texture_along_ray(radar_aux, rhv_field, wind_size=wind_size)
         trhv = get_metadata(textrhv_field)
         trhv['data'] = textrho
         radar_aux.add_field(textrhv_field, trhv)
 
     if (max_textzdr is not None) and (zdr_field in radar_aux.fields):
-        textzdr = texture_along_ray(radar_aux, zdr_field,
-                                    wind_size=wind_size, min_valid=min_valid)
+        textzdr = texture_along_ray(radar_aux, zdr_field, wind_size=wind_size)
         tzdr = get_metadata(textzdr_field)
         tzdr['data'] = textzdr
         radar_aux.add_field(textzdr_field, tzdr)
 
     if (max_textrefl is not None) and (refl_field in radar_aux.fields):
         textrefl = texture_along_ray(radar_aux, refl_field,
-                                     wind_size=wind_size, min_valid=min_valid)
+            wind_size=wind_size)
         trefl = get_metadata(textrefl_field)
         trefl['data'] = textrefl
         radar_aux.add_field(textrefl_field, trefl)

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -108,6 +108,144 @@ def moment_based_gate_filter(
     return gatefilter
 
 
+def moment_based_gate_filter2(
+        radar, zdr_field=None, rhv_field=None, phi_field=None, refl_field=None,
+        textzdr_field=None, textrhv_field=None, textphi_field=None,
+        textrefl_field=None, wind_size=7, min_valid=3, max_textphi=20.,
+        max_textrhv=0.3, max_textzdr=2.85, max_textrefl=8., min_rhv=0.6):
+    """
+    Create a filter which removes undesired gates based on texture of moments.
+
+    Creates a gate filter in which the following gates are excluded:
+
+    * Gates where RhoHV is below min_rhv
+    * Gates where the PhiDP texture is above max_textphi.
+    * Gates where the RhoHV texture is above max_textrhv.
+    * Gates where the ZDR texture is above max_textzdr
+    * Gates where the reflectivity texture is above max_textrefl
+    * If any of the thresholds is not set or the field (RhoHV, ZDR, PhiDP,
+    reflectivity) do not exist in the radar the filter is not applied.
+
+    Parameters
+    ----------
+    radar : Radar
+        Radar object from which the gate filter will be built.
+    zdr_field, rhv_field, phi_field, refl_field : str
+        Names of the radar fields which contain the differential reflectivity,
+        cross correlation ratio, differential phase and reflectivity from
+        which the textures will be computed. A value of None for any of these
+        parameters will use the default field name as defined in the Py-ART
+        configuration file.
+    textzdr_field, textrhv_field, textphi_field, textrefl_field : str
+        Names of the radar fields given to the texture of the
+        differential reflectivity, texture of the cross correlation ratio,
+        texture of differential phase and texture of reflectivity. A value
+        of None for any of these parameters will use the default field name
+        as defined in the Py-ART configuration file
+    wind_size : int
+        Size of the moving window used to compute the ray texture.
+    min_valid : int
+        Minimum number of valid range gates to compute the ray texture.
+    max_textphi, max_textrhv, max_textzdr, max_textrefl : float
+        Maximum value for the texture of the differential phase, texture of
+        RhoHV, texture of Zdr and texture of reflectivity. Gates in these
+        fields above these limits as well as gates which are masked or contain
+        invalid values will be excluded and not used in calculation which use
+        the filter.  A value of None will disable filtering based upon the
+        given field including removing masked or gates with an invalid value.
+        To disable the thresholding but retain the masked and invalid filter
+        set the parameter to a value above the highest value in the field.
+    min_rhv : float
+        Minimum value for the RhoHV. Gates below this limits as well as gates
+        which are masked or contain invalid values will be excluded and not
+        used in calculation which use the filter. A value of None will disable
+        filtering based upon the given field including removing masked or
+        gates with an invalid value. To disable the thresholding but retain
+        the masked and invalid filter set the parameter to a value below the
+        lowest value in the field.
+
+    Returns
+    -------
+    gatefilter : :py:class:`GateFilter`
+        A gate filter based upon the described criteria.  This can be
+        used as a gatefilter parameter to various functions in pyart.correct.
+
+    """
+    # parse the field parameters
+    if refl_field is None:
+        refl_field = get_field_name('reflectivity')
+    if zdr_field is None:
+        zdr_field = get_field_name('differential_reflectivity')
+    if rhv_field is None:
+        rhv_field = get_field_name('cross_correlation_ratio')
+    if phi_field is None:
+        phi_field = get_field_name('uncorrected_differential_phase')
+    if textrefl_field is None:
+        textrefl_field = get_field_name('reflectivity_texture')
+    if textzdr_field is None:
+        textzdr_field = get_field_name('differential_reflectivity_texture')
+    if textrhv_field is None:
+        textrhv_field = get_field_name('cross_correlation_ratio_texture')
+    if textphi_field is None:
+        textphi_field = get_field_name('differential_phase_texture')
+
+    # make deepcopy of input radar (we do not want to modify the original)
+    radar_aux = deepcopy(radar)
+
+    # compute the textures of the moments and add them into radar object
+    if (max_textphi is not None) and (phi_field in radar_aux.fields):
+        textphi = texture_along_ray(radar_aux, phi_field,
+                                    wind_size=wind_size, min_valid=min_valid)
+        tphi = get_metadata(textphi_field)
+        tphi['data'] = textphi
+        radar_aux.add_field(textphi_field, tphi)
+
+    if (max_textrhv is not None) and (rhv_field in radar_aux.fields):
+        textrho = texture_along_ray(radar_aux, rhv_field,
+                                    wind_size=wind_size, min_valid=min_valid)
+        trhv = get_metadata(textrhv_field)
+        trhv['data'] = textrho
+        radar_aux.add_field(textrhv_field, trhv)
+
+    if (max_textzdr is not None) and (zdr_field in radar_aux.fields):
+        textzdr = texture_along_ray(radar_aux, zdr_field,
+                                    wind_size=wind_size, min_valid=min_valid)
+        tzdr = get_metadata(textzdr_field)
+        tzdr['data'] = textzdr
+        radar_aux.add_field(textzdr_field, tzdr)
+
+    if (max_textrefl is not None) and (refl_field in radar_aux.fields):
+        textrefl = texture_along_ray(radar_aux, refl_field,
+                                     wind_size=wind_size, min_valid=min_valid)
+        trefl = get_metadata(textrefl_field)
+        trefl['data'] = textrefl
+        radar_aux.add_field(textrefl_field, trefl)
+
+    # filter gates based upon field parameters
+    gatefilter = GateFilter(radar_aux)
+    if (min_rhv is not None) and (rhv_field in radar_aux.fields):
+        gatefilter.exclude_below(rhv_field, min_rhv)
+        gatefilter.exclude_masked(rhv_field)
+        gatefilter.exclude_invalid(rhv_field)
+    if (max_textphi is not None) and (textphi_field in radar_aux.fields):
+        gatefilter.exclude_above(textphi_field, max_textphi)
+        gatefilter.exclude_masked(textphi_field)
+        gatefilter.exclude_invalid(textphi_field)
+    if (max_textrhv is not None) and (textrhv_field in radar_aux.fields):
+        gatefilter.exclude_above(textrhv_field, max_textrhv)
+        gatefilter.exclude_masked(textrhv_field)
+        gatefilter.exclude_invalid(textrhv_field)
+    if (max_textzdr is not None) and (textzdr_field in radar_aux.fields):
+        gatefilter.exclude_above(textzdr_field, max_textzdr)
+        gatefilter.exclude_masked(textzdr_field)
+        gatefilter.exclude_invalid(textzdr_field)
+    if (max_textrefl is not None) and (textrefl_field in radar_aux.fields):
+        gatefilter.exclude_above(textrefl_field, max_textrefl)
+        gatefilter.exclude_masked(textrefl_field)
+        gatefilter.exclude_invalid(textrefl_field)
+    return gatefilter
+
+
 class GateFilter(object):
     """
     A class for building a boolean arrays for filtering gates based on

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -46,5 +46,6 @@ from .circular_stats import mean_of_two_angles, mean_of_two_angles_deg
 from .xsect import cross_section_ppi
 from .hildebrand_sekhon import estimate_noise_hs74
 from .radar_utils import is_vpt, to_vpt, join_radar
+from .sigmath import texture_along_ray
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -34,11 +34,10 @@ def texture(myradar, var):
     return tex
 
 
-def texture_along_ray(myradar, var, wind_size=7, min_valid=3):
+def texture_along_ray(myradar, var, wind_size=7):
     """
     Compute field texture along ray using a user specified
-    window size. If the number of valid range bins within the
-    window is lower than min_valid the bin is set to invalid.
+    window size.
 
     Parameters
     ----------
@@ -48,9 +47,6 @@ def texture_along_ray(myradar, var, wind_size=7, min_valid=3):
         Name of the field which texture has to be computed
     wind_size : int
         Optional. Size of the rolling window used
-    min_valid : int
-        Optional. Minimum number of valid range bins to
-        compute the texture
 
     Returns
     -------

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -32,3 +32,38 @@ def texture(myradar, var):
         tex[timestep, 0:4] = np.ones(4) * ray[0]
         tex[timestep, -5:] = np.ones(5) * ray[-1]
     return tex
+
+
+def texture_along_ray(myradar, var, wind_size=7, min_valid=3):
+    """
+    Compute field texture along ray using a user specified
+    window size. If the number of valid range bins within the
+    window is lower than min_valid the bin is set to invalid.
+
+    Parameters
+    ----------
+    myradar : radar object
+        The radar object where the field is
+    var : str
+        Name of the field which texture has to be computed
+    wind_size : int
+        Optional. Size of the rolling window used
+    min_valid : int
+        Optional. Minimum number of valid range bins to
+        compute the texture
+
+    Returns
+    -------
+    tex : radar field
+        the texture of the specified field
+
+    """
+    half_wind = int((wind_size-1)/2)
+    fld = myradar.fields[var]['data']
+    tex = np.ma.zeros(fld.shape)
+    for timestep in range(tex.shape[0]):
+        ray = np.ma.std(rolling_window(fld[timestep, :], wind_size), 1)
+        tex[timestep, half_wind:-half_wind] = ray
+        tex[timestep, 0:half_wind] = np.ones(half_wind) * ray[0]
+        tex[timestep, -half_wind:] = np.ones(half_wind) * ray[-1]
+    return tex


### PR DESCRIPTION
Dear Py-ART users,

I have added the following functions:
In filters/gatefilter.py:  moment_based_gate_filter2 filters out gates according to radial textures
In util/sigmath.py: texture_along_ray computes the texture along a a ray with a user defined length.

Please let me know if this is up to standard.

Greetings from Switzerland,

Jordi