### PR TITLE
Add support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       env:
         - PYTHON_VERSION="3.5"
         - NOSE_ARGS="-v --with-cov --cov pyart pyart"
+    - python: 3.6
+      env:
+        - PYTHON_VERSION="3.6"
+        - NOSE_ARGS="-v --with-cov --cov pyart pyart"
 install: source continuous_integration/install.sh
 script: eval xvfb-run nosetests $NOSE_ARGS
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Other related open source software for working with weather radar data:
 Dependencies
 ============
 
-Py-ART is tested to work under Python 2.7, 3.4, and 3.5.
+Py-ART is tested to work under Python 2.7, 3.4, 3.5, and 3.6.
 
 The required dependencies to install Py-ART in addition to Python are:
 

--- a/continuous_integration/environment-3.6.yml
+++ b/continuous_integration/environment-3.6.yml
@@ -1,0 +1,16 @@
+name: testenv
+channels:
+  - jjhelmus   # required until conda-forge trmm_rsl fixed
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.6
+  - numpy
+  - scipy
+  - matplotlib
+  - netcdf4
+  - nose
+  - basemap
+  - trmm_rsl
+  - wradlib
+  - cartopy


### PR DESCRIPTION
Add Python 3.6 to Travis CI test matrix.
Add Python 3.6 to tested version in README.rst file.