### PR TITLE
ENH: location data available in HorizontalWindProfile class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.tmp
 *.vim
 tags
+.idea/
 
 # Compiled source #
 ###################

--- a/pyart/core/tests/test_wind_profile.py
+++ b/pyart/core/tests/test_wind_profile.py
@@ -39,3 +39,12 @@ def test_horizontalwindprofile_error():
     speed = [1, 1]
     direction = [1, 2, 3]
     assert_raises(ValueError, HorizontalWindProfile, height, speed, direction)
+
+
+def test_horizontalwindprofile_location_error():
+    height = [1, 2]
+    speed = [1, 1]
+    direction = [1, 2]
+    lat = [1]
+    assert_raises(ValueError, HorizontalWindProfile, height, speed, direction,
+                  latitude=lat, longitude=None)

--- a/pyart/core/wind_profile.py
+++ b/pyart/core/wind_profile.py
@@ -32,9 +32,9 @@ class HorizontalWindProfile(object):
 
     Other Parameters
     ----------------
-    latitude : array-like, 1D
+    latitude : array-like, 1D, optional
         Latitude in degrees north at each height sampled.
-    longitude : array-like, 1D
+    longitude : array-like, 1D, optional
         Longitude in degrees east at each height sampled.
 
     Attributes

--- a/pyart/core/wind_profile.py
+++ b/pyart/core/wind_profile.py
@@ -30,6 +30,13 @@ class HorizontalWindProfile(object):
     direction : array-like, 1D
         Horizontal wind direction in degrees at each height sampled.
 
+    Other Parameters
+    ----------------
+    latitude : array-like, 1D
+        Latitude in degrees north at each height sampled.
+    longitude : array-like, 1D
+        Longitude in degrees east at each height sampled.
+
     Attributes
     ----------
     height : array, 1D
@@ -39,20 +46,22 @@ class HorizontalWindProfile(object):
         Horizontal wind speed in meters per second at each height.
     direction : array, 1D
         Horizontal wind direction in degrees at each height.
-    u : array, 1D
+    u_wind : array, 1D
         U component of horizontal winds in meters per second at each height.
-    v : array, 1D
+    v_wind : array, 1D
         V component of horizontal winds in meters per second at each height.
 
     """
 
-    def __init__(self, height, speed, direction):
+    def __init__(self, height, speed, direction, latitude=None,
+                 longitude=None):
         """ initialize """
         if len(height) != len(speed) or len(height) != len(direction):
             raise ValueError("Wind parameters must have the same length.")
         self.height = np.asanyarray(height)
         self.speed = np.asanyarray(speed)
         self.direction = np.asanyarray(direction)
+        self._parse_location_data(latitude, longitude)
 
     @classmethod
     def from_u_and_v(cls, height, u_wind, v_wind):
@@ -90,3 +99,14 @@ class HorizontalWindProfile(object):
         # V = -cos(direction) * speed
         v_wind = -np.cos(np.deg2rad(self.direction)) * self.speed
         return v_wind
+
+    def _parse_location_data(self, latitude, longitude):
+        """ Parse profile location data. """
+        if latitude is not None:
+            if len(self.height) != len(latitude):
+                raise ValueError('Latitude data must have same length.')
+            self.latitude = np.asanyarray(latitude)
+        if longitude is not None:
+            if len(self.height) != len(longitude):
+                raise ValueError('Longitude data must have same length.')
+            self.longitude = np.asanyarray(longitude)

--- a/pyart/io/arm_sonde.py
+++ b/pyart/io/arm_sonde.py
@@ -41,7 +41,7 @@ def read_arm_sonde(filename):
     launch_datetime = netCDF4.num2date(
         dset.variables['time'][0], dset.variables['time'].units)
 
-    height = dset.variables['alt'][:]
+    height = dset.variables['alt'][:]  # meters above mean sea level
     speed = dset.variables['wspd'][:]  # m s-1
     direction = dset.variables['deg'][:]  # degrees clockwise from north
     lat = dset.variables['lat'][:]  # degrees north

--- a/pyart/io/arm_sonde.py
+++ b/pyart/io/arm_sonde.py
@@ -29,15 +29,16 @@ def read_arm_sonde(filename):
 
     Return
     ------
-    profile_datetime : datetime
-        Date and time of the profile
+    launch_datetime : datetime
+        Date and time corresponding to radiosonde launch time, i.e., first
+        recorded time.
     profile : HorizontalWindProfile
         Profile of the horizontal winds
 
     """
     dset = netCDF4.Dataset(filename, 'r')
 
-    profile_datetime = netCDF4.num2date(
+    launch_datetime = netCDF4.num2date(
         dset.variables['time'][0], dset.variables['time'].units)
 
     # extract wind profile
@@ -58,13 +59,16 @@ def read_arm_sonde(filename):
     # with h in meters and P in hPa
     height = -44330.77 * ((pressure / 1013.25)**(0.1902652) - 1)
 
-    speed = dset.variables['wspd'][:]
-    direction = dset.variables['deg'][:]
-    profile = HorizontalWindProfile(height, speed, direction)
+    speed = dset.variables['wspd'][:]  # m s-1
+    direction = dset.variables['deg'][:]  # degrees clockwise from north
+    lat = dset.variables['lat'][:]  # degrees north
+    lon = dset.variables['lon'][:]  # degrees east
+    profile = HorizontalWindProfile(
+        height, speed, direction, latitude=lat, longitude=lon)
 
     dset.close()
 
-    return profile_datetime, profile
+    return launch_datetime, profile
 
 
 def read_arm_sonde_vap(filename, radar=None, target_datetime=None):


### PR DESCRIPTION
Adding latitude and longitude parameters/attributes to `HorizontalWindProfile` class. This information is now parsed from ARM radiosonde datasets in `read_arm_sonde`. I also considered adding `sample_time` as an optional parameter/attribute to the class, e.g., 1D array of datetimes, but thought otherwise. Let me know if I should add this as well, seeing as this information is available from standard soundings. 