### PR TITLE
FIX: def test_rhi_elevation was used twice, the other should be named after field data.

### DIFF
--- a/pyart/io/tests/test_mdv_radar.py
+++ b/pyart/io/tests/test_mdv_radar.py
@@ -338,7 +338,7 @@ def test_rhi_elevation():
 
 
 # field data
-def test_rhi_elevation():
+def test_rhi_field_data():
     assert_almost_equal(RADAR_RHI.fields['reflectivity']['data'][0, 0],
                         23.93, 2)
 


### PR DESCRIPTION
This is mentioned in issue #703 .