### PR TITLE
BUG: Raise an error for too much sounding data

### DIFF
--- a/pyart/correct/dealias.py
+++ b/pyart/correct/dealias.py
@@ -230,6 +230,9 @@ def dealias_fourdd(radar, last_radar=None, sounding_heights=None,
         sc = np.ascontiguousarray(sounding_wind_speeds, dtype=np.float32)
         dc = np.ascontiguousarray(sounding_wind_direction, dtype=np.float32)
 
+        if len(hc) > 999:
+            raise ValueError("Too many sounding heights, maximum is 999")
+
         success, sound_volume = _fourdd_interface.create_soundvolume(
             vel_volume, hc, sc, dc, sign, max_shear)
         if success == 0:

--- a/pyart/correct/tests/test_dealias.py
+++ b/pyart/correct/tests/test_dealias.py
@@ -138,6 +138,22 @@ def test_error_raising():
     return
 
 
+@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
+def test_segmentation_fault_error():
+    # See GitHub issue #571
+
+    # ValueError when sounding is > 999
+    radar = pyart.testing.make_velocity_aliased_radar()
+    height = np.arange(2000)
+    speed = np.zeros((2000, ))
+    direction = np.zeros((2000, ))
+    assert_raises(
+        ValueError, pyart.correct.dealias_fourdd, radar,
+        sounding_heights=height, sounding_wind_speeds=speed,
+        sounding_wind_direction=direction)
+    return
+
+
 if __name__ == "__main__":
 
     radar, dealias_vel = perform_dealias()


### PR DESCRIPTION
Raise a ValueError when more than 999 sounding heights are provided to the
dealias_fourdd function.  This prevents a segmentation fault from occuring in
the C code of the FourDD algorithm.

Modifying the C routine where this limit is imposed to something larged (~5000)
would be reasonable but this change should wait until after the next release
in order for this error to be caught.

closes #571