### PR TITLE
allow reading from MDV with unknown vertical level

### DIFF
--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -354,6 +354,10 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
         zunits = 'mb'
     elif mdv.field_headers[0]["vlevel_type"] == 7:  # VERT_TYPE_THETA
         zunits = 'kelvin'
+    else:
+        warnings.warn("While reading MDV found unknown 'vlevel_type': %i" %
+                      mdv.field_headers[0]["vlevel_type"])
+        zunits = 'unknown'
 
     x = get_metadata('x')
     x['data'] = np.linspace(x_start, x_start + x_step * (nx-1), nx)

--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -355,7 +355,8 @@ def read_grid_mdv(filename, field_names=None, additional_metadata=None,
     elif mdv.field_headers[0]["vlevel_type"] == 7:  # VERT_TYPE_THETA
         zunits = 'kelvin'
     else:
-        warnings.warn("While reading MDV found unknown 'vlevel_type': %i" %
+        warnings.warn(("While reading MDV found unexpected 'vlevel_type'" +
+                      " (%i), units in the z axis set to 'unknown'") %
                       mdv.field_headers[0]["vlevel_type"])
         zunits = 'unknown'
 


### PR DESCRIPTION
While reading MDV warns for unknown 'vlevel_type', set units to 'unknown' and continue