### PR TITLE
BUG: Change use of dtype in linspace function

### DIFF
--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -233,7 +233,7 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
         # nbins is required
         nbins = hfile['dataset1/data1/data'].shape[1]
         _range['data'] = np.linspace(
-            0, max_range[0] * 1000., nbins, dtype='float32')
+            0, max_range[0] * 1000., nbins).astype('float32')
         _range['meters_to_center_of_first_gate'] = 0
         _range['meters_between_gates'] = max_range[0] * 1000. / nbins
 

--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -262,7 +262,7 @@ def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
         start_range = 0.
     _range['data'] = np.linspace(
         start_range+r_res / 2., float(nbins - 1.) * r_res+r_res / 2.,
-        nbins, dtype='float32')
+        nbins).astype('float32')
 
     # containers for data
     t_fixed_angle = np.empty(nslices, dtype='float64')


### PR DESCRIPTION
The dtype parameter was not added to NumPy's linspace function until version
1.9.0.  To support older versions of NumPy use the astype method instead.

closes #601