### PR TITLE
ADD: added a function that will make a QVP object from a radar object 

### DIFF
--- a/pyart/retrieve/__init__.py
+++ b/pyart/retrieve/__init__.py
@@ -35,6 +35,7 @@ Radar retrievals
     est_rain_rate_za
     est_rain_rate_hydro
     velocity_azimuth_display
+    quasi_vertical_profile
 
 """
 
@@ -51,5 +52,6 @@ from .qpe import est_rain_rate_zpoly, est_rain_rate_z, est_rain_rate_kdp
 from .qpe import est_rain_rate_a, est_rain_rate_zkdp, est_rain_rate_za
 from .qpe import est_rain_rate_hydro
 from .vad import velocity_azimuth_display
+from .qvp import quasi_vertical_profile
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/pyart/retrieve/qvp.py
+++ b/pyart/retrieve/qvp.py
@@ -1,0 +1,117 @@
+"""
+pyart.retrieve.quasi_vertical_profile
+=====================================
+
+Retrieval of QVPs from a radar object
+
+.. autosummary::
+    :toctree: generated/
+
+    quasi_vertical_profile
+
+"""
+
+import numpy as np
+
+from ..core.transforms import antenna_to_cartesian
+
+
+
+def quasi_vertical_profile(radar, fields = None, gatefilter = None):
+    
+    """
+    Quasi Vertical Profile.
+    
+    Creates a QVP object containing fields from a radar object that can
+    be used to plot and produce the quasi vertical profile
+    
+    
+    Parameters
+    ----------
+    radar : Radar
+        Radar object used.
+    field : string
+        Radar field to use for QVP calculation.
+    
+    Other Parameters
+    ----------------
+    gatefilter : GateFilter
+        A GateFilter indicating radar gates that should be excluded
+        from the import qvp calculation
+        
+    Returns
+    -------
+    qvp : Dictonary
+        A quasai vertical profile object containing fields 
+        from a radar object
+    
+    
+    
+    References
+    ----------
+    Troemel, S., M. Kumjian, A. Ryzhkov, and C. Simmer, 2013: Backscatter 
+    differential phase – estimation and variability. J. Appl. Meteor. Clim.. 
+    52, 2529 – 2548.
+
+    Troemel, S., A. Ryzhkov, P. Zhang, and C. Simmer, 2014: Investigations 
+    of backscatter differential phase in the melting layer. J. Appl. Meteorol. 
+    Clim. 53, 2344 – 2359.
+
+    Ryzhkov, A., P. Zhang, H. Reeves, M. Kumjian, T. Tschallener, S. Troemel, 
+    C. Simmer, 2015: Quasi-vertical profiles – a new way to look at polarimetric 
+    radar data. Submitted to J. Atmos. Oceanic Technol.
+    
+    """
+    
+    # Creating an empty dictonary
+    qvp = {}
+    
+    # Setting the desired radar angle and getting index value for desired radar angle
+    desired_angle = 20.0
+    index = abs(radar.fixed_angle['data'] - desired_angle).argmin()
+    radar_slice = radar.get_slice(index)
+
+    # Printing radar tilt angles and radar elevation
+    print(radar.fixed_angle['data'])
+    print(radar.elevation['data'][-1])
+    
+    
+    # Setting field parameters
+    # If fields is None then all radar fields pulled else defined field is used
+    if fields is None:
+        fields = radar.fields
+        
+        for field in fields:
+
+            # Filtering data based on defined gatefilter 
+            # If none is defined goes to else statement
+            if gatefilter is not None:
+                get_fields = radar.get_field(index, field)
+                mask_fields = np.ma.masked_where(gatefilter.gate_excluded[radar_slice], 
+                                                 get_fields)
+                radar_fields = np.ma.mean(mask_fields, axis = 0)
+            else:
+                radar_fields = radar.get_field(index, field).mean(axis = 0)
+
+            qvp.update({field:radar_fields})
+
+    else:
+        
+        # Filtereing data based on defined gatefilter
+        # If none is defined goes to else statement
+        if gatefilter is not None:
+            get_field = radar.get_field(index, fields)
+            mask_field = np.ma.masked_where(gatefilter.gate_excluded[radar_slice], 
+                                            get_field)
+            radar_field = np.ma.mean(mask_field, axis = 0)
+        else: 
+            radar_field = radar.get_field(index, fields).mean(axis = 0)
+            
+        qvp.update({fields:radar_field})
+
+    # Adding range, time, and height fields    
+    qvp.update({'range': radar.range['data'], 'time': radar.time})
+    x,y,z = antenna_to_cartesian(qvp['range']/1000.0, 0.0, 
+                                            radar.fixed_angle['data'][index])
+    qvp.update({'height': z})
+    return qvp

--- a/pyart/retrieve/qvp.py
+++ b/pyart/retrieve/qvp.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 pyart.retrieve.quasi_vertical_profile
 =====================================
 
@@ -49,17 +49,17 @@ def quasi_vertical_profile(radar, fields = None, gatefilter = None):
     
     References
     ----------
-    Troemel, S., M. Kumjian, A. Ryzhkov, and C. Simmer, 2013: Backscatter 
-    differential phase – estimation and variability. J. Appl. Meteor. Clim.. 
-    52, 2529 – 2548.
+    Troemel, S., M. Kumjian, A. Ryzhkov, and C. Simmer, 2013: Backscatter
+    differential phase - estimation and variability. J Appl. Meteor. Clim..
+    52, 2529 - 2548.
 
-    Troemel, S., A. Ryzhkov, P. Zhang, and C. Simmer, 2014: Investigations 
-    of backscatter differential phase in the melting layer. J. Appl. Meteorol. 
-    Clim. 53, 2344 – 2359.
+    Troemel, S., A. Ryzhkov, P. Zhang, and C. Simmer, 2014: Investigations
+    of backscatter differential phase in the melting layer. J. Appl. Meteorol.
+    Clim. 54, 2344 - 2359.
 
-    Ryzhkov, A., P. Zhang, H. Reeves, M. Kumjian, T. Tschallener, S. Troemel, 
-    C. Simmer, 2015: Quasi-vertical profiles – a new way to look at polarimetric 
-    radar data. Submitted to J. Atmos. Oceanic Technol.
+    Ryzhkov, A., P. Zhang, H. Reeves, M. Kumjian, T. Tschallener, S. Tromel, 
+    C. Simmer, 2015: Quasi-vertical profiles - a new way to look at polarimetric
+    radar data. Submitted to J. Atmos. Oceanic Technol. 
     
     """
     

--- a/pyart/retrieve/tests/test_qvp.py
+++ b/pyart/retrieve/tests/test_qvp.py
@@ -1,0 +1,40 @@
+""" Unit Tests for Py-ART's retrieve/qvp.py module. """
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+
+import pyart
+
+
+def test_quasi_vertical_profile():
+    test_radar = pyart.testing.make_target_radar()
+    height = np.arange(0, 1000, 200)
+    speed = np.ones_like(height) * 5
+    direction = np.array([0, 90, 180, 270, 45])
+    profile = pyart.core.HorizontalWindProfile(height, speed, direction)
+    sim_vel = pyart.util.simulated_vel_from_profile(test_radar, profile)
+    test_radar.add_field('velocity', sim_vel, replace_existing=True)
+
+    qvp = pyart.retrieve.quasi_vertical_profile(test_radar)
+
+    qvp_height = [0., 0., 0., 1., 1., 1., 1., 2., 2., 2., 2., 3., 3., 
+                  3., 3., 3., 4., 4., 4., 4., 5., 5., 5., 5., 6., 6., 
+                  6., 7., 7., 7., 7., 8., 8., 8., 8., 9., 9., 9., 10., 
+                  10., 10., 10., 11., 11., 11., 11., 12., 12., 12., 13.]
+    
+    qvp_range = [ 0., 20.408, 40.816, 61.224, 81.632, 102.040, 122.448, 142.857, 
+                 163.265, 183.673, 204.081, 224.489, 244.897, 265.306, 285.714, 
+                 306.122, 326.530, 346.938, 367.346, 387.755, 408.163, 428.571, 
+                 448.979, 469.387, 489.795, 510.204, 530.612, 551.020, 571.428, 
+                 591.836, 612.244, 632.653, 653.061, 673.469, 693.877, 714.285, 
+                 734.693, 755.102, 775.510, 795.918, 816.326, 836.734, 857.142, 
+                 877.551, 897.959, 918.367, 938.775, 959.183, 979.591, 1000]
+    
+    qvp_reflectivity = [ 0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0., 10., 10., 10., 
+                        10., 10., 10., 10., 10., 10., 10., 20., 20., 20., 20., 20., 20., 
+                        20., 20., 20., 20., 30., 30., 30., 30., 30., 30., 30., 30., 30., 
+                        30., 40., 40., 40., 40., 40., 40., 40., 40., 40., 40.]
+    
+    assert_almost_equal(qvp['height'], qvp_height, 3)
+    assert_almost_equal(qvp['range'], qvp_range, 3)
+    assert_almost_equal(qvp['reflectivity'], qvp_reflectivity, 3)


### PR DESCRIPTION
Code is based on adapted code from Scott Collis using the method found in Ryzhkov et all (2013, 2014, 2015)

Function will create a QVP dictionary with fields from a radar object. Testing of the code was done using radar scans and creating a time series plot and well as testing it against the unit test. 

Attached are some example time series plots
![reflectivity_no_gatefilter](https://user-images.githubusercontent.com/21142062/48159343-87717200-e29a-11e8-8c67-6e1614d234fe.png)
![zdr_with_rhv_gatefilter](https://user-images.githubusercontent.com/21142062/48159363-948e6100-e29a-11e8-893f-762ba79d2fff.png)
![ref_with_gate_id_gatefilter](https://user-images.githubusercontent.com/21142062/48159376-9ce69c00-e29a-11e8-86bc-176bc017f3d9.png)


 