### PR TITLE
FIX: Fixing docbuild failure in Travis.

### DIFF
--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -29,7 +29,6 @@ if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from .docscrape_sphinx import get_doc_object, SphinxDocString
-from sphinx.util.compat import Directive
 
 if sys.version_info[0] >= 3:
     sixu = lambda s: s


### PR DESCRIPTION
Removed deprecated import of sphinx.util.compat.
https://github.com/ribozz/sphinx-argparse/issues/65