### PR TITLE
Deprecate dealias sonde function and parameters

### DIFF
--- a/pyart/correct/__init__.py
+++ b/pyart/correct/__init__.py
@@ -35,12 +35,11 @@ Helper functions
 .. autosummary::
     :toctree: generated/
 
-    find_time_in_interp_sonde
     find_objects
 
 """
 
-from .dealias import dealias_fourdd, find_time_in_interp_sonde
+from .dealias import dealias_fourdd
 from .attenuation import calculate_attenuation
 from .phase_proc import phase_proc_lp
 # for backwards compatibility GateFilter available in the correct namespace

--- a/pyart/correct/dealias.py
+++ b/pyart/correct/dealias.py
@@ -8,7 +8,6 @@ Front end to the University of Washington 4DD code for Doppler dealiasing.
     :toctree: generated/
 
     dealias_fourdd
-    find_time_in_interp_sonde
     _create_rsl_volume
 
 """
@@ -308,52 +307,3 @@ def _create_rsl_volume(radar, field_name, vol_num, rsl_badval, excluded=None):
     rsl_volume = _rsl_interface.create_volume(fdata, rays_per_sweep, vol_num)
     _rsl_interface._label_volume(rsl_volume, radar)
     return rsl_volume
-
-
-def find_time_in_interp_sonde(interp_sonde, target, debug=False):
-    """
-    Find the wind parameter for a given time in a ARM interpsonde file.
-
-    This function is Deprecated and will be removed in future versions of
-    Py-ART. Use the :py:func:`pyart.io.read_arm_sonde_vap` function for similar
-    functionality.
-
-    Parameters
-    ----------
-    interp_sonde : netCDF4.Dataset
-        netCDF4 object pointing to a ARM interpsonde file.
-    target : datetime
-        Target datetime, the closest time in the interpsonde file will be
-        used.
-
-    Other Parameters
-    ----------------
-    debug : bool
-        Print debugging information.
-
-    Returns
-    -------
-    height : np.ndarray
-        Heights above the ground for the time closest to target.
-    speed : np.ndarray
-        Wind speeds at given height for the time closest to taget.
-    direction : np.ndarray
-        Wind direction at given height for the time closest to target.
-
-    """
-    warnings.warn(
-        "find_time_in_interp_sonde is deprecated and will be removed in a "
-        "future version of Py-ART.\n", DeprecationWarning)
-
-    sonde_datetimes = datetime_utils.datetimes_from_dataset(interp_sonde)
-
-    # get closest time index to target
-    idx = np.abs(sonde_datetimes - target).argmin()
-
-    if debug:
-        print('Target time is %s' % (target))
-        print('Interpolated sounding time is %s' % (sonde_datetimes[idx]))
-
-    return (interp_sonde.variables['height'][:],
-            interp_sonde.variables['wspd'][idx, :],
-            interp_sonde.variables['wdir'][idx, :])

--- a/pyart/correct/dealias.py
+++ b/pyart/correct/dealias.py
@@ -12,11 +12,8 @@ Front end to the University of Washington 4DD code for Doppler dealiasing.
 
 """
 
-import warnings
-
 import numpy as np
 
-from ..core import HorizontalWindProfile
 from ..config import get_field_name, get_fillvalue, get_metadata
 try:
     from ..io import _rsl_interface
@@ -25,14 +22,11 @@ try:
 except ImportError:
     _FOURDD_AVAILABLE = False
 from ._common_dealias import _parse_gatefilter, _set_limits
-from ..util import datetime_utils
 from ..exceptions import MissingOptionalDependency
 
 
 def dealias_fourdd(
         radar, last_radar=None, sonde_profile=None, gatefilter=False,
-        sounding_heights=None, sounding_wind_speeds=None,
-        sounding_wind_direction=None,
         filt=1, rsl_badval=131072.0, keep_original=False, set_limits=True,
         vel_field=None, corr_vel_field=None, last_vel_field=None,
         debug=False, max_shear=0.05, sign=1, **kwargs):
@@ -75,18 +69,6 @@ def dealias_fourdd(
         create this filter from the radar moments using any additional
         arguments by passing them to :py:func:`moment_based_gate_filter`. The
         default value assumes all gates are valid.
-    sounding_heights : ndarray, optional
-        This argument is deprecated and should be specified using the
-        sonde_profile argument.  Sounding heights in meters above mean sea
-        level.  If altitude attribute of the radar object if reference against
-        something other than mean sea level then this parameter should also be
-        referenced in that manner.
-    sounding_wind_speeds : ndarray, optional
-        This argument is deprecated and should be specified using the
-        sonde_profile argument.  Sounding wind speeds in m/s.
-    sounding_wind_direction : ndarray, optional
-        This argument is deprecated and should be specified using the
-        sonde_profile argument.  Sounding wind directions in degrees.
     filt : int, optional
         Flag controlling Bergen and Albers filter, 1 = yes, 0 = no.
     rsl_badval : float, optional
@@ -196,26 +178,7 @@ def dealias_fourdd(
             "Py-ART must be build with support for TRMM RSL to use" +
             "the dealias_fourdd function.")
 
-    # check for use of deprecated sonding_ arguments
-    deprecated_args_used = ((sounding_heights is not None) or
-                            (sounding_wind_speeds is not None) or
-                            (sounding_wind_direction is not None))
-    if deprecated_args_used:
-        msg = ("Sounding arguments are deprecated please use the "
-               "sonde_profile argument")
-        warnings.warn(msg, DeprecationWarning)
-        all_args_available = ((sounding_heights is not None) and
-                              (sounding_wind_speeds is not None) and
-                              (sounding_wind_direction is not None))
-        if all_args_available:
-            sonde_profile = HorizontalWindProfile(
-                sounding_heights, sounding_wind_speeds,
-                sounding_wind_direction)
-
     # verify that sounding data or last_volume is provided
-    sounding_available = ((sounding_heights is not None) and
-                          (sounding_wind_speeds is not None) and
-                          (sounding_wind_direction is not None))
     if (sonde_profile is None) and (last_radar is None):
         raise ValueError('sonde_profile or last_radar must be provided')
 

--- a/pyart/correct/tests/test_dealias.py
+++ b/pyart/correct/tests/test_dealias.py
@@ -127,32 +127,6 @@ def test_segmentation_fault_error():
     return
 
 
-# Remove this test when the sounding_ parameters of dealias_fourdd are
-# Deprecated
-@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
-def test_dealias_deprecated_arguments():
-
-    radar = pyart.testing.make_velocity_aliased_radar()
-    # speckling that will not be dealiased.
-    radar.fields['velocity']['data'][13, -4:] = [-7.5, 8.5, 0, 0]
-    height = np.linspace(150, 250, 10).astype('float32')
-    speed = np.ones((10), dtype='float32') * 0.5
-    direction = np.ones((10), dtype='float32') * 5.
-    profile = pyart.core.HorizontalWindProfile(height, speed, direction)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        dealias_vel = pyart.correct.dealias_fourdd(
-            radar, sounding_heights=height, sounding_wind_speeds=speed,
-            sounding_wind_direction=direction)
-    assert_allclose(
-        dealias_vel['data'][13, :27],
-        [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5,
-         12.5, 13.5, 12.5, 11.5, 10.5, 9.5, 8.5, 7.5, 6.5, 5.5, 4.5, 3.5,
-         2.5, 1.5, 0.5])
-    assert dealias_vel['data'][13, 46] is np.ma.masked
-    assert dealias_vel['data'][13, 47] is np.ma.masked
-
-
 if __name__ == "__main__":
 
     radar, dealias_vel = perform_dealias()

--- a/pyart/correct/tests/test_dealias.py
+++ b/pyart/correct/tests/test_dealias.py
@@ -153,30 +153,6 @@ def test_dealias_deprecated_arguments():
     assert dealias_vel['data'][13, 47] is np.ma.masked
 
 
-# Remove this test when the find_time_in_interp_sonde function is Deprecated
-@skipif(not pyart.correct.dealias._FOURDD_AVAILABLE)
-def test_find_time_in_interp_sounde():
-    target = datetime.datetime(2011, 5, 10, 11, 30, 8)
-    interp_sounde = netCDF4.Dataset(pyart.testing.INTERP_SOUNDE_FILE)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=DeprecationWarning)
-        t = pyart.correct.dealias.find_time_in_interp_sonde(
-            interp_sounde, target)
-    height, speed, direction = t
-
-    assert height.shape == (316,)
-    assert speed.shape == (316,)
-    assert direction.shape == (316,)
-
-    assert height.dtype == 'float32'
-    assert speed.dtype == 'float32'
-    assert direction.dtype == 'float32'
-
-    assert_almost_equal(height[100], 2.32, 2)
-    assert_almost_equal(speed[100], 15.54, 2) == 15.54
-    assert_almost_equal(direction[100], 231.8, 2) == 231.8
-
-
 if __name__ == "__main__":
 
     radar, dealias_vel = perform_dealias()


### PR DESCRIPTION
* Remove the deprecated `find_time_in_intep_sonde` function from pyart.correct.  `pyart.io.read_sonde_vap` should be used in its place.

* Remove the deprecated `sounding_heights`, `sounding_wind_speeds`, `and sounding_wind_direction` parameters from the `pyart.correct.dealias_fourdd` function.  These parameters should be specified using the `sonde_profile` argument.