### PR TITLE
fix of circular reference in Radar and Grid Class

### DIFF
--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -253,7 +253,6 @@ class Grid(object):
         self.point_latitude = get_metadata('point_latitude')
         self.point_latitude['data'] = geographic_coords[1]
 
-
     def init_point_altitude(self):
         """ Initialize the point_altitude attribute. """
         self.point_altitude = get_metadata('point_altitude')

--- a/pyart/core/radar.py
+++ b/pyart/core/radar.py
@@ -283,13 +283,12 @@ class Radar(object):
         """
         Initialize or reset the gate_longitude and gate_latitude attributes.
         """
-        x = self.gate_x['data']
-        y = self.gate_y['data']
         projparams = self.projection.copy()
         if projparams.pop('_include_lon_0_lat_0', False):
             projparams['lon_0'] = self.longitude['data'][0]
             projparams['lat_0'] = self.latitude['data'][0]
-        geographic_coords = cartesian_to_geographic(x, y, projparams)
+        geographic_coords = cartesian_to_geographic(
+            self.gate_x['data'], self.gate_y['data'], projparams)
 
         self.gate_longitude = get_metadata('gate_longitude')
         self.gate_longitude['data'] = geographic_coords[0]
@@ -301,7 +300,6 @@ class Radar(object):
         """ Initialize the gate_altitude attribute. """
         self.gate_altitude = get_metadata('gate_altitude')
         self.gate_altitude['data'] = self.altitude['data'] + self.gate_z['data']
-
 
     # private functions for checking limits, etc.
     def _check_sweep_in_range(self, sweep):

--- a/pyart/core/radar.py
+++ b/pyart/core/radar.py
@@ -7,11 +7,6 @@ A general central radial scanning (or dwelling) instrument class.
 .. autosummary::
     :toctree: generated/
 
-    _rays_per_sweep_data_factory
-    _gate_data_factory
-    _gate_lon_lat_data_factory
-    _gate_altitude_data_factory
-
 .. autosummary::
     :toctree: generated/
     :template: dev_template.rst
@@ -22,14 +17,11 @@ A general central radial scanning (or dwelling) instrument class.
 """
 from __future__ import print_function
 
-import copy
 import sys
 
 import numpy as np
-from netCDF4 import num2date, date2num
 
 from ..config import get_metadata
-from ..lazydict import LazyLoadDict
 from .transforms import antenna_vectors_to_cartesian, cartesian_to_geographic
 
 
@@ -85,7 +77,7 @@ class Radar(object):
     sweep_end_ray_index : dict
         Index of the last ray in each sweep relative to the start of the
         volume, 0-based.
-    rays_per_sweep : LazyLoadDict
+    rays_per_sweep : dict
         Number of rays in each sweep.  The data key of this attribute is
         create upon first access from the data in the sweep_start_ray_index and
         sweep_end_ray_index attributes.  If the sweep locations needs to be
@@ -106,13 +98,13 @@ class Radar(object):
         Azimuth of antenna, relative to true North.
     elevation : dict
         Elevation of antenna, relative to the horizontal plane.
-    gate_x, gate_y, gate_z : LazyLoadDict
+    gate_x, gate_y, gate_z : dict
         Location of each gate in a Cartesian coordinate system assuming a
         standard atmosphere with a 4/3 Earth's radius model. The data keys of
         these attributes are create upon first access from the data in the
         range, azimuth and elevation attributes. If these attributes are
         changed use :py:func:`init_gate_x_y_z` to reset.
-    gate_longitude, gate_latitude : LazyLoadDict
+    gate_longitude, gate_latitude : dict
         Geographic location of each gate.  The projection parameter(s) defined
         in the `projection` attribute are used to perform an inverse map
         projection from the Cartesian gate locations relative to the radar
@@ -128,7 +120,7 @@ class Radar(object):
         this dictionary. If this key is present and set to True, which is
         required when proj='pyart_aeqd', then the radar longitude and
         latitude will be added to the dictionary as 'lon_0' and 'lat_0'.
-    gate_altitude : LazyLoadDict
+    gate_altitude : dict
         The altitude of each radar gate as calculated from the altitude of the
         radar and the Cartesian z location of each gate.  If this attribute
         is changed use :py:func:`init_gate_altitude` to reset the attribute.
@@ -238,7 +230,7 @@ class Radar(object):
         self.nsweeps = len(sweep_number['data'])
         self.projection = {'proj': 'pyart_aeqd', '_include_lon_0_lat_0': True}
 
-        # initalize attributes with lazy load dictionaries
+        # initalize attributes
         self.init_rays_per_sweep()
         self.init_gate_x_y_z()
         self.init_gate_longitude_latitude()
@@ -268,41 +260,48 @@ class Radar(object):
     # Attribute init/reset method
     def init_rays_per_sweep(self):
         """ Initialize or reset the rays_per_sweep attribute. """
-        lazydic = LazyLoadDict(get_metadata('rays_per_sweep'))
-        lazydic.set_lazy('data', _rays_per_sweep_data_factory(self))
-        self.rays_per_sweep = lazydic
+        self.rays_per_sweep = get_metadata('rays_per_sweep')
+        self.rays_per_sweep['data'] = self.sweep_end_ray_index['data'] - \
+            self.sweep_start_ray_index['data'] + 1
 
     def init_gate_x_y_z(self):
         """ Initialize or reset the gate_{x, y, z} attributes. """
-        gate_x = LazyLoadDict(get_metadata('gate_x'))
-        gate_x.set_lazy('data', _gate_data_factory(self, 0))
-        self.gate_x = gate_x
+        cartesian_coords = antenna_vectors_to_cartesian(
+            self.range['data'], self.azimuth['data'], self.elevation['data'],
+            edges=False)
 
-        gate_y = LazyLoadDict(get_metadata('gate_y'))
-        gate_y.set_lazy('data', _gate_data_factory(self, 1))
-        self.gate_y = gate_y
+        self.gate_x = get_metadata('gate_x')
+        self.gate_x['data'] = cartesian_coords[0]
 
-        gate_z = LazyLoadDict(get_metadata('gate_z'))
-        gate_z.set_lazy('data', _gate_data_factory(self, 2))
-        self.gate_z = gate_z
+        self.gate_y = get_metadata('gate_y')
+        self.gate_y['data'] = cartesian_coords[1]
+
+        self.gate_z = get_metadata('gate_z')
+        self.gate_z['data'] = cartesian_coords[2]
 
     def init_gate_longitude_latitude(self):
         """
         Initialize or reset the gate_longitude and gate_latitude attributes.
         """
-        gate_longitude = LazyLoadDict(get_metadata('gate_longitude'))
-        gate_longitude.set_lazy('data', _gate_lon_lat_data_factory(self, 0))
-        self.gate_longitude = gate_longitude
+        x = self.gate_x['data']
+        y = self.gate_y['data']
+        projparams = self.projection.copy()
+        if projparams.pop('_include_lon_0_lat_0', False):
+            projparams['lon_0'] = self.longitude['data'][0]
+            projparams['lat_0'] = self.latitude['data'][0]
+        geographic_coords = cartesian_to_geographic(x, y, projparams)
 
-        gate_latitude = LazyLoadDict(get_metadata('gate_latitude'))
-        gate_latitude.set_lazy('data', _gate_lon_lat_data_factory(self, 1))
-        self.gate_latitude = gate_latitude
+        self.gate_longitude = get_metadata('gate_longitude')
+        self.gate_longitude['data'] = geographic_coords[0]
+
+        self.gate_latitude = get_metadata('gate_latitude')
+        self.gate_latitude['data'] = geographic_coords[1]
 
     def init_gate_altitude(self):
         """ Initialize the gate_altitude attribute. """
-        gate_altitude = LazyLoadDict(get_metadata('gate_altitude'))
-        gate_altitude.set_lazy('data', _gate_altitude_data_factory(self))
-        self.gate_altitude = gate_altitude
+        self.gate_altitude = get_metadata('gate_altitude')
+        self.gate_altitude['data'] = self.altitude['data'] + self.gate_z['data']
+
 
     # private functions for checking limits, etc.
     def _check_sweep_in_range(self, sweep):
@@ -880,58 +879,3 @@ class Radar(object):
                      radar_calibration=radar_calibration)
 
 
-def _rays_per_sweep_data_factory(radar):
-    """ Return a function which returns the number of rays per sweep. """
-    def _rays_per_sweep_data():
-        """ The function which returns the number of rays per sweep. """
-        return (radar.sweep_end_ray_index['data'] -
-                radar.sweep_start_ray_index['data'] + 1)
-    return _rays_per_sweep_data
-
-
-def _gate_data_factory(radar, coordinate):
-    """ Return a function which returns the Cartesian locations of gates. """
-    def _gate_data():
-        """ The function which returns the Cartesian locations of gates. """
-        ranges = radar.range['data']
-        azimuths = radar.azimuth['data']
-        elevations = radar.elevation['data']
-        cartesian_coords = antenna_vectors_to_cartesian(
-            ranges, azimuths, elevations, edges=False)
-        # load x, y, and z data except for the coordinate in question
-        if coordinate != 0:
-            radar.gate_x['data'] = cartesian_coords[0]
-        if coordinate != 1:
-            radar.gate_y['data'] = cartesian_coords[1]
-        if coordinate != 2:
-            radar.gate_z['data'] = cartesian_coords[2]
-        return cartesian_coords[coordinate]
-    return _gate_data
-
-
-def _gate_lon_lat_data_factory(radar, coordinate):
-    """ Return a function which returns the geographic locations of gates. """
-    def _gate_lon_lat_data():
-        """ The function which returns the geographic locations gates. """
-        x = radar.gate_x['data']
-        y = radar.gate_y['data']
-        projparams = radar.projection.copy()
-        if projparams.pop('_include_lon_0_lat_0', False):
-            projparams['lon_0'] = radar.longitude['data'][0]
-            projparams['lat_0'] = radar.latitude['data'][0]
-        geographic_coords = cartesian_to_geographic(x, y, projparams)
-        # set the other geographic coordinate
-        if coordinate == 0:
-            radar.gate_latitude['data'] = geographic_coords[1]
-        else:
-            radar.gate_longitude['data'] = geographic_coords[0]
-        return geographic_coords[coordinate]
-    return _gate_lon_lat_data
-
-
-def _gate_altitude_data_factory(radar):
-    """ Return a function which returns the gate altitudes. """
-    def _gate_altitude_data():
-        """ The function which returns the gate altitudes. """
-        return radar.altitude['data'] + radar.gate_z['data']
-    return _gate_altitude_data

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -17,7 +17,6 @@ except ImportError:
     _PYPROJ_AVAILABLE = False
 
 import pyart
-from pyart.lazydict import LazyLoadDict
 
 
 def test_grid_picklable():
@@ -124,37 +123,37 @@ def test_grid_class():
     assert isinstance(grid.z, dict)
     assert grid.z['data'].shape == (nz, )
 
-    assert isinstance(grid.point_x, LazyLoadDict)
+    assert isinstance(grid.point_x, dict)
     assert grid.point_x['data'].shape == (nz, ny, nx)
     assert_almost_equal(
         grid.point_x['data'][0, 0, :], grid.x['data'][:])
     assert_almost_equal(
         grid.point_x['data'][1, 1, :], grid.x['data'][:])
 
-    assert isinstance(grid.point_y, LazyLoadDict)
+    assert isinstance(grid.point_y, dict)
     assert grid.point_y['data'].shape == (nz, ny, nx)
     assert_almost_equal(
         grid.point_y['data'][0, :, 0], grid.y['data'][:])
     assert_almost_equal(
         grid.point_y['data'][1, :, 1], grid.y['data'][:])
 
-    assert isinstance(grid.point_z, LazyLoadDict)
+    assert isinstance(grid.point_z, dict)
     assert grid.point_z['data'].shape == (nz, ny, nx)
     assert_almost_equal(
         grid.point_z['data'][:, 0, 0], grid.z['data'][:])
     assert_almost_equal(
         grid.point_z['data'][:, 1, 1], grid.z['data'][:])
 
-    assert isinstance(grid.point_longitude, LazyLoadDict)
+    assert isinstance(grid.point_longitude, dict)
     assert grid.point_longitude['data'].shape == (nz, ny, nx)
     assert_almost_equal(grid.point_longitude['data'][0, 0, 159], -98.1, 1)
 
     grid.init_point_longitude_latitude()
-    assert isinstance(grid.point_latitude, LazyLoadDict)
+    assert isinstance(grid.point_latitude, dict)
     assert grid.point_latitude['data'].shape == (nz, ny, nx)
     assert_almost_equal(grid.point_latitude['data'][0, 200, 0], 36.7, 1)
 
-    assert isinstance(grid.point_altitude, LazyLoadDict)
+    assert isinstance(grid.point_altitude, dict)
     assert grid.point_altitude['data'].shape == (nz, ny, nx)
     assert_almost_equal(grid.point_altitude['data'][0, 0, 0], 300, 0)
     assert_almost_equal(grid.point_altitude['data'][1, 0, 0], 800, 0)
@@ -280,7 +279,7 @@ def test_projection_proj_raised():
 
 def test_init_point_x_y_z():
     grid = pyart.testing.make_target_grid()
-    assert isinstance(grid.point_x, LazyLoadDict)
+    assert isinstance(grid.point_x, dict)
     assert grid.point_x['data'].shape == (2, 400, 320)
     assert grid.point_x['data'][0, 0, 0] == grid.x['data'][0]
 

--- a/pyart/core/tests/test_radar.py
+++ b/pyart/core/tests/test_radar.py
@@ -12,7 +12,6 @@ import inspect
 import numpy as np
 from numpy.testing import assert_raises, assert_allclose, assert_almost_equal
 import pyart
-from pyart.lazydict import LazyLoadDict
 
 
 def test_radar_picklable():
@@ -204,7 +203,7 @@ def test_init_gate_x_y_z():
 def test_rays_per_sweep_attribute():
     radar = pyart.testing.make_target_radar()
     rays_per_sweep = radar.rays_per_sweep
-    assert isinstance(rays_per_sweep, LazyLoadDict)
+    assert isinstance(rays_per_sweep, dict)
     assert rays_per_sweep['data'].shape == (1, )
     assert rays_per_sweep['data'][0] == 360
 


### PR DESCRIPTION
fix of #696 

"The LazyLoadDict used in the Radar class causes a circular reference, which will make the memory used by the class never collected by the automatic gc system (known as the memory leakage)."

The LazyLoadDict is removed and the relevant parts are refactored in the Radar and Grid Class in this PR. The other codes using LazyLoadDict (e.g. the mdv class) are not changed.