### PR TITLE
Fixing infinite loop in 4DD algorithm

### DIFF
--- a/pyart/correct/src/dealias_fourdd.c
+++ b/pyart/correct/src/dealias_fourdd.c
@@ -332,7 +332,7 @@ static void continuity_dealias(
             float azold = sweepc->rv->ray[ray_index]->h.azimuth;
             float diffaz_newold = fabs(aznew-azold);
             if(diffaz_newold > 180.0)
-                diffaz_newold = 360.0-diffaz_newold
+                diffaz_newold = 360.0-diffaz_newold;
             if(fabs(aznew-azold)>spacing/2){
                 valid_above_ray = 1;
             }

--- a/pyart/correct/src/dealias_fourdd.c
+++ b/pyart/correct/src/dealias_fourdd.c
@@ -270,79 +270,27 @@ static void init_sweep(Sweep *sweep, float val)
 static int findRay(Sweep *sweep1, Sweep *sweep2, int ray_index) 
 {
     int numRays, rayIndex1;
-    float az0, az1, diffaz;
-    float spacing;
-    short direction, lastdir;
+    int minraynum; 
+    float az0, az1, diffaz, currmaxdiffaz;
+    currmaxdiffaz=99999999;
     
     numRays = sweep2->h.nrays;
-
-    if (ray_index < numRays) 
-        rayIndex1=ray_index;
-    else 
-        rayIndex1=numRays-1;
-    
     az0 = sweep1->ray[ray_index]->h.azimuth;
-    az1 = sweep2->ray[rayIndex1]->h.azimuth;
-    if (az0 == az1) {
-        return rayIndex1;
-    } else {
-        
-        /* Since the beamwidth is not necessarily the spacing between rays: */
-        spacing = fabs(sweep2->ray[0]->h.azimuth - sweep2->ray[50]->h.azimuth);
-        if (spacing>180)
-            spacing = 360.0 - spacing;
-        spacing = spacing / 50.0;
 
-        /* Compute the difference in azimuth between the two rays: */
-        diffaz=az0-az1;
-        if (diffaz>=180.0) 
-            diffaz=diffaz-360.0;
-        else if (diffaz<-180.0) 
-            diffaz=diffaz+360.0;
-       
-        /* Get close to the correct index: */
-        rayIndex1=rayIndex1+(int) (diffaz/spacing);
-        if (rayIndex1>=numRays) 
-            rayIndex1=rayIndex1-numRays;
-        if (rayIndex1<0) 
-            rayIndex1=numRays+rayIndex1;
-        az1=sweep2->ray[rayIndex1]->h.azimuth;
-        diffaz=az0-az1;
-        if (diffaz>=180.0)
-            diffaz=diffaz-360.0;
-        else if 
-            (diffaz<-180.0) diffaz=diffaz+360.0;
+    for(int i=0; i<numRays; i++){
+        az1 = sweep2->ray[i]->h.azimuth;
+        diffaz = fabs(az1-az0);
+        if(diffaz>180.0){
+            diffaz = 360 - diffaz;
+        }
+        if(diffaz<currmaxdiffaz){
+            currmaxdiffaz = diffaz;
+            minraynum = i;
+        }
 
-        /* Now add or subtract indices until the nearest ray is found: */
-        if (diffaz>=0) 
-            lastdir=1;
-        else 
-            lastdir=-1;
-        while (fabs(diffaz)>spacing/2.0) {
-	        if (diffaz>=0) {
-	            rayIndex1++;
-	            direction=1;
-	        } else {
-	            rayIndex1--;
-	            direction=-1;
-	        }
-	        if (rayIndex1>=numRays) 
-                rayIndex1=rayIndex1-numRays;
-	        if (rayIndex1<0) 
-                rayIndex1=numRays+rayIndex1;
-	        az1=sweep2->ray[rayIndex1]->h.azimuth;
-	        diffaz=az0-az1;
-	        if (diffaz>=180.0) 
-                diffaz=diffaz-360.0;
-	        else if 
-                (diffaz<-180.0) diffaz=diffaz+360.0;
-	        if (direction!=lastdir) 
-                break;
-	        else 
-                lastdir=direction;
-       }
-       return rayIndex1;
-     }
+
+    }    
+    return minraynum;
 }
 
 
@@ -360,18 +308,38 @@ static void continuity_dealias(
     int i, prevIndex = 0, abIndex = 0; 
     float val;
     float prevval, soundval, abval, diff, thresh;
+    float spacing;
+    short valid_above_ray;
+    valid_above_ray = 1;
 
     thresh = dp->compthresh * sweepc->NyqVelocity;
 
     for (ray_index=0; ray_index < sweepc->nrays; ray_index++) { 
         
-        if (sweepc->last != NULL)
+        if (sweepc->last != NULL){
            prevIndex = findRay(sweepc->rv, sweepc->last, ray_index);
-        if (sweepc->above != NULL)
+        }
+
+        if (sweepc->above != NULL){
+            valid_above_ray = 0;
+            spacing = fabs(sweepc->rv->ray[0]->h.azimuth - sweepc->rv->ray[50]->h.azimuth);
+            if (spacing>180.0)
+                spacing = 360.0 - spacing;
+            spacing = spacing / 50.0;
+
             abIndex = findRay(sweepc->rv, sweepc->above, ray_index);
-        
+            float aznew = sweepc->above->ray[abIndex]->h.azimuth;
+            float azold = sweepc->rv->ray[ray_index]->h.azimuth;
+            float diffaz_newold = fabs(aznew-azold);
+            if(diffaz_newold > 180.0)
+                diffaz_newold = 360.0-diffaz_newold
+            if(fabs(aznew-azold)>spacing/2){
+                valid_above_ray = 1;
+            }
+        }
         for (i=0; i < sweepc->nbins; i++) { 
-           
+
+
             if (get_mark(marks, ray_index, i) != 0) continue;
             val = ray_val(sweepc->vals->ray[ray_index], i);
             if (is_missing(val, dp)) continue;
@@ -383,7 +351,7 @@ static void continuity_dealias(
                 prevval=ray_val(sweepc->last->ray[prevIndex], i);
             if (sweepc->sound != NULL && sweepc->last == NULL)
                 soundval=ray_val(sweepc->sound->ray[ray_index], i);
-            if (sweepc->above != NULL)
+            if (sweepc->above != NULL && valid_above_ray==0)
                 abval=ray_val(sweepc->above->ray[abIndex], i);
             
             if (sweepc->last == NULL) {
@@ -410,6 +378,7 @@ static void continuity_dealias(
         }
     }
 }
+
 
 /* Mark gates where all neighbors are marked with a 0 as -1 */
 static void mark_neighborless(

--- a/pyart/correct/src/dealias_fourdd.c
+++ b/pyart/correct/src/dealias_fourdd.c
@@ -323,10 +323,12 @@ static void continuity_dealias(
 
         if (sweepc->above != NULL){
             valid_above_ray = 0;
-            spacing = fabs(sweepc->rv->ray[0]->h.azimuth - sweepc->rv->ray[50]->h.azimuth);
+            //Checking to make sure that the above ray is actually *above*.
+            //This takes an average of the azimuthal spacing over the first four rays
+            spacing = fabs(sweepc->above->ray[0]->h.azimuth - sweepc->above->ray[4]->h.azimuth);
             if (spacing>180.0)
                 spacing = 360.0 - spacing;
-            spacing = spacing / 50.0;
+            spacing = spacing / 4.0;
 
             abIndex = findRay(sweepc->rv, sweepc->above, ray_index);
             float aznew = sweepc->above->ray[abIndex]->h.azimuth;

--- a/pyart/correct/src/dealias_fourdd.c
+++ b/pyart/correct/src/dealias_fourdd.c
@@ -271,13 +271,14 @@ static int findRay(Sweep *sweep1, Sweep *sweep2, int ray_index)
 {
     int numRays, rayIndex1;
     int minraynum; 
+    int i;
     float az0, az1, diffaz, currmaxdiffaz;
     currmaxdiffaz=99999999;
     
     numRays = sweep2->h.nrays;
     az0 = sweep1->ray[ray_index]->h.azimuth;
 
-    for(int i=0; i<numRays; i++){
+    for(i=0; i<numRays; i++){
         az1 = sweep2->ray[i]->h.azimuth;
         diffaz = fabs(az1-az0);
         if(diffaz>180.0){


### PR DESCRIPTION
This PR is to address #690 (pinging @pjmarinescu ). I replaced the findRay function with a completely new and simplified function. I then check in the continuity_dealias function to make sure that the spacing is reasonable. This seems to fix the error, although I would definitely appreciate a second look. 

On our first look at the data, it looks like for the specific file that we're working with, it looks mostly okay, with some small oddities that could also be related to needing to QC the original data. 

As an aside, I don't think that my spacing variable makes a lot of sense- it's identical to the one in the original code, but the indices (0 and 50) seem arbitrary or specific to some radar. I'm not quite sure what that's doing, so I'm open to changes. For reference, the spacing is defined as: `spacing = fabs(sweep2->ray[0]->h.azimuth - sweep2->ray[50]->h.azimuth);`. 

Hopefully this works to resolve this issue- I'm open to any feedback on this, it's been quite a spin up to try to debug this code. 