### PR TITLE
DEP: Changed fromstring to frombuffer to removed depreciation.

### DIFF
--- a/pyart/io/_sigmet_noaa_hh.py
+++ b/pyart/io/_sigmet_noaa_hh.py
@@ -53,7 +53,7 @@ def _decode_noaa_hh_hdr(
         'tilt' and 'georefs_applied' dictionaries.
 
     """
-    xhdr = np.rec.fromstring(raw_extended_headers[..., :68].tostring(),
+    xhdr = np.rec.frombuffer(raw_extended_headers[..., :68].tostring(),
                              dtype=list(NOAA_HH_EXTENDED_HEADER))
 
     # rotation and tilt from azimuth/elevation angles

--- a/pyart/io/_sigmetfile.pyx
+++ b/pyart/io/_sigmetfile.pyx
@@ -290,7 +290,7 @@ cdef class SigmetFile:
         nbins = self.product_hdr['product_end']['number_bins']
 
         # prepare to read rays
-        self._rbuf = np.fromstring(lead_record, dtype='int16')
+        self._rbuf = np.frombuffer(lead_record, dtype='int16')
         self._rbuf_p = <np.int16_t*>self._rbuf.data
         self._rbuf_pos = int((12 + 76 * self.ndata_types) / 2) - 1
         # set data initially to ones so that missing data can be better
@@ -413,7 +413,7 @@ cdef class SigmetFile:
         if self.debug:
             print("Finished loading record:", self._record_number)
         self._raw_product_bhdrs[-1].append(_unpack_raw_prod_bhdr(record))
-        self._rbuf = np.fromstring(record, dtype='int16')
+        self._rbuf = np.frombuffer(record, dtype='int16')
         self._rbuf_pos = 6
         self._rbuf_p = <np.int16_t*>self._rbuf.data
         return 0

--- a/pyart/io/chl.py
+++ b/pyart/io/chl.py
@@ -382,7 +382,7 @@ class ChlFile(object):
 
     def _extract_fields(self):
         """ Extract field data from _dstring attribute post read. """
-        all_data = np.fromstring(self._dstring, dtype=self._dtype)
+        all_data = np.frombuffer(self._dstring, dtype=self._dtype)
         all_data = all_data.reshape(-1, self.ngates)
         for i, field_num in enumerate(self._field_nums):
 

--- a/pyart/io/mdv_common.py
+++ b/pyart/io/mdv_common.py
@@ -604,7 +604,7 @@ class MdvFile(object):
                 raise NotImplementedError('unknown compression mode')
 
             # read the decompressed data, reshape and mask
-            sw_data = np.fromstring(decompr_data, np_form).astype('float32')
+            sw_data = np.frombuffer(decompr_data, np_form).astype('float32')
             sw_data.shape = (ny, nx)
             mask = sw_data == field_header['bad_data_value']
             np.putmask(sw_data, mask, [np.NaN])
@@ -1153,7 +1153,7 @@ def _decode_rle8(compr_data, key, decompr_size):
     # Encoding is described in section 7 of:
     # http://rap.ucar.edu/projects/IHL/RalHtml/protocols/mdv_file/
     # This function would benefit greate by being rewritten in Cython
-    data = np.fromstring(compr_data, dtype='>B')
+    data = np.frombuffer(compr_data, dtype='>B')
     out = np.empty((decompr_size, ), dtype='uint8')
     data_ptr = 0
     out_ptr = 0

--- a/pyart/io/nexrad_level3.py
+++ b/pyart/io/nexrad_level3.py
@@ -177,13 +177,13 @@ class NEXRADLevel3File(object):
             radial_header = _unpack_from_buf(buf2, pos, RADIAL_HEADER)
             pos += 6
             if packet_code == 16:
-                radial[:] = np.fromstring(buf2[pos:pos+nbins], '>u1')
+                radial[:] = np.frombuffer(buf2[pos:pos+nbins], '>u1')
                 pos += radial_header['nbytes']
             else:
                 assert packet_code == AF1F
                 # decode run length encoding
                 rle_size = radial_header['nbytes'] * 2
-                rle = np.fromstring(buf2[pos:pos+rle_size], dtype='>u1')
+                rle = np.frombuffer(buf2[pos:pos+rle_size], dtype='>u1')
                 colors = np.bitwise_and(rle, 0b00001111)
                 runs = np.bitwise_and(rle, 0b11110000) // 16
                 radial[:] = np.repeat(colors, runs)
@@ -233,28 +233,28 @@ class NEXRADLevel3File(object):
             mdata = self._get_data_msg_134()
 
         elif msg_code in [94, 99, 182, 186]:
-            hw31, hw32 = np.fromstring(threshold_data[:4], '>i2')
+            hw31, hw32 = np.frombuffer(threshold_data[:4], '>i2')
             data = (self.raw_data - 2) * (hw32/10.) + hw31/10.
             mdata = np.ma.array(data, mask=self.raw_data < 2)
 
         elif msg_code in [32]:
-            hw31, hw32 = np.fromstring(threshold_data[:4], '>i2')
+            hw31, hw32 = np.frombuffer(threshold_data[:4], '>i2')
             data = (self.raw_data) * (hw32/10.) + hw31/10.
             mdata = np.ma.array(data, mask=self.raw_data < 2)
 
         elif msg_code in [138]:
-            hw31, hw32 = np.fromstring(threshold_data[:4], '>i2')
+            hw31, hw32 = np.frombuffer(threshold_data[:4], '>i2')
             data = self.raw_data * (hw32/100.) + hw31/100.
             mdata = np.ma.array(data)
 
         elif msg_code in [159, 161, 163]:
-            scale, offset = np.fromstring(threshold_data[:8], '>f4')
+            scale, offset = np.frombuffer(threshold_data[:8], '>f4')
             data = (self.raw_data - offset) / (scale)
             mdata = np.ma.array(data, mask=self.raw_data < 2)
 
         elif msg_code in [170, 172, 173, 174, 175]:
             # units are 0.01 inches
-            scale, offset = np.fromstring(threshold_data[:8], '>f4')
+            scale, offset = np.frombuffer(threshold_data[:8], '>f4')
             data = (self.raw_data - offset) / (scale) * 0.01
             mdata = np.ma.array(data, mask=self.raw_data < 1)
 
@@ -276,7 +276,7 @@ class NEXRADLevel3File(object):
 
     def _get_data_8_or_16_levels(self):
         """ Return a masked array for products with 8 or 16 data levels. """
-        thresh = np.fromstring(self.prod_descr['threshold_data'], '>B')
+        thresh = np.frombuffer(self.prod_descr['threshold_data'], '>B')
         flags = thresh[::2]
         values = thresh[1::2]
 
@@ -297,7 +297,7 @@ class NEXRADLevel3File(object):
 
     def _get_data_msg_134(self):
         """ Return a masked array for product with message code 134. """
-        hw31, hw32, hw33, hw34, hw35 = np.fromstring(
+        hw31, hw32, hw33, hw34, hw35 = np.frombuffer(
             self.prod_descr['threshold_data'][:10], '>i2')
         linear_scale = _int16_to_float16(hw31)
         linear_offset = _int16_to_float16(hw32)

--- a/pyart/io/uffile.py
+++ b/pyart/io/uffile.py
@@ -360,7 +360,7 @@ class UFRay(object):
                 field_header.update(vel_header)
 
         data_str = self._buf[data_offset:data_offset+field_header['nbins']*2]
-        raw_data = np.fromstring(data_str, dtype='>i2')
+        raw_data = np.frombuffer(data_str, dtype='>i2')
         return raw_data
 
     def get_datetime(self):

--- a/pyart/testing/data/dummify_nexrad_file.py
+++ b/pyart/testing/data/dummify_nexrad_file.py
@@ -22,7 +22,7 @@ out.write(fin.read(24 + 12 + RECORD_SIZE * 134))
 # read the rest of the file, and create a array of int8
 buf = fin.read()
 buf_length = len(buf)
-buf_data = np.fromstring(buf, dtype='i1')
+buf_data = np.frombuffer(buf, dtype='i1')
 fin.close()
 
 # replace all radial data with a single value so it compresses well


### PR DESCRIPTION
Changed all files, but nexrad2 (already addressed in #700) in pyart that needed np.fromstring changed to np.frombuffer. We'll see what the tests show. Should only show basemap and nexrad2 with warnings because basemap is a dependency and the nexrad2 pull request is pending. If anything looks off let me know.