### PR TITLE
Computation of secondary moments, noise correction of RhoHV and pseudo-PPI from RHI volume

### DIFF
--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -192,7 +192,9 @@ def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
             [rbf['volume']['sensorinfo']['lon']], dtype='float64')
         altitude['data'] = np.array(
             [rbf['volume']['sensorinfo']['alt']], dtype='float64')
-        frequency['data'] = 3e8 / float(rbf['volume']['sensorinfo']['wavelen'])
+        frequency['data'] = np.array(
+            [3e8 / float(rbf['volume']['sensorinfo']['wavelen'])],
+            dtype='float64')
     elif 'radarinfo' in rbf['volume'].keys():
         latitude['data'] = np.array(
             [rbf['volume']['radarinfo']['@lat']], dtype='float64')
@@ -200,7 +202,9 @@ def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
             [rbf['volume']['radarinfo']['@lon']], dtype='float64')
         altitude['data'] = np.array(
             [rbf['volume']['radarinfo']['@alt']], dtype='float64')
-        frequency['data'] = 3e8 / float(rbf['volume']['radarinfo']['wavelen'])
+        frequency['data'] = np.array(
+            [3e8 / float(rbf['volume']['radarinfo']['wavelen'])],
+            dtype='float64')
 
     # antenna speed
     if 'antspeed' in common_slice_info:
@@ -389,6 +393,7 @@ def _get_angle(ray_info, angle_step=None, scan_type='ppi'):
     moving_angle = np.angle((np.exp(1.j * np.deg2rad(angle_start)) +
                             np.exp(1.j * np.deg2rad(angle_stop))) / 2.,
                             deg=True)
+    moving_angle[moving_angle < 0.] += 360.  # [0, 360]
 
     return moving_angle, angle_start, angle_stop
 

--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -26,6 +26,7 @@ Other corrections
     calculate_attenuation
     phase_proc_lp
     despeckle_field
+    correct_noise_rhohv
 
 Helper functions
 ================
@@ -46,5 +47,6 @@ from ..filters.gatefilter import GateFilter, moment_based_gate_filter
 from .unwrap import dealias_unwrap_phase
 from .region_dealias import dealias_region_based
 from .despeckle import find_objects, despeckle_field
+from .noise import correct_noise_rhohv
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -27,6 +27,7 @@ Other corrections
     phase_proc_lp
     despeckle_field
     correct_noise_rhohv
+    correct_bias
 
 Helper functions
 ================
@@ -47,6 +48,6 @@ from ..filters.gatefilter import GateFilter, moment_based_gate_filter
 from .unwrap import dealias_unwrap_phase
 from .region_dealias import dealias_region_based
 from .despeckle import find_objects, despeckle_field
-from .noise import correct_noise_rhohv
+from .bias_and_noise import correct_noise_rhohv, correct_bias
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/correct/bias_and_noise.py
+++ b/pyart/correct/bias_and_noise.py
@@ -91,12 +91,8 @@ def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
     zdr = np.ma.power(10., 0.1*zdrdB)
     alpha = np.ma.power(10., 0.1*(nh-nv))
 
-    mask = np.ma.getmaskarray(urhohv)
-
     rhohv_data = urhohv*np.ma.sqrt((1.+1./snr_h)*(1.+zdr/(alpha*snr_h)))
     rhohv_data[rhohv_data > 1.] = 1.
-    rhohv_data[mask] = np.ma.masked
-    rhohv_data.set_fill_value(get_fillvalue())
 
     rhohv = get_metadata(rhohv_field)
     rhohv['data'] = rhohv_data
@@ -136,11 +132,7 @@ def correct_bias(radar, bias=0., field_name=None):
     else:
         raise KeyError('Field not available: ' + field_name)
 
-    mask = np.ma.getmaskarray(field_data)
-
     corr_field_data = field_data - bias
-    corr_field_data[mask] = np.ma.masked
-    corr_field_data.set_fill_value(get_fillvalue())
 
     if field_name.startswith('corrected_'):
         corr_field_name = field_name

--- a/pyart/correct/bias_and_noise.py
+++ b/pyart/correct/bias_and_noise.py
@@ -1,5 +1,5 @@
 """
-pyart.correct.noise
+pyart.correct.bias_and_noise
 ===================
 
 Corrects polarimetric variables for noise
@@ -92,12 +92,11 @@ def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
     alpha = np.ma.power(10., 0.1*(nh-nv))
 
     mask = np.ma.getmaskarray(urhohv)
-    fill_value = urhohv.get_fill_value()
 
     rhohv_data = urhohv*np.ma.sqrt((1.+1./snr_h)*(1.+zdr/(alpha*snr_h)))
     rhohv_data[rhohv_data > 1.] = 1.
-    rhohv_data.set_fill_value(fill_value)
-    rhohv_data.data[mask.nonzero()] = fill_value
+    rhohv_data[mask] = np.ma.masked
+    rhohv_data.set_fill_value(get_fillvalue())
 
     rhohv = get_metadata(rhohv_field)
     rhohv['data'] = rhohv_data
@@ -138,11 +137,10 @@ def correct_bias(radar, bias=0., field_name=None):
         raise KeyError('Field not available: ' + field_name)
 
     mask = np.ma.getmaskarray(field_data)
-    fill_value = field_data.get_fill_value()
 
     corr_field_data = field_data - bias
-    corr_field_data.set_fill_value(fill_value)
-    corr_field_data.data[mask] = fill_value
+    corr_field_data[mask] = np.ma.masked
+    corr_field_data.set_fill_value(get_fillvalue())
 
     if field_name.startswith('corrected_'):
         corr_field_name = field_name

--- a/pyart/correct/bias_and_noise.py
+++ b/pyart/correct/bias_and_noise.py
@@ -8,6 +8,7 @@ Corrects polarimetric variables for noise
     :toctree: generated/
 
     correct_noise_rhohv
+    correct_bias
 
 """
 
@@ -20,7 +21,9 @@ def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
                         zdr_field=None, nh_field=None, nv_field=None,
                         rhohv_field=None):
     """
-    Corrects RhoHV for noise
+    Corrects RhoHV for noise according to eq. 6 in Gourley et al. 2006.
+    This correction should only be performed if noise has not been subtracted
+    from the signal during the moments computation.
 
     Parameters
     ----------
@@ -39,13 +42,18 @@ def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
 
     Returns
     -------
-    rhohv : dictionary of dictionaries
+    rhohv : dict
         noise corrected RhoHV field
+
+    References
+    ----------
+    Gourley et al. Data Quality of the Meteo-France C-Band Polarimetric
+    Radar, JAOT, 23, 1340-1356
 
     """
     # parse the field parameters
     if urhohv_field is None:
-        rhohv_field = get_field_name('uncorrected_cross_correlation_ratio')
+        urhohv_field = get_field_name('uncorrected_cross_correlation_ratio')
     if snr_field is None:
         snr_field = get_field_name('signal_to_noise_ratio')
     if zdr_field is None:
@@ -86,14 +94,62 @@ def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
     mask = np.ma.getmaskarray(urhohv)
     fill_value = urhohv.get_fill_value()
 
-    rhohv_data = np.ma.masked_where(
-        mask, urhohv*np.ma.sqrt((1.+1./snr_h)*(1.+zdr/(alpha*snr_h))))
+    rhohv_data = urhohv*np.ma.sqrt((1.+1./snr_h)*(1.+zdr/(alpha*snr_h)))
+    rhohv_data[rhohv_data > 1.] = 1.
     rhohv_data.set_fill_value(fill_value)
     rhohv_data.data[mask.nonzero()] = fill_value
-    is_above1 = rhohv_data > 1.
-    rhohv_data[is_above1.nonzero()] = 1.
 
     rhohv = get_metadata(rhohv_field)
     rhohv['data'] = rhohv_data
 
     return rhohv
+
+
+def correct_bias(radar, bias=0., field_name=None):
+    """
+    Corrects a radar data bias. If field name is none the correction is
+    applied to horizontal reflectivity by default
+
+    Parameters
+    ----------
+    radar : Radar
+        radar object
+
+    bias : float
+        the bias magnitude
+
+    field_name: str
+        names of the field to be corrected
+
+    Returns
+    -------
+    corrected_field : dict
+        The corrected field
+
+    """
+    # parse the field parameters
+    if field_name is None:
+        field_name = get_field_name('reflectivity')
+
+    # extract fields from radar
+    if field_name in radar.fields:
+        field_data = radar.fields[field_name]['data']
+    else:
+        raise KeyError('Field not available: ' + field_name)
+
+    mask = np.ma.getmaskarray(field_data)
+    fill_value = field_data.get_fill_value()
+
+    corr_field_data = field_data - bias
+    corr_field_data.set_fill_value(fill_value)
+    corr_field_data.data[mask] = fill_value
+
+    if field_name.startswith('corrected_'):
+        corr_field_name = field_name
+    else:
+        corr_field_name = 'corrected_'+field_name
+
+    corr_field = get_metadata(corr_field_name)
+    corr_field['data'] = corr_field_data
+
+    return corr_field

--- a/pyart/correct/noise.py
+++ b/pyart/correct/noise.py
@@ -1,0 +1,99 @@
+"""
+pyart.correct.noise
+===================
+
+Corrects polarimetric variables for noise
+
+.. autosummary::
+    :toctree: generated/
+
+    correct_noise_rhohv
+
+"""
+
+import numpy as np
+
+from ..config import get_metadata, get_field_name, get_fillvalue
+
+
+def correct_noise_rhohv(radar, urhohv_field=None, snr_field=None,
+                        zdr_field=None, nh_field=None, nv_field=None,
+                        rhohv_field=None):
+    """
+    Corrects RhoHV for noise
+
+    Parameters
+    ----------
+    radar : Radar
+        radar object
+
+    urhohv_field : str
+        name of the RhoHV uncorrected for noise field
+
+    snr_field, zdr_field, nh_field, nv_field: str
+        names of the SNR, ZDR, horizontal channel noise in dBZ and vertical
+        channel noise in dBZ used to correct RhoHV
+
+    rhohv_field: str
+        name of the rhohv field to output
+
+    Returns
+    -------
+    rhohv : dictionary of dictionaries
+        noise corrected RhoHV field
+
+    """
+    # parse the field parameters
+    if urhohv_field is None:
+        rhohv_field = get_field_name('uncorrected_cross_correlation_ratio')
+    if snr_field is None:
+        snr_field = get_field_name('signal_to_noise_ratio')
+    if zdr_field is None:
+        zdr_field = get_field_name('differential_reflectivity')
+    if nh_field is None:
+        nh_field = get_field_name('noisedBZ_hh')
+    if nv_field is None:
+        nv_field = get_field_name('noisedBZ_vv')
+    if rhohv_field is None:
+        rhohv_field = get_field_name('cross_correlation_ratio')
+
+    # extract fields from radar
+    if urhohv_field in radar.fields:
+        urhohv = radar.fields[urhohv_field]['data']
+    else:
+        raise KeyError('Field not available: ' + urhohv_field)
+    if snr_field in radar.fields:
+        snrdB_h = radar.fields[snr_field]['data']
+    else:
+        raise KeyError('Field not available: ' + snr_field)
+    if zdr_field in radar.fields:
+        zdrdB = radar.fields[zdr_field]['data']
+    else:
+        raise KeyError('Field not available: ' + zdr_field)
+    if nh_field in radar.fields:
+        nh = radar.fields[nh_field]['data']
+    else:
+        raise KeyError('Field not available: ' + nh_field)
+    if nv_field in radar.fields:
+        nv = radar.fields[nv_field]['data']
+    else:
+        raise KeyError('Field not available: ' + nv_field)
+
+    snr_h = np.ma.power(10., 0.1*snrdB_h)
+    zdr = np.ma.power(10., 0.1*zdrdB)
+    alpha = np.ma.power(10., 0.1*(nh-nv))
+
+    mask = np.ma.getmaskarray(urhohv)
+    fill_value = urhohv.get_fill_value()
+
+    rhohv_data = np.ma.masked_where(
+        mask, urhohv*np.ma.sqrt((1.+1./snr_h)*(1.+zdr/(alpha*snr_h))))
+    rhohv_data.set_fill_value(fill_value)
+    rhohv_data.data[mask.nonzero()] = fill_value
+    is_above1 = rhohv_data > 1.
+    rhohv_data[is_above1.nonzero()] = 1.
+
+    rhohv = get_metadata(rhohv_field)
+    rhohv['data'] = rhohv_data
+
+    return rhohv

--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -15,6 +15,10 @@ Radar retrievals
 
     kdp_maesaka
     calculate_snr_from_reflectivity
+    compute_snr
+    compute_l
+    compute_cdr
+    compute_noisedBZ
     fetch_radar_time_profile
     map_profile_to_gates
     steiner_conv_strat
@@ -28,6 +32,8 @@ from .kdp_proc import kdp_maesaka
 from .echo_class import steiner_conv_strat
 from .gate_id import map_profile_to_gates, fetch_radar_time_profile
 from .simple_moment_calculations import calculate_snr_from_reflectivity
+from .simple_moment_calculations import compute_snr, compute_l, compute_cdr
+from .simple_moment_calculations import compute_noisedBZ
 from .advection import grid_displacement_pc, grid_shift
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/retrieve/simple_moment_calculations.py
+++ b/pyart/retrieve/simple_moment_calculations.py
@@ -108,7 +108,7 @@ def compute_noisedBZ(nrays, noisedBZ_val, range, ref_dist,
 
     noisedBZ = get_metadata(noise_field)
     noisedBZ['data'] = np.tile(noisedBZ_vec, (nrays, 1))
-    noisedBZ['data'].set_fill_value(get_fillvalue())
+#    noisedBZ['data'].set_fill_value(get_fillvalue())
 
     return noisedBZ
 
@@ -153,7 +153,7 @@ def compute_snr(radar, refl_field=None, noise_field=None, snr_field=None):
         raise KeyError('Field not available: ' + noise_field)
 
     snr_data = refl-noisedBZ
-    snr_data.set_fill_value(get_fillvalue())
+#    snr_data.set_fill_value(get_fillvalue())
 
     snr = get_metadata(snr_field)
     snr['data'] = snr_data
@@ -194,12 +194,12 @@ def compute_l(radar, rhohv_field=None, l_field=None):
     else:
         raise KeyError('Field not available: ' + rhohv_field)
 
-    mask = np.ma.getmaskarray(rhohv)
+#    mask = np.ma.getmaskarray(rhohv)
 
     rhohv[rhohv >= 1.] = 0.9999
     l_data = -np.ma.log10(1.-rhohv)
-    l_data.data[mask] = np.ma.masked
-    l_data.set_fill_value(get_fillvalue())
+#    l_data.data[mask] = np.ma.masked
+#    l_data.set_fill_value(get_fillvalue())
 
     l = get_metadata(l_field)
     l['data'] = l_data
@@ -248,14 +248,10 @@ def compute_cdr(radar, rhohv_field=None, zdr_field=None, cdr_field=None):
 
     zdr = np.ma.power(10., 0.1*zdrdB)
 
-    mask = np.ma.getmaskarray(rhohv)
-
     cdr_data = (
         10.*np.ma.log10(
             (1.+1./zdr-2.*rhohv*np.ma.sqrt(1./zdr)) /
             (1.+1./zdr+2.*rhohv*np.ma.sqrt(1./zdr))))
-    cdr_data.data[mask] = np.ma.masked
-    cdr_data.set_fill_value(get_fillvalue())
 
     cdr = get_metadata(cdr_field)
     cdr['data'] = cdr_data

--- a/pyart/retrieve/simple_moment_calculations.py
+++ b/pyart/retrieve/simple_moment_calculations.py
@@ -152,12 +152,8 @@ def compute_snr(radar, refl_field=None, noise_field=None, snr_field=None):
     else:
         raise KeyError('Field not available: ' + noise_field)
 
-    mask = np.ma.getmaskarray(refl)
-    fill_value = refl.get_fill_value()
-
     snr_data = refl-noisedBZ
-    snr_data.set_fill_value(fill_value)
-    snr_data.data[mask.nonzero()] = fill_value
+    snr_data.set_fill_value(get_fillvalue())
 
     snr = get_metadata(snr_field)
     snr['data'] = snr_data
@@ -199,12 +195,11 @@ def compute_l(radar, rhohv_field=None, l_field=None):
         raise KeyError('Field not available: ' + rhohv_field)
 
     mask = np.ma.getmaskarray(rhohv)
-    fill_value = rhohv.get_fill_value()
 
     rhohv[rhohv >= 1.] = 0.9999
     l_data = -np.ma.log10(1.-rhohv)
-    l_data.set_fill_value(fill_value)
-    l_data.data[mask.nonzero()] = fill_value
+    l_data.data[mask] = np.ma.masked
+    l_data.set_fill_value(get_fillvalue())
 
     l = get_metadata(l_field)
     l['data'] = l_data
@@ -254,14 +249,13 @@ def compute_cdr(radar, rhohv_field=None, zdr_field=None, cdr_field=None):
     zdr = np.ma.power(10., 0.1*zdrdB)
 
     mask = np.ma.getmaskarray(rhohv)
-    fill_value = rhohv.get_fill_value()
 
     cdr_data = (
         10.*np.ma.log10(
             (1.+1./zdr-2.*rhohv*np.ma.sqrt(1./zdr)) /
             (1.+1./zdr+2.*rhohv*np.ma.sqrt(1./zdr))))
-    cdr_data.set_fill_value(fill_value)
-    cdr_data.data[mask.nonzero()] = fill_value
+    cdr_data.data[mask] = np.ma.masked
+    cdr_data.set_fill_value(get_fillvalue())
 
     cdr = get_metadata(cdr_field)
     cdr['data'] = cdr_data

--- a/pyart/retrieve/simple_moment_calculations.py
+++ b/pyart/retrieve/simple_moment_calculations.py
@@ -17,7 +17,7 @@ Simple moment calculations.
 
 import numpy as np
 
-from ..config import get_metadata, get_field_name
+from ..config import get_metadata, get_field_name, get_fillvalue
 from ..core.transforms import antenna_to_cartesian
 
 
@@ -96,7 +96,7 @@ def compute_noisedBZ(nrays, noisedBZ_val, range, ref_dist,
 
     Returns
     -------
-    noisedBZ : dictionary of dictionaries
+    noisedBZ : dict
         the noise field
 
     """
@@ -108,6 +108,7 @@ def compute_noisedBZ(nrays, noisedBZ_val, range, ref_dist,
 
     noisedBZ = get_metadata(noise_field)
     noisedBZ['data'] = np.tile(noisedBZ_vec, (nrays, 1))
+    noisedBZ['data'].set_fill_value(get_fillvalue())
 
     return noisedBZ
 
@@ -129,7 +130,7 @@ def compute_snr(radar, refl_field=None, noise_field=None, snr_field=None):
 
     Returns
     -------
-    snr : dictionary of dictionaries
+    snr : dict
         the SNR field
 
     """
@@ -154,7 +155,7 @@ def compute_snr(radar, refl_field=None, noise_field=None, snr_field=None):
     mask = np.ma.getmaskarray(refl)
     fill_value = refl.get_fill_value()
 
-    snr_data = np.ma.masked_where(mask, refl-noisedBZ)
+    snr_data = refl-noisedBZ
     snr_data.set_fill_value(fill_value)
     snr_data.data[mask.nonzero()] = fill_value
 
@@ -181,7 +182,7 @@ def compute_l(radar, rhohv_field=None, l_field=None):
 
     Returns
     -------
-    l : dictionary of dictionaries
+    l : dict
         L field
 
     """
@@ -199,10 +200,9 @@ def compute_l(radar, rhohv_field=None, l_field=None):
 
     mask = np.ma.getmaskarray(rhohv)
     fill_value = rhohv.get_fill_value()
-    is_one = rhohv >= 1.
-    rhohv[is_one.nonzero()] = 0.9999
 
-    l_data = np.ma.masked_where(mask, -np.ma.log10(1.-rhohv))
+    rhohv[rhohv >= 1.] = 0.9999
+    l_data = -np.ma.log10(1.-rhohv)
     l_data.set_fill_value(fill_value)
     l_data.data[mask.nonzero()] = fill_value
 
@@ -229,7 +229,7 @@ def compute_cdr(radar, rhohv_field=None, zdr_field=None, cdr_field=None):
 
     Returns
     -------
-    cdr : dictionary of dictionaries
+    cdr : dict
         CDR field
 
     """
@@ -256,10 +256,10 @@ def compute_cdr(radar, rhohv_field=None, zdr_field=None, cdr_field=None):
     mask = np.ma.getmaskarray(rhohv)
     fill_value = rhohv.get_fill_value()
 
-    cdr_data = np.ma.masked_where(
-        mask, 10.*np.ma.log10(
+    cdr_data = (
+        10.*np.ma.log10(
             (1.+1./zdr-2.*rhohv*np.ma.sqrt(1./zdr)) /
-            (1.+1./zdr+2*rhohv*np.ma.sqrt(1./zdr))))
+            (1.+1./zdr+2.*rhohv*np.ma.sqrt(1./zdr))))
     cdr_data.set_fill_value(fill_value)
     cdr_data.data[mask.nonzero()] = fill_value
 

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -32,6 +32,7 @@ Miscellaneous functions
     :toctree: generated/
 
     cross_section_ppi
+    cross_section_rhi
     estimate_noise_hs74
     is_vpt
     to_vpt
@@ -44,7 +45,7 @@ from .circular_stats import angular_mean, angular_std
 from .circular_stats import angular_mean_deg, angular_std_deg
 from .circular_stats import interval_mean, interval_std
 from .circular_stats import mean_of_two_angles, mean_of_two_angles_deg
-from .xsect import cross_section_ppi
+from .xsect import cross_section_ppi, cross_section_rhi
 from .hildebrand_sekhon import estimate_noise_hs74
 from .radar_utils import is_vpt, to_vpt, join_radar
 from .simulated_vel import simulated_vel_from_profile

--- a/pyart/util/radar_utils.py
+++ b/pyart/util/radar_utils.py
@@ -168,8 +168,8 @@ def join_radar(radar1, radar2):
         sh2 = radar2.fields[var]['data'].shape
         new_field_shape = (sh1[0] + sh2[0], max(sh1[1], sh2[1]))
         new_field = np.ma.zeros(new_field_shape)
-        new_field.set_fill_value = get_fillvalue()
         new_field[:] = np.ma.masked
+        new_field.set_fill_value(get_fillvalue())
         new_field[0:sh1[0], 0:sh1[1]] = radar1.fields[var]['data']
         new_field[sh1[0]:, 0:sh2[1]] = radar2.fields[var]['data']
         new_radar.fields[var]['data'] = new_field

--- a/pyart/util/xsect.py
+++ b/pyart/util/xsect.py
@@ -15,6 +15,7 @@ Function for extracting cross sections from radar volumes.
 """
 
 from copy import copy
+from warnings import warn
 
 import numpy as np
 
@@ -58,7 +59,7 @@ def cross_section_ppi(radar, target_azimuths, az_tol=None):
             else:
                 d_az_min = np.min(d_az)
                 if d_az_min > az_tol:
-                    print('WARNING: No azimuth found whithin tolerance ' +
+                    warn('WARNING: No azimuth found whithin tolerance ' +
                           'for angle '+str(target_azimuth) +
                           '. Minimum distance to radar azimuth ' +
                           str(d_az_min)+' larger than tolerance '+
@@ -70,8 +71,7 @@ def cross_section_ppi(radar, target_azimuths, az_tol=None):
 
     rhi_nsweeps = len(valid_azimuths)
     if rhi_nsweeps == 0:
-        print('WARNING: No azimuth found whithin tolerance.')
-        return None
+        raise ValueError('No azimuth found within tolerance')
 
     radar_rhi = _construct_xsect_radar(
         radar, 'rhi', prhi_rays, rhi_nsweeps, valid_azimuths)
@@ -118,7 +118,7 @@ def cross_section_rhi(radar, target_elevations, el_tol=None):
             else:
                 d_el_min = np.min(d_el)
                 if d_el_min > el_tol:
-                    print('WARNING: No elevation found whithin tolerance ' +
+                    warn('WARNING: No elevation found whithin tolerance ' +
                           'for angle '+str(target_elevation) +
                           '. Minimum distance to radar elevation ' +
                           str(d_el_min)+' larger than tolerance '+
@@ -130,8 +130,7 @@ def cross_section_rhi(radar, target_elevations, el_tol=None):
 
     ppi_nsweeps = len(valid_elevations)
     if ppi_nsweeps == 0:
-        print('WARNING: No elevation found whithin tolerance.')
-        return None
+        raise ValueError('No elevation found within tolerance')
 
     radar_ppi = _construct_xsect_radar(
         radar, 'ppi', pppi_rays, ppi_nsweeps, valid_elevations)

--- a/pyart/util/xsect.py
+++ b/pyart/util/xsect.py
@@ -8,6 +8,7 @@ Function for extracting cross sections from radar volumes.
     :toctree: generated/
 
     cross_section_ppi
+    cross_section_rhi
     _copy_dic
 
 """
@@ -99,6 +100,89 @@ def cross_section_ppi(radar, target_azimuths):
         azimuth, elevation)
 
     return radar_rhi
+
+
+def cross_section_rhi(radar, target_elevations):
+    """
+    Extract cross sections from an RHI volume along one or more elevation
+    angles.
+
+    Parameters
+    ----------
+    radar : Radar
+        Radar volume containing RHI sweeps from which azimuthal
+        cross sections will be extracted.
+    target_elevations : list
+        Elevation angles in degrees where cross sections will be taken.
+
+    Returns
+    -------
+    radar_ppi : Radar
+        Radar volume containing PPI sweeps which contain azimuthal
+        cross sections from the original RHI volume.
+
+    """
+
+    # determine which rays from the rhi radar make up the pseudo PPI
+    pppi_rays = []
+    ppi_nsweeps = len(target_elevations)
+    rhi_nsweeps = radar.nsweeps
+
+    for target_elevation in target_elevations:
+        for sweep_slice in radar.iter_slice():
+            sweep_elevations = radar.elevation['data'][sweep_slice]
+            ray_number = np.argmin(np.abs(sweep_elevations - target_elevation))
+            pppi_rays.append(ray_number + sweep_slice.start)
+
+    _range = _copy_dic(radar.range)
+    latitude = _copy_dic(radar.latitude)
+    longitude = _copy_dic(radar.longitude)
+    altitude = _copy_dic(radar.altitude)
+    metadata = _copy_dic(radar.metadata)
+    scan_type = 'ppi'
+
+    time = _copy_dic(radar.time, excluded_keys=['data'])
+    time['data'] = radar.time['data'][pppi_rays].copy()
+
+    azimuth = _copy_dic(radar.azimuth, excluded_keys=['data'])
+    azimuth['data'] = radar.azimuth['data'][pppi_rays].copy()
+
+    elevation = _copy_dic(radar.elevation, excluded_keys=['data'])
+    elevation['data'] = radar.elevation['data'][pppi_rays].copy()
+
+    fields = {}
+    for field_name, orig_field_dic in radar.fields.items():
+        field_dic = _copy_dic(orig_field_dic, excluded_keys=['data'])
+        field_dic['data'] = orig_field_dic['data'][pppi_rays].copy()
+        fields[field_name] = field_dic
+
+    sweep_number = _copy_dic(radar.sweep_number, excluded_keys=['data'])
+    sweep_number['data'] = np.arange(ppi_nsweeps, dtype='int32')
+
+    sweep_mode = _copy_dic(radar.sweep_mode, excluded_keys=['data'])
+    sweep_mode['data'] = np.array(['ppi']*ppi_nsweeps)
+
+    fixed_angle = _copy_dic(radar.fixed_angle, excluded_keys=['data'])
+    fixed_angle['data'] = np.array(target_elevations, dtype='float32')
+
+    sweep_start_ray_index = _copy_dic(
+        radar.sweep_start_ray_index, excluded_keys=['data'])
+    ssri = np.arange(ppi_nsweeps, dtype='int32') * rhi_nsweeps
+    sweep_start_ray_index['data'] = ssri
+
+    sweep_end_ray_index = _copy_dic(
+        radar.sweep_end_ray_index, excluded_keys=['data'])
+    seri = np.arange(ppi_nsweeps, dtype='int32')*rhi_nsweeps + rhi_nsweeps-1
+    sweep_end_ray_index['data'] = seri
+
+    radar_ppi = Radar(
+        time, _range, fields, metadata, scan_type,
+        latitude, longitude, altitude,
+        sweep_number, sweep_mode, fixed_angle,
+        sweep_start_ray_index, sweep_end_ray_index,
+        azimuth, elevation)
+
+    return radar_ppi
 
 
 def _copy_dic(orig_dic, excluded_keys=None):

--- a/pyart/util/xsect.py
+++ b/pyart/util/xsect.py
@@ -9,6 +9,7 @@ Function for extracting cross sections from radar volumes.
 
     cross_section_ppi
     cross_section_rhi
+    _construct_xsect_radar
     _copy_dic
 
 """
@@ -20,7 +21,7 @@ import numpy as np
 from ..core import Radar
 
 
-def cross_section_ppi(radar, target_azimuths):
+def cross_section_ppi(radar, target_azimuths, az_tol=None):
     """
     Extract cross sections from a PPI volume along one or more azimuth angles.
 
@@ -31,6 +32,9 @@ def cross_section_ppi(radar, target_azimuths):
         cross sections will be extracted.
     target_azimuth : list
         Azimuthal angles in degrees where cross sections will be taken.
+    az_tol : float
+        Azimuth angle tolerance in degrees. If none the nearest angle is used.
+        If valid only angles within the tolerance distance are considered.
 
     Returns
     -------
@@ -42,67 +46,40 @@ def cross_section_ppi(radar, target_azimuths):
 
     # determine which rays from the ppi radar make up the pseudo RHI
     prhi_rays = []
-    rhi_nsweeps = len(target_azimuths)
-    ppi_nsweeps = radar.nsweeps
-
+    valid_azimuths = []
     for target_azimuth in target_azimuths:
         for sweep_slice in radar.iter_slice():
             sweep_azimuths = radar.azimuth['data'][sweep_slice]
-            ray_number = np.argmin(np.abs(sweep_azimuths - target_azimuth))
-            prhi_rays.append(ray_number + sweep_slice.start)
+            d_az = np.abs(sweep_azimuths - target_azimuth)
+            if az_tol is None:
+                ray_number = np.argmin(d_az)
+                prhi_rays.append(ray_number + sweep_slice.start)
+                valid_azimuths.append(target_azimuth)
+            else:
+                d_az_min = np.min(d_az)
+                if d_az_min > az_tol:
+                    print('WARNING: No azimuth found whithin tolerance ' +
+                          'for angle '+str(target_azimuth) +
+                          '. Minimum distance to radar azimuth ' +
+                          str(d_az_min)+' larger than tolerance '+
+                          str(az_tol))
+                else:
+                    ray_number = np.argmin(d_az)
+                    prhi_rays.append(ray_number + sweep_slice.start)
+                    valid_azimuths.append(target_azimuth)
 
-    _range = _copy_dic(radar.range)
-    latitude = _copy_dic(radar.latitude)
-    longitude = _copy_dic(radar.longitude)
-    altitude = _copy_dic(radar.altitude)
-    metadata = _copy_dic(radar.metadata)
-    scan_type = 'rhi'
+    rhi_nsweeps = len(valid_azimuths)
+    if rhi_nsweeps == 0:
+        print('WARNING: No azimuth found whithin tolerance.')
+        return None
 
-    time = _copy_dic(radar.time, excluded_keys=['data'])
-    time['data'] = radar.time['data'][prhi_rays].copy()
-
-    azimuth = _copy_dic(radar.azimuth, excluded_keys=['data'])
-    azimuth['data'] = radar.azimuth['data'][prhi_rays].copy()
-
-    elevation = _copy_dic(radar.elevation, excluded_keys=['data'])
-    elevation['data'] = radar.elevation['data'][prhi_rays].copy()
-
-    fields = {}
-    for field_name, orig_field_dic in radar.fields.items():
-        field_dic = _copy_dic(orig_field_dic, excluded_keys=['data'])
-        field_dic['data'] = orig_field_dic['data'][prhi_rays].copy()
-        fields[field_name] = field_dic
-
-    sweep_number = _copy_dic(radar.sweep_number, excluded_keys=['data'])
-    sweep_number['data'] = np.arange(rhi_nsweeps, dtype='int32')
-
-    sweep_mode = _copy_dic(radar.sweep_mode, excluded_keys=['data'])
-    sweep_mode['data'] = np.array(['rhi']*rhi_nsweeps)
-
-    fixed_angle = _copy_dic(radar.fixed_angle, excluded_keys=['data'])
-    fixed_angle['data'] = np.array(target_azimuths, dtype='float32')
-
-    sweep_start_ray_index = _copy_dic(
-        radar.sweep_start_ray_index, excluded_keys=['data'])
-    ssri = np.arange(rhi_nsweeps, dtype='int32') * ppi_nsweeps
-    sweep_start_ray_index['data'] = ssri
-
-    sweep_end_ray_index = _copy_dic(
-        radar.sweep_end_ray_index, excluded_keys=['data'])
-    seri = np.arange(rhi_nsweeps, dtype='int32')*ppi_nsweeps + ppi_nsweeps-1
-    sweep_end_ray_index['data'] = seri
-
-    radar_rhi = Radar(
-        time, _range, fields, metadata, scan_type,
-        latitude, longitude, altitude,
-        sweep_number, sweep_mode, fixed_angle,
-        sweep_start_ray_index, sweep_end_ray_index,
-        azimuth, elevation)
+    radar_rhi = _construct_xsect_radar(
+        radar, 'rhi', prhi_rays, rhi_nsweeps, valid_azimuths)
 
     return radar_rhi
 
 
-def cross_section_rhi(radar, target_elevations):
+def cross_section_rhi(radar, target_elevations, el_tol=None):
     """
     Extract cross sections from an RHI volume along one or more elevation
     angles.
@@ -114,6 +91,10 @@ def cross_section_rhi(radar, target_elevations):
         cross sections will be extracted.
     target_elevations : list
         Elevation angles in degrees where cross sections will be taken.
+    el_tol : float
+        Elevation angle tolerance in degrees. If none the nearest angle is
+        used. If valid only angles within the tolerance distance are
+        considered.
 
     Returns
     -------
@@ -125,64 +106,116 @@ def cross_section_rhi(radar, target_elevations):
 
     # determine which rays from the rhi radar make up the pseudo PPI
     pppi_rays = []
-    ppi_nsweeps = len(target_elevations)
-    rhi_nsweeps = radar.nsweeps
-
+    valid_elevations = []
     for target_elevation in target_elevations:
         for sweep_slice in radar.iter_slice():
             sweep_elevations = radar.elevation['data'][sweep_slice]
-            ray_number = np.argmin(np.abs(sweep_elevations - target_elevation))
-            pppi_rays.append(ray_number + sweep_slice.start)
+            d_el = np.abs(sweep_elevations - target_elevation)
+            if el_tol is None:
+                ray_number = np.argmin(d_el)
+                pppi_rays.append(ray_number + sweep_slice.start)
+                valid_elevations.append(target_elevation)
+            else:
+                d_el_min = np.min(d_el)
+                if d_el_min > el_tol:
+                    print('WARNING: No elevation found whithin tolerance ' +
+                          'for angle '+str(target_elevation) +
+                          '. Minimum distance to radar elevation ' +
+                          str(d_el_min)+' larger than tolerance '+
+                          str(el_tol))
+                else:
+                    ray_number = np.argmin(d_el)
+                    pppi_rays.append(ray_number + sweep_slice.start)
+                    valid_elevations.append(target_elevation)
 
+    ppi_nsweeps = len(valid_elevations)
+    if ppi_nsweeps == 0:
+        print('WARNING: No elevation found whithin tolerance.')
+        return None
+
+    radar_ppi = _construct_xsect_radar(
+        radar, 'ppi', pppi_rays, ppi_nsweeps, valid_elevations)
+
+    return radar_ppi
+
+
+def _construct_xsect_radar(radar, scan_type, pxsect_rays, xsect_nsweeps, target_angles):
+    """
+    Constructs a new radar object that contains cross-sections at fixed angles
+    of a PPI or RHI volume scan.
+
+    Parameters
+    ----------
+    radar : Radar
+        Radar volume containing RHI/PPI sweeps from which a
+        cross sections will be extracted.
+    scan_type : str
+        Type of cross section scan (ppi or rhi)
+    pxsect_rays : list
+        list of rays from the radar volume to be copied in the cross-sections
+        radar object
+    xsect_nsweeps : int
+        Number of sweeps in the cross-section radar
+
+    traget_angles : array
+        the target fixed angles
+
+    Returns
+    -------
+    radar_xsect : Radar
+        Radar volume containing sweeps which contain cross sections from the
+        original volume.
+
+    """
     _range = _copy_dic(radar.range)
     latitude = _copy_dic(radar.latitude)
     longitude = _copy_dic(radar.longitude)
     altitude = _copy_dic(radar.altitude)
     metadata = _copy_dic(radar.metadata)
-    scan_type = 'ppi'
 
     time = _copy_dic(radar.time, excluded_keys=['data'])
-    time['data'] = radar.time['data'][pppi_rays].copy()
+    time['data'] = radar.time['data'][pxsect_rays].copy()
 
     azimuth = _copy_dic(radar.azimuth, excluded_keys=['data'])
-    azimuth['data'] = radar.azimuth['data'][pppi_rays].copy()
+    azimuth['data'] = radar.azimuth['data'][pxsect_rays].copy()
 
     elevation = _copy_dic(radar.elevation, excluded_keys=['data'])
-    elevation['data'] = radar.elevation['data'][pppi_rays].copy()
+    elevation['data'] = radar.elevation['data'][pxsect_rays].copy()
 
     fields = {}
     for field_name, orig_field_dic in radar.fields.items():
         field_dic = _copy_dic(orig_field_dic, excluded_keys=['data'])
-        field_dic['data'] = orig_field_dic['data'][pppi_rays].copy()
+        field_dic['data'] = orig_field_dic['data'][pxsect_rays].copy()
         fields[field_name] = field_dic
 
     sweep_number = _copy_dic(radar.sweep_number, excluded_keys=['data'])
-    sweep_number['data'] = np.arange(ppi_nsweeps, dtype='int32')
+    sweep_number['data'] = np.arange(xsect_nsweeps, dtype='int32')
 
     sweep_mode = _copy_dic(radar.sweep_mode, excluded_keys=['data'])
-    sweep_mode['data'] = np.array(['ppi']*ppi_nsweeps)
+    sweep_mode['data'] = np.array([scan_type]*xsect_nsweeps)
 
     fixed_angle = _copy_dic(radar.fixed_angle, excluded_keys=['data'])
-    fixed_angle['data'] = np.array(target_elevations, dtype='float32')
+    fixed_angle['data'] = np.array(target_angles, dtype='float32')
 
     sweep_start_ray_index = _copy_dic(
         radar.sweep_start_ray_index, excluded_keys=['data'])
-    ssri = np.arange(ppi_nsweeps, dtype='int32') * rhi_nsweeps
+    ssri = np.arange(xsect_nsweeps, dtype='int32') * radar.nsweeps
     sweep_start_ray_index['data'] = ssri
 
     sweep_end_ray_index = _copy_dic(
         radar.sweep_end_ray_index, excluded_keys=['data'])
-    seri = np.arange(ppi_nsweeps, dtype='int32')*rhi_nsweeps + rhi_nsweeps-1
+    seri = (np.arange(xsect_nsweeps, dtype='int32') *
+            radar.nsweeps + radar.nsweeps-1)
     sweep_end_ray_index['data'] = seri
 
-    radar_ppi = Radar(
+    radar_xsect = Radar(
         time, _range, fields, metadata, scan_type,
         latitude, longitude, altitude,
         sweep_number, sweep_mode, fixed_angle,
         sweep_start_ray_index, sweep_end_ray_index,
         azimuth, elevation)
 
-    return radar_ppi
+    return radar_xsect
 
 
 def _copy_dic(orig_dic, excluded_keys=None):


### PR DESCRIPTION
Dear Py-ART users,

I have added the following functionalities to Py-ART:
- A correction of RhoHV for noise in correct/noise.py
- The computation of the new fields: noise in dBZ, signal to noise ratio, logarithmic RhoHv (L parameter), and circular depolarization ratio in retrieve/simple_moment_calculations.
- A cross-section of a volume of RHIs along particular azimuths (pseudo-PPI) in util/xsect.py

@jjhelmus, I think we should set standard names for the new fields.

Let me know if you think these new functionalities can be implemented in Py-ART and are up to standard.

Greetings from Switzerland,


Jordi
