### PR TITLE
AttributeError fix with python 3.6 in cfradial.py

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -189,7 +189,12 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         ray_angle_res = None
 
     # first sweep mode determines scan_type
-    mode = netCDF4.chartostring(sweep_mode['data'][0])[()].decode('utf-8')
+    try:
+        mode = netCDF4.chartostring(sweep_mode['data'][0])[()].decode('utf-8')
+    except AttributeError:
+        # Python 3, all strings are already unicode.        
+        mode = netCDF4.chartostring(sweep_mode['data'][0])[()]
+
 
     # options specified in the CF/Radial standard
     if mode == 'rhi':


### PR DESCRIPTION
This is a fix for a problem I had after an update (netcdf4 1.2.8 np112py36_0).

`type(netCDF4.chartostring(sweep_mode['data'][0])[()])` is `numpy._str` and there is no `decode` attribute in numpy._str

Because all strings are already in unicode in python we can drop the `decode('utf-8')`.