### PR TITLE
DOC: Noticed link to wradlib was to the old bit bucket page, no longer exists.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ These include:
 
 Other related open source software for working with weather radar data:
 
-* `wradlib <http://wradlib.bitbucket.org/>`_ : 
+* `wradlib <http://wradlib.org/wradlib-docs/latest/>`_ : 
   An open source library for weather radar data processing.
   
 * `BALTRAD <http://baltrad.eu/>`_ : Community-based weather radar networking.


### PR DESCRIPTION
Link in README was outdated and the link has been updated to wradlib's docs latest page.