### PR TITLE
FIX: Should fix the CI fail for 2.7 doc build. Let us see if CI test for 2.7 passes.

### DIFF
--- a/continuous_integration/build_docs.sh
+++ b/continuous_integration/build_docs.sh
@@ -6,7 +6,7 @@ set -e
 cd "$TRAVIS_BUILD_DIR"
 
 echo "Building Docs"
-conda install -q sphinx pil
+conda install -q sphinx pillow
 
 mv "$TRAVIS_BUILD_DIR"/doc /tmp
 cd /tmp/doc


### PR DESCRIPTION
@scollis With some researching online it seems pillow is preferred now over pil, with installing pillow, you can still do an import PIL or from PIL import Image. pil isn't playing nicely with geotiff or poppler dependencies of the dependencies, which are downloaded from the .yml env during the 2.7 test. pillow however has no issue being conda installed with sphinx when that line of code was originally failing with pil.

https://support.enthought.com/hc/en-us/articles/207704216-Use-Pillow-instead-of-PIL-for-Python-Imaging