### PR TITLE
OverflowError: Python int too large to convert to C long in despeckle

### DIFF
--- a/pyart/correct/despeckle.py
+++ b/pyart/correct/despeckle.py
@@ -25,8 +25,9 @@ import numpy as np
 from ..filters.gatefilter import GateFilter
 from scipy.ndimage import label
 from scipy.signal import convolve2d
+from ..config import get_fillvalue
 
-BAD = 9999 # Absurdly unphysical value, for easy thresholding
+BAD = get_fillvalue() # Get default fill value.
 DELTA = 5.0  # deg, allowable gap between PPI edges to be considered full 360
 # To do:
 # Testing

--- a/pyart/correct/despeckle.py
+++ b/pyart/correct/despeckle.py
@@ -26,7 +26,7 @@ from ..filters.gatefilter import GateFilter
 from scipy.ndimage import label
 from scipy.signal import convolve2d
 
-BAD = 1e20  # Absurdly unphysical value, for easy thresholding
+BAD = 9999 # Absurdly unphysical value, for easy thresholding
 DELTA = 5.0  # deg, allowable gap between PPI edges to be considered full 360
 # To do:
 # Testing


### PR DESCRIPTION
I had this error while using pyart.correct.despeckle:

 File "pyart/correct/despeckle.py", line 144, in despeckle_field
    gatefilter=gatefilter, delta=delta)
  File "pyart/correct/despeckle.py", line 85, in find_objects
    gatefilter=gatefilter)
  File "pyart/correct/despeckle.py", line 412, in _get_data
    data = data.filled(fill_value=BAD)
  File "numpy/ma/core.py", line 3687, in filled
    fill_value = _check_fill_value(fill_value, self.dtype)
  File "numpy/ma/core.py", line 485, in _check_fill_value
    raise TypeError(err_msg % (fill_value, ndtype))
TypeError: Fill value 1e+20 overflows dtype int16

I don't know why the dtype is int16 (I'm using numpy 1.12 and python 3.6) but that was fixed by changing the global constant BAD to 9999.