### PR TITLE
BUG: Read in altitude form ARM sonde files

### DIFF
--- a/pyart/io/arm_sonde.py
+++ b/pyart/io/arm_sonde.py
@@ -40,24 +40,7 @@ def read_arm_sonde(filename):
     profile_datetime = netCDF4.num2date(
         dset.variables['time'][0], dset.variables['time'].units)
 
-    # extract wind profile
-    pressure = dset.variables['pres'][:]
-    # pressure to altitude:
-    # h = h_0 + T/L * [(P/P_0)**(-(R*L) / (g * M)) - 1]
-    #
-    # Where
-    # T = 288.15 K
-    # L = -0.0065 K/m
-    # P_0 = 1013.25 hPa
-    # g = 9.80665 m/s**2
-    # R = 8.31147 J / (mol * K)
-    # M = 0.0289644 kg / mol
-    #
-    # Then
-    # h = -44330.77 * ((P/1013.25)**(0.1902652) - 1)
-    # with h in meters and P in hPa
-    height = -44330.77 * ((pressure / 1013.25)**(0.1902652) - 1)
-
+    height = dset.variables['alt'][:]
     speed = dset.variables['wspd'][:]
     direction = dset.variables['deg'][:]
     profile = HorizontalWindProfile(height, speed, direction)

--- a/pyart/io/tests/test_arm_sonde.py
+++ b/pyart/io/tests/test_arm_sonde.py
@@ -53,7 +53,7 @@ def test_read_arm_sonde():
     profile_dt, hprofile = pyart.io.read_arm_sonde(pyart.testing.SONDE_FILE)
 
     assert profile_dt == datetime.datetime(2011, 5, 20, 8, 28)
-    assert_almost_equal(hprofile.height[:5], [371, 376, 384, 391, 399], 0)
+    assert_almost_equal(hprofile.height[:5], [315, 321, 328, 336, 344], 0)
     assert_almost_equal(hprofile.speed[:5], [5, 3.2, 3.7, 4.3, 4.8], 1)
     assert_almost_equal(
         hprofile.direction[:5], [215., 193., 191., 191., 189.], 1)


### PR DESCRIPTION
Read in the altitude directly from ARM sonde files from the alt variable.
Previously the altitude/height was calculated from the pressure which would
give slightly incorrect values.

closes #606