### PR TITLE
Don't crash on broken nexrad NL2

### DIFF
--- a/pyart/io/nexrad_level2.py
+++ b/pyart/io/nexrad_level2.py
@@ -536,8 +536,8 @@ class NEXRADLevel2File(object):
             msg = self.radial_records[msg_num]
             if moment not in msg.keys():
                 continue
-            ngates = msg[moment]['ngates']
-            data[i, :ngates] = msg[moment]['data']
+            ngates = min(msg[moment]['ngates'], max_ngates, len(msg[moment]['data']))
+            data[i, :ngates] = msg[moment]['data'][:ngates]
 
         # return raw data if requested
         if raw_data:


### PR DESCRIPTION
Some nexrad L2 files have inconsistent gate number in their headers and actual sweeps. I cannot give an example at this time but I've encounter this issue many times in daily operational run when processing CDX/Batch scans. An easy but not perfect solution is to take whichever variable that gives minimal gate number to avoid a crash. 