### PR TITLE
FIX: Added a warning messsage when an axes is defined without a projection

### DIFF
--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -13,6 +13,8 @@ for drawing maps.
 
 """
 
+import warnings
+
 import numpy as np
 import matplotlib.pyplot as plt
 try:
@@ -30,8 +32,6 @@ except ImportError:
 from .radardisplay import RadarDisplay
 from .common import parse_ax_fig, parse_vmin_vmax, parse_cmap
 from ..exceptions import MissingOptionalDependency
-
-import warnings
 
 class RadarMapDisplayCartopy(RadarDisplay):
     """

--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -31,6 +31,7 @@ from .radardisplay import RadarDisplay
 from .common import parse_ax_fig, parse_vmin_vmax, parse_cmap
 from ..exceptions import MissingOptionalDependency
 
+import warnings
 
 class RadarMapDisplayCartopy(RadarDisplay):
     """
@@ -259,6 +260,9 @@ class RadarMapDisplayCartopy(RadarDisplay):
                 # set map projection to LambertConformal if none is specified
                 projection = cartopy.crs.LambertConformal(
                     central_longitude=lon_0, central_latitude=lat_0)
+                warnings.warn("No projection was defined for the axes." + 
+                              " Overridding defined axes and using default axes.",
+                              UserWarning)
             ax = plt.axes(projection=projection)
 
         if min_lon:


### PR DESCRIPTION
This is in response to issue #743. A warning is now raised when a user doesn't define a projection when setting the axes when creating a map display. 

When an axes is set but no projection is defined, the program will override the defined axes and change it to the default along with a default projection. A user will now be warned when this happens.