### PR TITLE
FIX: Fixed an issue of nexrad level 2 throwing an error when no msg5 …

### DIFF
--- a/pyart/io/nexrad_level2.py
+++ b/pyart/io/nexrad_level2.py
@@ -21,6 +21,8 @@ pyart.io.nexrad_level2
 
 """
 
+
+
 # This file is part of the Py-ART, the Python ARM Radar Toolkit
 # https://github.com/ARM-DOE/pyart
 
@@ -79,7 +81,7 @@ import struct
 from datetime import datetime, timedelta
 
 import numpy as np
-
+import warnings
 
 class NEXRADLevel2File(object):
     """
@@ -176,9 +178,15 @@ class NEXRADLevel2File(object):
 
         # pull out the vcp record
         msg_5 = [r for r in self._records if r['header']['type'] == 5]
+
+        wstring1 = 'No MSG5 detected. Setting to meaningless data \n'
+        wstring2 = 'Rethink your life choices and be ready for errors'
+
         if len(msg_5):
             self.vcp = msg_5[0]
         else:
+            # There is no VCP Data.. This is uber dodgy
+            warnings.warn(wstring1+wstring2)
             self.vcp = None
         return
 
@@ -426,7 +434,10 @@ class NEXRADLevel2File(object):
         if scans is None:
             scans = range(self.nscans)
         if self._msg_type == '31':
-            cut_parameters = self.vcp['cut_parameters']
+            if self.vcp is not None:
+                cut_parameters = self.vcp['cut_parameters']
+            else:
+                cut_parameters = [{'elevation_angle' : 0.0}]*self.nscans
             scale = 360. / 65536.
             return np.array([cut_parameters[i]['elevation_angle'] * scale
                              for i in scans], dtype='float32')

--- a/pyart/io/nexrad_level2.py
+++ b/pyart/io/nexrad_level2.py
@@ -179,14 +179,14 @@ class NEXRADLevel2File(object):
         # pull out the vcp record
         msg_5 = [r for r in self._records if r['header']['type'] == 5]
 
-        wstring1 = 'No MSG5 detected. Setting to meaningless data \n'
-        wstring2 = 'Rethink your life choices and be ready for errors'
-
         if len(msg_5):
             self.vcp = msg_5[0]
         else:
             # There is no VCP Data.. This is uber dodgy
-            warnings.warn(wstring1+wstring2)
+            warnings.warn("No MSG5 detected. Setting to meaningless data. "
+                          "Rethink your life choices and be ready for errors."
+                          "Specifically fixed angle data will be missing")
+            
             self.vcp = None
         return
 
@@ -437,7 +437,7 @@ class NEXRADLevel2File(object):
             if self.vcp is not None:
                 cut_parameters = self.vcp['cut_parameters']
             else:
-                cut_parameters = [{'elevation_angle' : 0.0}]*self.nscans
+                cut_parameters = [{'elevation_angle': 0.0}] * self.nscans
             scale = 360. / 65536.
             return np.array([cut_parameters[i]['elevation_angle'] * scale
                              for i in scans], dtype='float32')


### PR DESCRIPTION
…present

Py-ART used msg5 data to set the target angle for the radar, fixed_angle in cf-radial.
Now for level2 data with no msg5 it will set all fixed angles to 0.0

I played with setting a warning.. probably a better way to do it -SC