### PR TITLE
Remove jhelmus contact info from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<meta name="description" content="Your description goes here" />
 	<meta name="keywords" content="your,keywords,goes,here" />
-	<meta name="author" content="Jonathan J. Helmus" />
 	<link rel="stylesheet" type="text/css" href="1024px.css" title="1024px" media="screen,projection" />
 	<title>Py-ART - The Python ARM Radar Toolkit.</title>
 </head>
@@ -136,8 +135,7 @@
 		<h2>Getting help</h2>
 		<p>
         Py-ART has a <a href="http://groups.google.com/group/pyart-users/">mailing list</a> where 
-        you can ask questions and request help.  Also feel free to email the lead developer of the 
-        pproject, <a href="mailto:jhelmus@anl.gov.com">Jonathan J. Helmus,</a> directly with questions or comments.
+        you can ask questions and request help.
 		</p>
 
 		<h2>Contributing</h2>
@@ -148,8 +146,8 @@
 		<a href="https://github.com/ARM-DOE/pyart">GitHub</a>.  
 		Feature requests and bug reports can be sumbitted to the 
 		<a href="https://github.com/ARM-DOE/pyart/issues">Issue tracker,</a> posting
-		to the <a href="http://groups.google.com/group/pyart-users/">pyart-users mailing list</a>
-        or contacting Jonathan Helmus directly.	 Contributions of source code, documentation
+		to the <a href="http://groups.google.com/group/pyart-users/">pyart-users mailing list.</a>
+        Contributions of source code, documentation
         or additional example are always appreciated from both developers and users.  Developers
         looking for more detailed information on the inner workings of Py-ART should examine the 
 		<a href="http://arm-doe.github.io/pyart-docs-travis/dev_reference/index.html">developer reference manual.</a>
@@ -181,7 +179,6 @@
         <h2>People</h2>
         <ul>
             <li>Science lead: <a href="http://www.anl.gov/contributors/scott-collis">Scott Collis</a></li>
-            <li>Developement lead: <a href="http://www.evs.anl.gov/about-evs/staff/detail/index.cfm?/Helmus/Jonathan">Jonathan Helmus</a></li>
         </ul>
 	</div>
 


### PR DESCRIPTION
Remove link to Jonathan Helmus' contact information and suggestions to contact
him directly from the Py-ART landing page.