### PR TITLE
TST: Do not use jjhelmus channel for Travis CI test environment

### DIFF
--- a/continuous_integration/environment-2.7.yml
+++ b/continuous_integration/environment-2.7.yml
@@ -1,6 +1,5 @@
 name: testenv
 channels:
-  - jjhelmus   # required until conda-forge trmm_rsl fixed
   - conda-forge
   - defaults
 dependencies:

--- a/continuous_integration/environment-2.7.yml
+++ b/continuous_integration/environment-2.7.yml
@@ -13,3 +13,4 @@ dependencies:
   - trmm_rsl
   - wradlib
   - cartopy
+  - cvxopt

--- a/continuous_integration/environment-3.4.yml
+++ b/continuous_integration/environment-3.4.yml
@@ -1,6 +1,5 @@
 name: testenv
 channels:
-  - jjhelmus   # required until conda-forge trmm_rsl fixed
   - conda-forge
   - defaults
 dependencies:

--- a/continuous_integration/environment-3.5.yml
+++ b/continuous_integration/environment-3.5.yml
@@ -1,6 +1,5 @@
 name: testenv
 channels:
-  - jjhelmus   # required until conda-forge trmm_rsl fixed
   - conda-forge
   - defaults
 dependencies:

--- a/continuous_integration/environment-3.6.yml
+++ b/continuous_integration/environment-3.6.yml
@@ -1,6 +1,5 @@
 name: testenv
 channels:
-  - jjhelmus   # required until conda-forge trmm_rsl fixed
   - conda-forge
   - defaults
 dependencies:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -17,7 +17,7 @@ conda update -q conda
 ## Create a testenv with the correct Python version
 conda env create -f continuous_integration/environment-$PYTHON_VERSION.yml
 source activate testenv
-# TODO install cbc, cylp, glpk, cvxopt_glpk in Python 2.7
+# TODO install cylp and  glpk in Python 2.7
 
 # install coverage modules
 pip install nose-cov

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -17,8 +17,6 @@ conda update -q conda
 ## Create a testenv with the correct Python version
 conda env create -f continuous_integration/environment-$PYTHON_VERSION.yml
 source activate testenv
-# KLUDGE to replace unwanted packages from the jjhelmus channel
-conda install -c conda-forge pyproj wradlib
 # TODO install cbc, cylp, glpk, cvxopt_glpk in Python 2.7
 
 # install coverage modules


### PR DESCRIPTION
All packages used for Travis CI test are loaded from conda-forge or the default conda channels.  
Install cvxopt into Python 2.7 channel from conda-forge.