### PR TITLE
FIX: This is a temporary fix for Cartopy issue #1120.

### DIFF
--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -19,6 +19,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 try:
     import cartopy
+
+    # Temporary fix for Cartopy issue #1120.
+    from matplotlib.axes import Axes
+    from cartopy.mpl.geoaxes import GeoAxes
+    GeoAxes._pcolormesh_patched = Axes.pcolormesh
+
     _CARTOPY_AVAILABLE = True
 except ImportError:
     _CARTOPY_AVAILABLE = False
@@ -28,11 +34,6 @@ try:
     _LAMBERT_GRIDLINES = True
 except ImportError:
     _LAMBERT_GRIDLINES = False
-
-# Temporary fix for Cartopy issue #1120.
-from matplotlib.axes import Axes
-from cartopy.mpl.geoaxes import GeoAxes
-GeoAxes._pcolormesh_patched = Axes.pcolormesh
 
 from .radardisplay import RadarDisplay
 from .common import parse_ax_fig, parse_vmin_vmax, parse_cmap

--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -29,6 +29,11 @@ try:
 except ImportError:
     _LAMBERT_GRIDLINES = False
 
+# Temporary fix for Cartopy issue #1120.
+from matplotlib.axes import Axes
+from cartopy.mpl.geoaxes import GeoAxes
+GeoAxes._pcolormesh_patched = Axes.pcolormesh
+
 from .radardisplay import RadarDisplay
 from .common import parse_ax_fig, parse_vmin_vmax, parse_cmap
 from ..exceptions import MissingOptionalDependency

--- a/pyart/graph/radarmapdisplay_cartopy.py
+++ b/pyart/graph/radarmapdisplay_cartopy.py
@@ -23,7 +23,8 @@ try:
     # Temporary fix for Cartopy issue #1120.
     from matplotlib.axes import Axes
     from cartopy.mpl.geoaxes import GeoAxes
-    GeoAxes._pcolormesh_patched = Axes.pcolormesh
+    if hasattr(GeoAxes, '_pcolormesh_patched'):
+        GeoAxes._pcolormesh_patched = Axes.pcolormesh
 
     _CARTOPY_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
A temporary fix suggested by @dopplershift that sets the pcolormesh axes to matplotlib axis until geoaxes in cartopy is updated for matplotlib 3.0.0.