### PR TITLE
BLD: Add kludge to setup.py script for Python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,14 @@ if sys.version_info[0] < 3:
 else:
     import builtins
 
+# KLUDGE:
+# NumPy 1.11.2 contains a bug which prevents submodules from working correctly
+# on Python 3.4 unless importlib.machinery has been imported at some time.
+try:
+    import importlib.machinery
+except:
+    pass
+
 
 CLASSIFIERS = """\
 Development Status :: 5 - Production/Stable


### PR DESCRIPTION
NumPy 1.11.2 contains a bug which prevents submodules from being built
correctly on Python 3.4 unless importlib.machinery has been imported at some
time.