### PR TITLE
added Raster keyword for happier vector file output

### DIFF
--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -234,7 +234,7 @@ class RadarDisplay(object):
             colorbar_flag=True, colorbar_label=None,
             colorbar_orient='vertical', edges=True, gatefilter=None,
             filter_transitions=True, ax=None, fig=None,
-            ticks=None, ticklabs=None, **kwargs):
+            ticks=None, ticklabs=None, raster=None, **kwargs):
         """
         Plot a PPI.
 
@@ -312,6 +312,12 @@ class RadarDisplay(object):
             Axis to plot on. None will use the current axis.
         fig : Figure
             Figure to add the colorbar to. None will use the current figure.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -332,6 +338,9 @@ class RadarDisplay(object):
             vmin = vmax = None
         pm = ax.pcolormesh(
             x, y, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm, **kwargs)
+
+        if raster is not None:
+            pm.set_rasterized(True)
 
         if title_flag:
             self._set_title(field, sweep, title, ax)
@@ -356,7 +365,7 @@ class RadarDisplay(object):
             reverse_xaxis=None, colorbar_flag=True, colorbar_label=None,
             colorbar_orient='vertical', edges=True, gatefilter=None,
             filter_transitions=True, ax=None, fig=None,
-            ticks=None, ticklabs=None, **kwargs):
+            ticks=None, ticklabs=None, raster=False, **kwargs):
         """
         Plot a RHI.
 
@@ -435,6 +444,12 @@ class RadarDisplay(object):
             Axis to plot on. None will use the current axis.
         fig : Figure
             Figure to add the colorbar to. None will use the current figure.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -462,6 +477,9 @@ class RadarDisplay(object):
         pm = ax.pcolormesh(
             R, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm, **kwargs)
 
+        if raster is not None:
+            pm.set_rasterized(True)
+
         if title_flag:
             self._set_title(field, sweep, title, ax)
 
@@ -486,7 +504,7 @@ class RadarDisplay(object):
             colorbar_orient='vertical', edges=True,
             filter_transitions=True, time_axis_flag=False,
             date_time_form=None, tz=None, ax=None, fig=None,
-            ticks=None, ticklabs=None, **kwargs):
+            ticks=None, ticklabs=None, raster=None, **kwargs):
         """
         Plot a VPT scan.
 
@@ -568,6 +586,12 @@ class RadarDisplay(object):
             Axis to plot on. None will use the current axis.
         fig : Figure
             Figure to add the colorbar to. None will use the current figure.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -603,6 +627,9 @@ class RadarDisplay(object):
         pm = ax.pcolormesh(
             x, y, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm, **kwargs)
 
+        if raster is not None:
+            pm.set_rasterized(True)
+
         if title_flag:
             self._set_vpt_title(field, title, ax)
 
@@ -626,7 +653,8 @@ class RadarDisplay(object):
             colorbar_flag=True, colorbar_label=None,
             colorbar_orient='vertical', edges=True, gatefilter=None,
             reverse_xaxis=None, filter_transitions=True,
-            ax=None, fig=None, ticks=None, ticklabs=None, **kwargs):
+            ax=None, fig=None, ticks=None, ticklabs=None,
+            raster=None, **kwargs):
         """
         Plot pseudo-RHI scan by extracting the vertical field associated
         with the given azimuth.
@@ -706,6 +734,12 @@ class RadarDisplay(object):
             Axis to plot on. None will use the current axis.
         fig : Figure
             Figure to add the colorbar to. None will use the current figure.
+        raster : bool
+            False by default.  Set to True to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -731,6 +765,9 @@ class RadarDisplay(object):
             vmin = vmax = None
         pm = ax.pcolormesh(
             R, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm, **kwargs)
+
+        if raster is not None:
+            pm.set_rasterized(True)
 
         if title_flag:
             self._set_az_rhi_title(field, target_azimuth, title, ax)

--- a/pyart/graph/radardisplay_airborne.py
+++ b/pyart/graph/radardisplay_airborne.py
@@ -137,7 +137,7 @@ class AirborneRadarDisplay(RadarDisplay):
             axislabels=(None, None), axislabels_flag=True,
             colorbar_flag=True, colorbar_label=None,
             colorbar_orient='vertical', edges=True, filter_transitions=True,
-            ax=None, fig=None, gatefilter=None, **kwargs):
+            ax=None, fig=None, gatefilter=None, raster=True, **kwargs):
         """
         Plot a sweep as a grid.
 
@@ -211,6 +211,12 @@ class AirborneRadarDisplay(RadarDisplay):
             Axis to plot on. None will use the current axis.
         fig : Figure
             Figure to add the colorbar to. None will use the current figure.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -233,6 +239,9 @@ class AirborneRadarDisplay(RadarDisplay):
             vmin = vmax = None
         pm = ax.pcolormesh(
             x, z, data, vmin=vmin, vmax=vmax, cmap=cmap, norm=norm, **kwargs)
+
+        if raster is not None:
+            pm.set_rasterized(True)
 
         if title_flag:
             self._set_title(field, sweep, title, ax)

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -107,7 +107,7 @@ class RadarMapDisplay(RadarDisplay):
             width=None, height=None, lon_0=None, lat_0=None,
             resolution='h', shapefile=None, edges=True, gatefilter=None,
             basemap=None, filter_transitions=True, embelish=True,
-            ticks=None, ticklabs=None, **kwargs):
+            ticks=None, ticklabs=None, raster=False, **kwargs):
         """
         Plot a PPI volume sweep onto a geographic map.
 
@@ -215,6 +215,12 @@ class RadarMapDisplay(RadarDisplay):
         basemap: Basemap instance
             If None, create basemap instance using other keyword info.
             If not None, use the user-specifed basemap instance.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
 
         """
         # parse parameters
@@ -287,6 +293,9 @@ class RadarMapDisplay(RadarDisplay):
         pm = basemap.pcolormesh(
             self._x0 + x * 1000., self._y0 + y * 1000., data,
             vmin=vmin, vmax=vmax, cmap=cmap, norm=norm)
+
+        if raster is not None:
+            pm.set_rasterized(True)
 
         if shapefile is not None:
             basemap.readshapefile(shapefile, 'shapefile', ax=ax)

--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -120,7 +120,7 @@ class RadarMapDisplayCartopy(RadarDisplay):
             width=None, height=None, lon_0=None, lat_0=None,
             resolution='110m', shapefile=None, shapefile_kwargs=None,
             edges=True, gatefilter=None,
-            filter_transitions=True, embelish=True,
+            filter_transitions=True, embelish=True, raster=False,
             ticks=None, ticklabs=None):
         """
         Plot a PPI volume sweep onto a geographic map.
@@ -220,6 +220,12 @@ class RadarMapDisplayCartopy(RadarDisplay):
             True by default. Set to False to supress drawing of coastlines
             etc.. Use for speedup when specifying shapefiles.
             Note that lat lon labels only work with certain projections.
+        raster : bool
+            False by default.  Set to true to render the display as a raster
+            rather than a vector in call to pcolormesh.  Saves time in plotting
+            high resolution data over large areas.  Be sure to set the dpi
+            of the plot for your application if you save it as a vector format
+            (i.e., pdf, eps, svg).
         """
         # parse parameters
         ax, fig = parse_ax_fig(ax, fig)
@@ -265,7 +271,9 @@ class RadarMapDisplayCartopy(RadarDisplay):
         pm = ax.pcolormesh(x * 1000., y * 1000., data,
                            vmin=vmin, vmax=vmax, cmap=cmap,
                            norm=norm, transform=self.grid_projection)
-
+        #plot as raster in vector graphics files
+        if raster is not None:
+            pm.set_rasterized(True)
         # add embelishments
         if embelish is True:
             # Create a feature for States/Admin 1 regions at 1:resolution


### PR DESCRIPTION
This PR addresses the issue of large file size outputs in `plot_ppi*` displays when creating vector graphics for publications.  If saving to pdf, eps, or svg output, `pcolormesh` was rendering many polygons, and not clipping those polygons to the plot window, meaning that for high resolution data, the output file sizes were huge (sometimes exceeding 100 megabytes), and editing the resulting images in graphics software such as Illustrator was difficult.  Such large files are also a world of pain in the publication process.

The PR introduces the raster keyword, which, when set to True, will cause the artist (`pcolormesh`) to use `pm.set_rasterized(True)`.  Behavior is described here: [http://matplotlib.org/api/_as_gen/matplotlib.artist.Artist.set_rasterized.html](http://matplotlib.org/api/_as_gen/matplotlib.artist.Artist.set_rasterized.html)

When saving the file, setting the `dpi` keyword in `plt.save_fig()` changes the resolution of the raster image in the plot.

An example pdf (5.6 MB) file is below from a multi-panel NEXRAD level 2 sweep.

[KILX20160316_020459_V06.gz.pdf](https://github.com/ARM-DOE/pyart/files/916604/KILX20160316_020459_V06.gz.pdf)
