### PR TITLE
BUG: pyart.io.read can read RSL only files

### DIFF
--- a/pyart/io/auto_read.py
+++ b/pyart/io/auto_read.py
@@ -17,7 +17,7 @@ import gzip
 
 import netCDF4
 
-from .rsl import read_rsl
+from .rsl import read_rsl, _RSL_AVAILABLE
 from .mdv_radar import read_mdv
 from .cfradial import read_cfradial
 from .sigmet import read_sigmet


### PR DESCRIPTION
Files which are only support by RSL can be read with pyart.io.read.  Previously
attempting to read these files with pyart.io.read would result in a NameError
as the _RSL_AVAILABLE variable was not imported into the auto_read.py module.

closes #589