### PR TITLE
ADD: Velocity texture calculation into pyart.filters

### DIFF
--- a/pyart/filters/__init__.py
+++ b/pyart/filters/__init__.py
@@ -21,5 +21,6 @@ Filtering radar data
 
 from .gatefilter import GateFilter, moment_based_gate_filter
 from .gatefilter import moment_and_texture_based_gate_filter
+from .gatefilter import calculate_velocity_texture
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -22,10 +22,11 @@ corrections routines in Py-ART.
 from copy import deepcopy
 
 import numpy as np
+from scipy import ndimage
 
 from ..config import get_field_name, get_metadata
 from ..util import texture_along_ray
-
+from ..util import angular_texture_2d
 
 def moment_based_gate_filter(
         radar, ncp_field=None, rhv_field=None, refl_field=None,
@@ -248,6 +249,72 @@ def moment_and_texture_based_gate_filter(
         gatefilter.exclude_invalid(textrefl_field)
     return gatefilter
 
+def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
+                               check_nyq_uniform=True):
+    """
+    Derive the texture of the velocity field 
+
+    Parameters
+    ----------
+    radar: Radar
+        Radar object from which velocity texture field will be made.
+    vel_field_name : str
+        Name of the velocity field. A value of None will force Py-ART to
+        automatically determine the name of the velocity field.
+    wind_size : int
+        The size of the window to calculate texture from. The window is 
+        defined to be a square of size wind_size by wind_size. 
+    nyq : float
+        The nyquist velocity of the radar. A value of None will force Py-ART
+        to try and determine this automatically
+    check_nyquist_uniform : bool, optional
+        True to check if the Nyquist velocities are uniform for all rays 
+        within a sweep, False will skip this check. This parameter is ignored
+        when the nyq parameter is not None.
+ 
+    Returns
+    -------
+    vel_dict: dict
+        A dictionary containing the field entries for the radial velocity
+        texture
+ 
+    """
+    
+    # Parse names of velocity field
+    if vel_field is None:
+        vel_field = get_field_name('velocity')
+     
+    # Allocate memory for texture field   
+    vel_texture = np.zeros(radar.fields[vel_field]['data'].shape)
+
+    """ 
+    If an array of nyquist velocities is derived, use different
+    nyquist velocites for each sweep in texture calculation according to
+    the nyquist velocity in each sweep
+    """
+    
+    if(nyq is None):
+        # Find nyquist velocity if not specified
+        nyq = [radar.get_nyquist_vel(i, check_nyq_uniform) for i in
+               range(radar.nsweeps)]
+        for i in range(0,radar.nsweeps):
+            start_ray, end_ray = radar.get_start_end(i)
+            inds = range(start_ray,end_ray)
+            vel_sweep = radar.fields[vel_field]['data'][inds]
+            vel_texture[inds] = angular_texture_2d(vel_sweep,
+                                                   wind_size,
+                                                   nyq[i])
+    else:
+        vel_texture = angular_texture_2d(radar.fields[vel_field]['data'],
+                                         wind_size, 
+                                         nyq)
+    vel_texture_field = get_metadata('velocity')
+    vel_texture_field['long_name'] = 'Doppler velocity texture'
+    vel_texture_field['standard_name'] = 'texture_of_radial_velocity_of_scatters_away_from_instrument'
+    vel_texture_field['data'] = ndimage.filters.median_filter(vel_texture,
+                                                              size=(wind_size,
+                                                                    wind_size))
+    return vel_texture_field
 
 class GateFilter(object):
     """

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -28,6 +28,7 @@ from ..config import get_field_name, get_metadata
 from ..util import texture_along_ray
 from ..util import angular_texture_2d
 
+
 def moment_based_gate_filter(
         radar, ncp_field=None, rhv_field=None, refl_field=None,
         min_ncp=0.5, min_rhv=None, min_refl=-20., max_refl=100.0):
@@ -249,10 +250,11 @@ def moment_and_texture_based_gate_filter(
         gatefilter.exclude_invalid(textrefl_field)
     return gatefilter
 
+
 def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
                                check_nyq_uniform=True):
     """
-    Derive the texture of the velocity field 
+    Derive the texture of the velocity field
 
     Parameters
     ----------
@@ -262,60 +264,61 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
         Name of the velocity field. A value of None will force Py-ART to
         automatically determine the name of the velocity field.
     wind_size : int
-        The size of the window to calculate texture from. The window is 
-        defined to be a square of size wind_size by wind_size. 
+        The size of the window to calculate texture from. The window is
+        defined to be a square of size wind_size by wind_size.
     nyq : float
         The nyquist velocity of the radar. A value of None will force Py-ART
         to try and determine this automatically
     check_nyquist_uniform : bool, optional
-        True to check if the Nyquist velocities are uniform for all rays 
+        True to check if the Nyquist velocities are uniform for all rays
         within a sweep, False will skip this check. This parameter is ignored
         when the nyq parameter is not None.
- 
+
     Returns
     -------
     vel_dict: dict
         A dictionary containing the field entries for the radial velocity
         texture
- 
+
     """
-    
+
     # Parse names of velocity field
     if vel_field is None:
         vel_field = get_field_name('velocity')
-     
-    # Allocate memory for texture field   
+
+    # Allocate memory for texture field
     vel_texture = np.zeros(radar.fields[vel_field]['data'].shape)
 
-    """ 
+    """
     If an array of nyquist velocities is derived, use different
     nyquist velocites for each sweep in texture calculation according to
     the nyquist velocity in each sweep
     """
-    
+
     if(nyq is None):
         # Find nyquist velocity if not specified
         nyq = [radar.get_nyquist_vel(i, check_nyq_uniform) for i in
                range(radar.nsweeps)]
-        for i in range(0,radar.nsweeps):
+        for i in range(0, radar.nsweeps):
             start_ray, end_ray = radar.get_start_end(i)
-            inds = range(start_ray,end_ray)
+            inds = range(start_ray, end_ray)
             vel_sweep = radar.fields[vel_field]['data'][inds]
             vel_texture[inds] = angular_texture_2d(vel_sweep,
                                                    wind_size,
                                                    nyq[i])
     else:
         vel_texture = angular_texture_2d(radar.fields[vel_field]['data'],
-                                         wind_size, 
+                                         wind_size,
                                          nyq)
     vel_texture_field = get_metadata('velocity')
     vel_texture_field['long_name'] = 'Doppler velocity texture'
-    vel_texture_field['standard_name'] = ('texture_of_radial_velocity' + 
+    vel_texture_field['standard_name'] = ('texture_of_radial_velocity' +
                                           '_of_scatters_away_from_instrument')
     vel_texture_field['data'] = ndimage.filters.median_filter(vel_texture,
                                                               size=(wind_size,
                                                                     wind_size))
     return vel_texture_field
+
 
 class GateFilter(object):
     """

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -10,6 +10,7 @@ corrections routines in Py-ART.
 
     moment_based_gate_filter
     moment_and_texture_based_gate_filter
+    calculate_velocity_texture
 
 .. autosummary::
     :toctree: generated/
@@ -289,12 +290,10 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
     # Allocate memory for texture field
     vel_texture = np.zeros(radar.fields[vel_field]['data'].shape)
 
-    
     # If an array of nyquist velocities is derived, use different
     # nyquist velocites for each sweep in texture calculation according to
     # the nyquist velocity in each sweep.
     
-
     if(nyq is None):
         # Find nyquist velocity if not specified
         nyq = [radar.get_nyquist_vel(i, check_nyq_uniform) for i in

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -268,7 +268,7 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
         defined to be a square of size wind_size by wind_size.
     nyq : float
         The nyquist velocity of the radar. A value of None will force Py-ART
-        to try and determine this automatically
+        to try and determine this automatically.
     check_nyquist_uniform : bool, optional
         True to check if the Nyquist velocities are uniform for all rays
         within a sweep, False will skip this check. This parameter is ignored
@@ -278,7 +278,7 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
     -------
     vel_dict: dict
         A dictionary containing the field entries for the radial velocity
-        texture
+        texture.
 
     """
 
@@ -289,11 +289,11 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
     # Allocate memory for texture field
     vel_texture = np.zeros(radar.fields[vel_field]['data'].shape)
 
-    """
-    If an array of nyquist velocities is derived, use different
-    nyquist velocites for each sweep in texture calculation according to
-    the nyquist velocity in each sweep
-    """
+    
+    # If an array of nyquist velocities is derived, use different
+    # nyquist velocites for each sweep in texture calculation according to
+    # the nyquist velocity in each sweep.
+    
 
     if(nyq is None):
         # Find nyquist velocity if not specified
@@ -303,13 +303,11 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
             start_ray, end_ray = radar.get_start_end(i)
             inds = range(start_ray, end_ray)
             vel_sweep = radar.fields[vel_field]['data'][inds]
-            vel_texture[inds] = angular_texture_2d(vel_sweep,
-                                                   wind_size,
-                                                   nyq[i])
+            vel_texture[inds] = angular_texture_2d(
+                vel_sweep, wind_size, nyq[i])
     else:
-        vel_texture = angular_texture_2d(radar.fields[vel_field]['data'],
-                                         wind_size,
-                                         nyq)
+        vel_texture = angular_texture_2d(
+            radar.fields[vel_field]['data'], wind_size, nyq)
     vel_texture_field = get_metadata('velocity')
     vel_texture_field['long_name'] = 'Doppler velocity texture'
     vel_texture_field['standard_name'] = ('texture_of_radial_velocity' +

--- a/pyart/filters/gatefilter.py
+++ b/pyart/filters/gatefilter.py
@@ -310,7 +310,8 @@ def calculate_velocity_texture(radar, vel_field=None, wind_size=4, nyq=None,
                                          nyq)
     vel_texture_field = get_metadata('velocity')
     vel_texture_field['long_name'] = 'Doppler velocity texture'
-    vel_texture_field['standard_name'] = 'texture_of_radial_velocity_of_scatters_away_from_instrument'
+    vel_texture_field['standard_name'] = ('texture_of_radial_velocity' + 
+                                          '_of_scatters_away_from_instrument')
     vel_texture_field['data'] = ndimage.filters.median_filter(vel_texture,
                                                               size=(wind_size,
                                                                     wind_size))

--- a/pyart/filters/tests/test_gatefilter.py
+++ b/pyart/filters/tests/test_gatefilter.py
@@ -23,6 +23,7 @@ radar.add_field('test_field2', {'data': fdata2})
 fdata3 = np.zeros(fdata.shape)
 radar.add_field('zero_field', {'data': fdata3})
 
+
 def test_gatefilter_init():
     gfilter = pyart.correct.GateFilter(radar)
     assert np.all(gfilter.gate_excluded == np.False_)
@@ -400,20 +401,21 @@ def test_gatefilter_include_gates():
     assert gfilter.gate_included[0, 2] is np.False_
     assert gfilter.gate_included[2, 2] is np.True_
 
-def test_gatefilter_calculate_texture():
-    texture_field = pyart.filters.calculate_velocity_texture(radar, 
-                                                             wind_size=2,
-                                                             vel_field='zero_field',
-                                                             nyq=10)
-    assert np.all(texture_field['data'] == 0) 
-    texture_field = pyart.filters.calculate_velocity_texture(radar, 
-                                                             wind_size=3,
-                                                             vel_field='zero_field',
-                                                             nyq=10)
-    assert np.all(texture_field['data'] == 0)  
-    texture_field = pyart.filters.calculate_velocity_texture(radar, 
-                                                             wind_size=4,
-                                                             vel_field='zero_field',
-                                                             nyq=10)
-    assert np.all(texture_field['data'] == 0) 
 
+def test_gatefilter_calculate_texture():
+    vel_field = 'zero_field'
+    texture_field = pyart.filters.calculate_velocity_texture(radar,
+                                                             wind_size=2,
+                                                             vel_field,
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0)
+    texture_field = pyart.filters.calculate_velocity_texture(radar,
+                                                             wind_size=3,
+                                                             vel_field,
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0)
+    texture_field = pyart.filters.calculate_velocity_texture(radar,
+                                                             wind_size=4,
+                                                             vel_field,
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0)

--- a/pyart/filters/tests/test_gatefilter.py
+++ b/pyart/filters/tests/test_gatefilter.py
@@ -404,18 +404,12 @@ def test_gatefilter_include_gates():
 
 def test_gatefilter_calculate_texture():
     vel_field = 'zero_field'
-    texture_field = pyart.filters.calculate_velocity_texture(radar,
-                                                             vel_field,
-                                                             wind_size=2,
-                                                             nyq=10)
+    texture_field = pyart.filters.calculate_velocity_texture(
+        radar, vel_field, wind_size=2, nyq=10)
     assert np.all(texture_field['data'] == 0)
-    texture_field = pyart.filters.calculate_velocity_texture(radar,
-                                                             vel_field,
-                                                             wind_size=3,
-                                                             nyq=10)
+    texture_field = pyart.filters.calculate_velocity_texture(
+        radar, vel_field, wind_size=3, nyq=10)
     assert np.all(texture_field['data'] == 0)
-    texture_field = pyart.filters.calculate_velocity_texture(radar,
-                                                             vel_field,
-                                                             wind_size=4,
-                                                             nyq=10)
+    texture_field = pyart.filters.calculate_velocity_texture(
+        radar, vel_field, wind_size=4, nyq=10)
     assert np.all(texture_field['data'] == 0)

--- a/pyart/filters/tests/test_gatefilter.py
+++ b/pyart/filters/tests/test_gatefilter.py
@@ -405,17 +405,17 @@ def test_gatefilter_include_gates():
 def test_gatefilter_calculate_texture():
     vel_field = 'zero_field'
     texture_field = pyart.filters.calculate_velocity_texture(radar,
+                                                             vel_field,
                                                              wind_size=2,
-                                                             vel_field,
                                                              nyq=10)
     assert np.all(texture_field['data'] == 0)
     texture_field = pyart.filters.calculate_velocity_texture(radar,
+                                                             vel_field,
                                                              wind_size=3,
-                                                             vel_field,
                                                              nyq=10)
     assert np.all(texture_field['data'] == 0)
     texture_field = pyart.filters.calculate_velocity_texture(radar,
-                                                             wind_size=4,
                                                              vel_field,
+                                                             wind_size=4,
                                                              nyq=10)
     assert np.all(texture_field['data'] == 0)

--- a/pyart/filters/tests/test_gatefilter.py
+++ b/pyart/filters/tests/test_gatefilter.py
@@ -19,6 +19,9 @@ fdata2[4, 4] = np.PINF
 fdata2[5, 5] = np.NINF
 radar.add_field('test_field2', {'data': fdata2})
 
+# zero field
+fdata3 = np.zeros(fdata.shape)
+radar.add_field('zero_field', {'data': fdata3})
 
 def test_gatefilter_init():
     gfilter = pyart.correct.GateFilter(radar)
@@ -396,3 +399,21 @@ def test_gatefilter_include_gates():
     assert gfilter.gate_included[2, 0] is np.False_
     assert gfilter.gate_included[0, 2] is np.False_
     assert gfilter.gate_included[2, 2] is np.True_
+
+def test_gatefilter_calculate_texture():
+    texture_field = pyart.filters.calculate_velocity_texture(radar, 
+                                                             wind_size=2,
+                                                             vel_field='zero_field',
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0) 
+    texture_field = pyart.filters.calculate_velocity_texture(radar, 
+                                                             wind_size=3,
+                                                             vel_field='zero_field',
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0)  
+    texture_field = pyart.filters.calculate_velocity_texture(radar, 
+                                                             wind_size=4,
+                                                             vel_field='zero_field',
+                                                             nyq=10)
+    assert np.all(texture_field['data'] == 0) 
+

--- a/pyart/util/__init__.py
+++ b/pyart/util/__init__.py
@@ -50,5 +50,6 @@ from .hildebrand_sekhon import estimate_noise_hs74
 from .radar_utils import is_vpt, to_vpt, join_radar
 from .simulated_vel import simulated_vel_from_profile
 from .sigmath import texture_along_ray
+from .sigmath import angular_texture_2d
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -45,8 +45,8 @@ def angular_texture_2d(image, N, interval):
     
     # Calculate convolution
     kernel = np.ones((N, N))
-    xs = signal.convolve2d(x, kernel, mode="same")
-    ys = signal.convolve2d(y, kernel, mode="same")
+    xs = signal.convolve2d(x, kernel, mode="same", boundary="symm")
+    ys = signal.convolve2d(y, kernel, mode="same", boundary="symm")
     ns = N**2
     
     # Calculate norm over specified window

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -30,6 +30,7 @@ def angular_texture_2d(image, N, interval):
         radial coordinates, pi will be defined to be interval
         and -pi will be -interval. It is recommended that interval be
         set to the Nyquist velocity.
+
     """
 
     # transform distribution from original interval to [-pi, pi]

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -22,14 +22,19 @@ def angular_texture_2d(image, N, interval):
     image : 2D array of floats
         The array containing the velocities in which to calculate
         texture from.
-    N : window size for calculating texture
-        The texture will be calculated from an N by N window centered
-        around the gate.
-    interval :
+    N : int
+        This is the window size for calculating texture. The texture will be 
+        calculated from an N by N window centered around the gate.
+    interval : float
         The absolute value of the maximum velocity. In conversion to
         radial coordinates, pi will be defined to be interval
         and -pi will be -interval. It is recommended that interval be
         set to the Nyquist velocity.
+
+    Returns
+    -------
+    std_dev : float array
+        Texture of the radial velocity field.
 
     """
 
@@ -40,8 +45,7 @@ def angular_texture_2d(image, N, interval):
     center = interval_min + half_width
 
     # Calculate parameters needed for angular std. dev
-    a = (np.asarray(image) - center) / (half_width) * np.pi
-    im = a
+    im = (np.asarray(image) - center) / (half_width) * np.pi
     x = np.cos(im)
     y = np.sin(im)
 

--- a/pyart/util/sigmath.py
+++ b/pyart/util/sigmath.py
@@ -10,22 +10,23 @@ from __future__ import print_function
 from scipy import signal
 import numpy as np
 
+
 def angular_texture_2d(image, N, interval):
     """
     Compute the angular texture of an image. Uses convolutions
     in order to speed up texture calculation by a factor of ~50
     compared to using ndimage.generic_filter
-     
+
     Parameters
     ----------
-    image : 2D array of floats 
+    image : 2D array of floats
         The array containing the velocities in which to calculate
         texture from.
     N : window size for calculating texture
         The texture will be calculated from an N by N window centered
         around the gate.
     interval :
-        The absolute value of the maximum velocity. In conversion to 
+        The absolute value of the maximum velocity. In conversion to
         radial coordinates, pi will be defined to be interval
         and -pi will be -interval. It is recommended that interval be
         set to the Nyquist velocity.
@@ -36,25 +37,26 @@ def angular_texture_2d(image, N, interval):
     interval_min = -interval
     half_width = (interval_max - interval_min) / 2.
     center = interval_min + half_width
-    
+
     # Calculate parameters needed for angular std. dev
     a = (np.asarray(image) - center) / (half_width) * np.pi
     im = a
     x = np.cos(im)
     y = np.sin(im)
-    
+
     # Calculate convolution
     kernel = np.ones((N, N))
     xs = signal.convolve2d(x, kernel, mode="same", boundary="symm")
     ys = signal.convolve2d(y, kernel, mode="same", boundary="symm")
     ns = N**2
-    
+
     # Calculate norm over specified window
     xmean = xs/ns
     ymean = ys/ns
     norm = np.sqrt(xmean**2 + ymean**2)
     std_dev = np.sqrt(-2 * np.log(norm)) * (half_width) / np.pi
     return std_dev
+
 
 def rolling_window(a, window):
     """ create a rolling window object for application of functions
@@ -108,6 +110,3 @@ def texture_along_ray(myradar, var, wind_size=7):
         tex[timestep, 0:half_wind] = np.ones(half_wind) * ray[0]
         tex[timestep, -half_wind:] = np.ones(half_wind) * ray[-1]
     return tex
-
-
-


### PR DESCRIPTION
I have added a much faster velocity texture calculation and placed it into a subroutine into pyart.filters that returns a velocity texture field dictionary.