### PR TITLE
ADD: include_fields parameter

### DIFF
--- a/pyart/aux_io/arm_vpt.py
+++ b/pyart/aux_io/arm_vpt.py
@@ -18,7 +18,8 @@ from ..core.radar import Radar
 
 
 def read_kazr(filename, field_names=None, additional_metadata=None,
-              file_field_names=False, exclude_fields=None):
+              file_field_names=False, exclude_fields=None,
+              include_fields=None):
     """
     Read K-band ARM Zenith Radar (KAZR) NetCDF ingest data.
 
@@ -40,7 +41,12 @@ def read_kazr(filename, field_names=None, additional_metadata=None,
         `field_names` parameter to rename fields.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
     Returns
     -------
@@ -51,7 +57,7 @@ def read_kazr(filename, field_names=None, additional_metadata=None,
     # create metadata retrieval object
     filemetadata = FileMetadata(
         'cfradial', field_names, additional_metadata, file_field_names,
-        exclude_fields)
+        exclude_fields, include_fields)
 
     # read the data
     ncobj = netCDF4.Dataset(filename)
@@ -139,6 +145,8 @@ def read_kazr(filename, field_names=None, additional_metadata=None,
         field_name = filemetadata.get_field_name(key)
         if field_name is None:
             if exclude_fields is not None and key in exclude_fields:
+                continue
+            if include_fields is not None and not key in include_fields:
                 continue
             field_name = key
         fields[field_name] = cfradial._ncvar_to_dict(ncvars[key])

--- a/pyart/aux_io/d3r_gcpex_nc.py
+++ b/pyart/aux_io/d3r_gcpex_nc.py
@@ -43,7 +43,8 @@ D3R_FIELD_NAMES = {
 
 
 def read_d3r_gcpex_nc(filename, field_names=None, additional_metadata=None,
-                      file_field_names=False, exclude_fields=None, **kwargs):
+                      file_field_names=False, exclude_fields=None,
+                      include_fields=None, **kwargs):
     """
     Read a D3R GCPEX netCDF file.
 
@@ -70,7 +71,12 @@ def read_d3r_gcpex_nc(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
     Returns
     -------
@@ -93,7 +99,8 @@ def read_d3r_gcpex_nc(filename, field_names=None, additional_metadata=None,
     if field_names is None:
         field_names = D3R_FIELD_NAMES
     filemetadata = FileMetadata('cfradial', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # read the data
     ncobj = netCDF4.Dataset(filename)
@@ -197,6 +204,9 @@ def read_d3r_gcpex_nc(filename, field_names=None, additional_metadata=None,
         if field_name is None:
             if exclude_fields is not None and key in exclude_fields:
                 continue
+            if include_fields is not None:
+                if not key in include_fields:
+                    continue
             field_name = key
         fields[field_name] = _ncvar_to_dict(ncvars[key])
 

--- a/pyart/aux_io/gamic_hdf5.py
+++ b/pyart/aux_io/gamic_hdf5.py
@@ -40,8 +40,8 @@ LIGHT_SPEED = 2.99792458e8  # speed of light in meters per second
 
 def read_gamic(filename, field_names=None, additional_metadata=None,
                file_field_names=False, exclude_fields=None,
-               valid_range_from_file=True, units_from_file=True,
-               pulse_width=None, **kwargs):
+               include_fields=None, valid_range_from_file=True,
+               units_from_file=True, pulse_width=None, **kwargs):
     """
     Read a GAMIC hdf5 file.
 
@@ -63,7 +63,12 @@ def read_gamic(filename, field_names=None, additional_metadata=None,
         `field_names` parameter to rename fields.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     valid_range_from_file : bool, optional
         True to extract valid range (valid_min and valid_max) for all
         field from the file when they are present.  False will not extract
@@ -91,7 +96,8 @@ def read_gamic(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrieval object
     filemetadata = FileMetadata('gamic', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # Open HDF5 file and get handle
     gfile = GAMICFile(filename)

--- a/pyart/aux_io/noxp_iphex_nc.py
+++ b/pyart/aux_io/noxp_iphex_nc.py
@@ -64,7 +64,12 @@ def read_noxp_iphex_nc(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
     Returns
     -------
@@ -89,7 +94,8 @@ def read_noxp_iphex_nc(filename, field_names=None, additional_metadata=None,
     if field_names is None:
         field_names = NOXP_FIELD_NAMES
     filemetadata = FileMetadata('cfradial', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # read the data
     ncobj = netCDF4.Dataset(filename)
@@ -179,6 +185,8 @@ def read_noxp_iphex_nc(filename, field_names=None, additional_metadata=None,
         field_name = filemetadata.get_field_name(key)
         if field_name is None:
             if exclude_fields is not None and key in exclude_fields:
+                continue
+            if include_fields is not None and not key in include_fields:
                 continue
             field_name = key
         fields[field_name] = _ncvar_to_dict(ncvars[key])

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -49,7 +49,8 @@ ODIM_H5_FIELD_NAMES = {
 
 
 def read_odim_h5(filename, field_names=None, additional_metadata=None,
-                 file_field_names=False, exclude_fields=None, **kwargs):
+                 file_field_names=False, exclude_fields=None, 
+                 include_fields=None, **kwargs):
     """
     Read a ODIM_H5 file.
 
@@ -76,7 +77,12 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
 
     Returns
@@ -105,7 +111,8 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
     if field_names is None:
         field_names = ODIM_H5_FIELD_NAMES
     filemetadata = FileMetadata('odim_h5', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # open the file
     try:

--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -73,7 +73,8 @@ RAINBOW_FIELD_NAMES = {
 
 
 def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
-                     file_field_names=False, exclude_fields=None, **kwargs):
+                     file_field_names=False, exclude_fields=None,
+                     include_fields=None, **kwargs):
     """
     Read a RAINBOW file.
     This routine has been tested to read rainbow5 files version 5.22.3,
@@ -118,7 +119,12 @@ def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
 
     Returns
@@ -148,7 +154,8 @@ def read_rainbow_wrl(filename, field_names=None, additional_metadata=None,
     if field_names is None:
         field_names = RAINBOW_FIELD_NAMES
     filemetadata = FileMetadata('RAINBOW', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     rbf = read_rainbow(filename, loaddata=True)
 

--- a/pyart/aux_io/sinarame_h5.py
+++ b/pyart/aux_io/sinarame_h5.py
@@ -61,7 +61,8 @@ SINARAME_H5_FIELD_NAMES = {
 
 
 def read_sinarame_h5(filename, field_names=None, additional_metadata=None,
-                     file_field_names=False, exclude_fields=None, **kwargs):
+                     file_field_names=False, exclude_fields=None,
+                     include_fields=None, **kwargs):
     """
     Read a SINARAME_H5 file.
 
@@ -88,7 +89,12 @@ def read_sinarame_h5(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
 
     Returns
@@ -118,7 +124,8 @@ def read_sinarame_h5(filename, field_names=None, additional_metadata=None,
         field_names = SINARAME_H5_FIELD_NAMES
     filemetadata = FileMetadata('SINARAME_h5', field_names,
                                 additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # open the file
     hfile = h5py.File(filename, 'r')

--- a/pyart/config.py
+++ b/pyart/config.py
@@ -211,11 +211,13 @@ class FileMetadata():
         True to keep the field names in the file.
     exclude_fields : list of strings
         Fields to exclude during readings.
-
+    include_fields : list of strings
+        Fields to include during readings.
     """
 
     def __init__(self, filetype, field_names=None, additional_metadata=None,
-                 file_field_names=False, exclude_fields=None):
+                 file_field_names=False, exclude_fields=None,
+                 include_fields=None):
         """
         Initialize.
         """
@@ -246,6 +248,11 @@ class FileMetadata():
             self._exclude_fields = []
         else:
             self._exclude_fields = exclude_fields
+ 
+        if include_fields is None:
+            self._include_fields = None
+        else:
+            self._include_fields = include_fields 
 
     def get_metadata(self, p):
         """
@@ -309,5 +316,10 @@ class FileMetadata():
 
         if field_name in self._exclude_fields:
             return None     # field is excluded
+        elif self._include_fields is not None:
+            if not field_name in self._include_fields:
+                return None
+            else:
+                return field_name
         else:
             return field_name

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -70,7 +70,7 @@ _INSTRUMENT_PARAMS_DIMS = {
 
 def read_cfradial(filename, field_names=None, additional_metadata=None,
                   file_field_names=False, exclude_fields=None,
-                  delay_field_loading=False, **kwargs):
+                  include_fields=None, delay_field_loading=False, **kwargs):
     """
     Read a Cfradial netCDF file.
 
@@ -92,7 +92,12 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         `field_names` parameter to rename fields.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     delay_field_loading : bool
         True to delay loading of field data from the file until the 'data'
         key in a particular field dictionary is accessed.  In this case
@@ -195,7 +200,6 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         # Python 3, all strings are already unicode.        
         mode = netCDF4.chartostring(sweep_mode['data'][0])[()]
 
-
     # options specified in the CF/Radial standard
     if mode == 'rhi':
         scan_type = 'rhi'
@@ -287,8 +291,12 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
         field_name = filemetadata.get_field_name(key)
         if field_name is None:
             if exclude_fields is not None and key in exclude_fields:
+                if key not in include_fields: 
+                    continue
+            if include_fields is None or key in include_fields:
+                field_name = key
+            else:
                 continue
-            field_name = key
         fields[field_name] = _ncvar_to_dict(ncvars[key], delay_field_loading)
 
     if 'ray_n_gates' in ncvars:

--- a/pyart/io/chl.py
+++ b/pyart/io/chl.py
@@ -30,7 +30,7 @@ from .common import make_time_unit_str, _test_arguments, prepare_for_read
 
 def read_chl(filename, field_names=None, additional_metadata=None,
              file_field_names=None, exclude_fields=None,
-             use_file_field_attributes=True, **kwargs):
+             include_fields=None, use_file_field_attributes=True, **kwargs):
     """
     Read a CSU-CHILL CHL file.
 
@@ -58,6 +58,10 @@ def read_chl(filename, field_names=None, additional_metadata=None,
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
         after the `file_field_names` and `field_names` parameters.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `field_file_names` and `field_names` parameters. Set to
+        None to include all fields not in exclude_fields.
     use_file_field_attributes : bool, optional
         True to use information provided by in the file to set the field
         attribute `long_name`, `units`, `valid_max`, and `valid_min`.  False
@@ -75,7 +79,8 @@ def read_chl(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrival object
     filemetadata = FileMetadata('chl', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # read data
     chl_file = ChlFile(prepare_for_read(filename))

--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -22,7 +22,7 @@ from .cfradial import _ncvar_to_dict, _create_ncvar
 from .common import _test_arguments
 
 
-def read_grid(filename, exclude_fields=None, **kwargs):
+def read_grid(filename, exclude_fields=None, include_fields=None, **kwargs):
     """
     Read a netCDF grid file produced by Py-ART.
 
@@ -34,8 +34,14 @@ def read_grid(filename, exclude_fields=None, **kwargs):
 
     Other Parameters
     ----------------
-    exclude_fields : list
-        A list of fields to exclude from the grid object.
+    exclude_fields : list or None, optional
+        List of fields to exclude from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
     Returns
     -------
@@ -95,6 +101,9 @@ def read_grid(filename, exclude_fields=None, **kwargs):
     for field in field_keys:
         if field in exclude_fields:
             continue
+        if include_fields is not None:
+            if field not in include_fields:
+                continue
         field_dic = _ncvar_to_dict(dset.variables[field])
         if field_dic['data'].shape == field_shape_with_time:
             field_dic['data'].shape = field_shape

--- a/pyart/io/mdv_radar.py
+++ b/pyart/io/mdv_radar.py
@@ -23,7 +23,7 @@ from . import mdv_common
 
 def read_mdv(filename, field_names=None, additional_metadata=None,
              file_field_names=False, exclude_fields=None,
-             delay_field_loading=False, **kwargs):
+             include_fields=None, delay_field_loading=False, **kwargs):
     """
     Read a MDV file.
 
@@ -51,7 +51,12 @@ def read_mdv(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     delay_field_loading : bool
         True to delay loading of field data from the file until the 'data'
         key in a particular field dictionary is accessed.  In this case
@@ -75,7 +80,8 @@ def read_mdv(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrieval object
     filemetadata = FileMetadata('mdv', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     mdvfile = mdv_common.MdvFile(prepare_for_read(filename))
 

--- a/pyart/io/nexrad_archive.py
+++ b/pyart/io/nexrad_archive.py
@@ -35,7 +35,8 @@ from .nexrad_interpolate import _fast_interpolate_scan
 
 def read_nexrad_archive(filename, field_names=None, additional_metadata=None,
                         file_field_names=False, exclude_fields=None,
-                        delay_field_loading=False, station=None, scans=None,
+                        include_fields=None, delay_field_loading=False,
+                        station=None, scans=None,
                         linear_interp=True, **kwargs):
     """
     Read a NEXRAD Level 2 Archive file.
@@ -67,7 +68,12 @@ def read_nexrad_archive(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     delay_field_loading : bool, optional
         True to delay loading of field data from the file until the 'data'
         key in a particular field dictionary is accessed.  In this case
@@ -106,7 +112,7 @@ def read_nexrad_archive(filename, field_names=None, additional_metadata=None,
     # create metadata retrieval object
     filemetadata = FileMetadata('nexrad_archive', field_names,
                                 additional_metadata, file_field_names,
-                                exclude_fields)
+                                exclude_fields, include_fields)
 
     # open the file and retrieve scan information
     nfile = NEXRADLevel2File(prepare_for_read(filename))

--- a/pyart/io/nexrad_cdm.py
+++ b/pyart/io/nexrad_cdm.py
@@ -28,7 +28,7 @@ from .common import make_time_unit_str, _test_arguments
 
 def read_nexrad_cdm(filename, field_names=None, additional_metadata=None,
                     file_field_names=False, exclude_fields=None,
-                    station=None, **kwargs):
+                    include_fields=None, station=None, **kwargs):
     """
     Read a Common Data Model (CDM) NEXRAD Level 2 file.
 
@@ -59,7 +59,12 @@ def read_nexrad_cdm(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     station : str
         Four letter ICAO name of the NEXRAD station used to determine the
         location in the returned radar object.  This parameter is only
@@ -86,7 +91,7 @@ def read_nexrad_cdm(filename, field_names=None, additional_metadata=None,
     # create metadata retrieval object
     filemetadata = FileMetadata('nexrad_cdm', field_names,
                                 additional_metadata, file_field_names,
-                                exclude_fields)
+                                exclude_fields, include_fields)
 
     # open the file
     dataset = netCDF4.Dataset(filename)

--- a/pyart/io/nexradl3_read.py
+++ b/pyart/io/nexradl3_read.py
@@ -20,7 +20,8 @@ from .nexrad_level3 import NEXRADLevel3File
 
 
 def read_nexrad_level3(filename, field_names=None, additional_metadata=None,
-                       file_field_names=False, exclude_fields=None, **kwargs):
+                       file_field_names=False, exclude_fields=None, 
+                       include_fields=None, **kwargs):
     """
     Read a NEXRAD Level 3 product.
 
@@ -52,7 +53,12 @@ def read_nexrad_level3(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
 
     Returns
     -------
@@ -72,7 +78,7 @@ def read_nexrad_level3(filename, field_names=None, additional_metadata=None,
     # create metadata retrieval object
     filemetadata = FileMetadata('nexrad_level3', field_names,
                                 additional_metadata, file_field_names,
-                                exclude_fields)
+                                exclude_fields, include_fields)
 
     # open the file
     nfile = NEXRADLevel3File(prepare_for_read(filename))

--- a/pyart/io/rsl.py
+++ b/pyart/io/rsl.py
@@ -66,7 +66,12 @@ def read_rsl(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     delay_field_loading : bool
         True to delay loading of field data from the file until the 'data'
         key in a particular field dictionary is accessed.  In this case
@@ -97,7 +102,8 @@ def read_rsl(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrieval object
     filemetadata = FileMetadata('rsl', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields, 
+                                include_fields)
 
     # read the file, determine common parameters
     fillvalue = get_fillvalue()

--- a/pyart/io/rsl.py
+++ b/pyart/io/rsl.py
@@ -38,7 +38,7 @@ from ..exceptions import MissingOptionalDependency
 
 def read_rsl(filename, field_names=None, additional_metadata=None,
              file_field_names=False, exclude_fields=None,
-             delay_field_loading=False,
+             delay_field_loading=False, include_fields=None,
              radar_format=None, callid=None, skip_range_check=False):
     """
     Read a file supported by RSL

--- a/pyart/io/sigmet.py
+++ b/pyart/io/sigmet.py
@@ -36,9 +36,9 @@ SPEED_OF_LIGHT = 299793000.0
 
 def read_sigmet(filename, field_names=None, additional_metadata=None,
                 file_field_names=False, exclude_fields=None,
-                time_ordered='none', full_xhdr=None, noaa_hh_hdr=None,
-                debug=False, ignore_xhdr=False, ignore_sweep_start_ms=None,
-                **kwargs):
+                include_fields=None, time_ordered='none', full_xhdr=None,
+                noaa_hh_hdr=None, debug=False, ignore_xhdr=False,
+                ignore_sweep_start_ms=None, **kwargs):
     """
     Read a Sigmet (IRIS) product file.
 
@@ -66,7 +66,12 @@ def read_sigmet(filename, field_names=None, additional_metadata=None,
         `additional_metadata`.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     time_ordered : 'none', 'sequential', 'full', ...,  optional
         Parameter controlling if and how the rays are re-ordered by time.
         The default, 'none' keeps the rays ordered in the same manner as
@@ -120,7 +125,8 @@ def read_sigmet(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrieval object
     filemetadata = FileMetadata('sigmet', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # open the file
     sigmetfile = SigmetFile(prepare_for_read(filename), debug=debug)

--- a/pyart/io/uf.py
+++ b/pyart/io/uf.py
@@ -50,7 +50,7 @@ _SWEEP_MODE_STR = {
 
 def read_uf(filename, field_names=None, additional_metadata=None,
             file_field_names=False, exclude_fields=None,
-            delay_field_loading=False, **kwargs):
+            include_fields=None, delay_field_loading=False, **kwargs):
     """
     Read a UF File.
 
@@ -76,7 +76,12 @@ def read_uf(filename, field_names=None, additional_metadata=None,
         `field_names` parameter to rename fields.
     exclude_fields : list or None, optional
         List of fields to exclude from the radar object. This is applied
-        after the `file_field_names` and `field_names` parameters.
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields specified by include_fields.
+    include_fields : list or None, optional
+        List of fields to include from the radar object. This is applied
+        after the `file_field_names` and `field_names` parameters. Set
+        to None to include all fields not specified by exclude_fields.
     delay_field_loading : bool
         This option is not implemented in the function but included for
         compatibility.
@@ -92,7 +97,8 @@ def read_uf(filename, field_names=None, additional_metadata=None,
 
     # create metadata retrieval object
     filemetadata = FileMetadata('uf', field_names, additional_metadata,
-                                file_field_names, exclude_fields)
+                                file_field_names, exclude_fields,
+                                include_fields)
 
     # Open UF file and get handle
     ufile = UFFile(prepare_for_read(filename))


### PR DESCRIPTION
In response to #780 raised by @vlouf I have added an include_fields parameter to pyart.io.read and pyart.aux_io.read functions. If it is set to None, all of the fields that are not in exclude_fields will be loaded. Otherwise, it will only load the fields that are in include_fields.

I have not tested it for any of the aux_io cases as we don't have unit tests set up for those, but it works for all of the example files in the Py-ART testing suite.