### PR TITLE
DOC: Added more links to optional dependencies, removed broken links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,10 +97,12 @@
     		<li><a href="http://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/">NASA TRMM RSL</a></li>
             <li><a href="http://tfinley.net/software/pyglpk/">PyGLPK</a></li> 
             <li><a href="http://matplotlib.org/basemap/">Basemap</a></li> 
-            <li><a href="http://code.google.com/p/pyproj/">pyproj</a></li> 
+            <li><a href="http://code.google.com/p/pyproj/">pyproj</a></li>
+            <li><a href="http://wradlib.org">wradlib<a/></li>
+            <li><a href="http://pypi.python.org/pypi/GDAL/">gdal</a></li>
         </ul>
 
-        An easy way to obtain most or all of these dependancies is to install a
+        An easy way to obtain most or all of these dependencies is to install a
         Scientific Python distribution such as
         <a href="https://www.enthought.com/products/canopy/">Enthought Canopy</a>,
         or <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a> which 
@@ -144,13 +146,15 @@
 		<a href="http://opensource.org/licenses/BSD-3-Clause">New BSD License.</a>  
 		Source code for the package is available on 
 		<a href="https://github.com/ARM-DOE/pyart">GitHub</a>.  
-		Feature requests and bug reports can be sumbitted to the 
+		Feature requests and bug reports can be submitted to the 
 		<a href="https://github.com/ARM-DOE/pyart/issues">Issue tracker,</a> posting
 		to the <a href="http://groups.google.com/group/pyart-users/">pyart-users mailing list.</a>
         Contributions of source code, documentation
         or additional example are always appreciated from both developers and users.  Developers
         looking for more detailed information on the inner workings of Py-ART should examine the 
 		<a href="http://arm-doe.github.io/pyart-docs-travis/dev_reference/index.html">developer reference manual.</a>
+        To learn more on contributing to Py-ART, see the
+        <a href="https://github.com/ARM-DOE/pyart/blob/master/contributors_guide.rst">contributor's guide.</a>
 	</div>
 
 	<div id="sidebar">
@@ -164,6 +168,7 @@
 
 		<h2>Downloads</h2>
 		<ul>
+                        <li><a href="https://anaconda.org/conda-forge/arm_pyart">Anaconda Cloud</a></li>
 			<li><a href="https://github.com/ARM-DOE/pyart">GitHub Repo</a></li>
             <li><a href="https://github.com/ARM-DOE/pyart/archive/master.zip">Zip file of repository</a></li>
 		</ul>	
@@ -174,7 +179,6 @@
 			<li><a href="http://groups.google.com/group/pyart-users/">Mailing List</a></li>
 			<li><a href="https://github.com/ARM-DOE/pyart/issues">Report Bugs</a></li>
 			<li><a href="http://www.arm.gov/">ARM</a></li>
-			<li><a href="http://radar.arm.gov/ARM_Radars/Home.html">ARM Radar Group</a></li>
         </ul>
         <h2>People</h2>
         <ul>


### PR DESCRIPTION
Removed broken link for ARM radar group. Added more optional dependencies links, wradlib and gdal. Added link to contributor's guide. Fixed some typos, and added link to Anaconda Cloud.