### PR TITLE
MAINT: Removal of basemap from core modules and some fixes.

### DIFF
--- a/pyart/_debug_info.py
+++ b/pyart/_debug_info.py
@@ -99,10 +99,10 @@ def _debug_info(stream=None):
         cvxopt_version = "MISSING"
 
     try:
-        from mpl_toolkits import basemap
-        basemap_version = basemap.__version__
+        import cartopy
+        cartopy_version = cartopy.__version__
     except:
-        basemap_version = "MISSING"
+        cartopy_version = "MISSING"
 
     try:
         import pytest
@@ -126,7 +126,7 @@ def _debug_info(stream=None):
     print("CyLP:", cylp_available, file=stream)
     print("PyGLPK version:", glpk_version, file=stream)
     print("CVXOPT version:", cvxopt_version, file=stream)
-    print("basemap version:", basemap_version, file=stream)
+    print("Cartopy version:", cartopy_version, file=stream)
     print("pytest version:", pytest_version, file=stream)
 
 if __name__ == "__main__":

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -24,7 +24,7 @@ import warnings
 import numpy as np
 
 try:
-    from mpl_toolkits.basemap import pyproj
+    import pyproj
     _PYPROJ_AVAILABLE = True
 except ImportError:
     _PYPROJ_AVAILABLE = False
@@ -171,7 +171,7 @@ class Grid(object):
                 'Proj instance can not be made for the pyart_aeqd projection')
         if not _PYPROJ_AVAILABLE:
             raise MissingOptionalDependency(
-                "Basemap is required to create a Proj instance but it " +
+                "PyProj is required to create a Proj instance but it " +
                 "is not installed")
         proj = pyproj.Proj(projparams)
         return proj

--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -30,6 +30,7 @@ except ImportError:
     _PYPROJ_AVAILABLE = False
 
 from ..config import get_metadata
+from ..exceptions import MissingOptionalDependency
 from ..lazydict import LazyLoadDict
 from .transforms import cartesian_to_geographic
 from .transforms import cartesian_vectors_to_geographic

--- a/pyart/core/tests/test_grid.py
+++ b/pyart/core/tests/test_grid.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_almost_equal
 import pytest
 
 try:
-    from mpl_toolkits.basemap import pyproj
+    import pyproj
     _PYPROJ_AVAILABLE = True
 except ImportError:
     _PYPROJ_AVAILABLE = False

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -39,11 +39,7 @@ try:
     import pyproj
     _PYPROJ_AVAILABLE = True
 except ImportError:
-    try:
-        from mpl_toolkits.basemap import pyproj
-        _PYPROJ_AVAILABLE = True
-    except ImportError:
-        _PYPROJ_AVAILABLE = False
+    _PYPROJ_AVAILABLE = False
 
 PI = np.pi
 
@@ -378,9 +374,9 @@ def geographic_to_cartesian(lon, lat, projparams):
         Projection parameters passed to pyproj.Proj. If this parameter is a
         dictionary with a 'proj' key equal to 'pyart_aeqd' then a azimuthal
         equidistant projection will be used that is native to Py-ART and
-        does not require pyproj/basemap to be installed. In this case a
-        non-default value of R can be specified by setting the 'R' key to the
-        desired value.
+        does not require pyproj to be installed. In this case a non-default
+        value of R can be specified by setting the 'R' key to the desired
+        value.
 
     Returns
     -------
@@ -403,7 +399,7 @@ def geographic_to_cartesian(lon, lat, projparams):
         # check that pyproj is available
         if not _PYPROJ_AVAILABLE:
             raise MissingOptionalDependency(
-                "Basemap is required to use geographic_to_cartesian "
+                "PyProj is required to use geographic_to_cartesian "
                 "with a projection other than pyart_aeqd but it is not "
                 "installed")
         proj = pyproj.Proj(projparams)
@@ -505,9 +501,9 @@ def cartesian_to_geographic(x, y, projparams):
         Projection parameters passed to pyproj.Proj. If this parameter is a
         dictionary with a 'proj' key equal to 'pyart_aeqd' then a azimuthal
         equidistant projection will be used that is native to Py-ART and
-        does not require pyproj/basemap to be installed. In this case a
-        non-default value of R can be specified by setting the 'R' key to the
-        desired value.
+        does not require pyproj to be installed. In this case a non-default
+        value of R can be specified by setting the 'R' key to the desired
+        value.
 
     Returns
     -------
@@ -529,7 +525,7 @@ def cartesian_to_geographic(x, y, projparams):
         # check that pyproj is available
         if not _PYPROJ_AVAILABLE:
             raise MissingOptionalDependency(
-                "Basemap is required to use cartesian_to_geographic "
+                "PyProj is required to use cartesian_to_geographic "
                 "with a projection other than pyart_aeqd but it is not "
                 "installed")
         proj = pyproj.Proj(projparams)
@@ -555,7 +551,7 @@ def cartesian_vectors_to_geographic(x, y, projparams, edges=False):
         Projection parameters passed to pyproj.Proj. If this parameter is a
         dictionary with a 'proj' key equal to 'pyart_aeqd' then a azimuthal
         equidistant projection will be used that is native to Py-ART and
-        does not require pyproj/basemap to be installed. In this case a
+        does not require pyproj to be installed. In this case a
         non-default value of R can be specified by setting the 'R' key to the
         desired value.
     edges : bool, optional

--- a/pyart/core/transforms.py
+++ b/pyart/core/transforms.py
@@ -32,8 +32,6 @@ and antenna (azimuth, elevation, range) coordinate systems.
 
 import warnings
 
-from ..exceptions import MissingOptionalDependency
-
 import numpy as np
 try:
     import pyproj
@@ -41,10 +39,12 @@ try:
 except ImportError:
     _PYPROJ_AVAILABLE = False
 
+from ..exceptions import MissingOptionalDependency
+
 PI = np.pi
 
 
-def antenna_to_cartesian(ranges, azimuths, elevations, debug=False):
+def antenna_to_cartesian(ranges, azimuths, elevations):
     """
     Return Cartesian coordinates from antenna coordinates.
 

--- a/pyart/lazydict.py
+++ b/pyart/lazydict.py
@@ -12,11 +12,16 @@ A dictionary-like class supporting lazy loading of specified keys.
 
 """
 
-import collections
+try:
+    # Python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7, will be removed in next release after Py-ART Impressionism.
+    from collections import MutableMapping
 import itertools
 
 
-class LazyLoadDict(collections.MutableMapping):
+class LazyLoadDict(MutableMapping):
     """
     A dictionary-like class supporting lazy loading of specified keys.
 


### PR DESCRIPTION
I removed basemap from the core modules, which pyproj from basemap is being used in these modules. I set the code to just use proj from pyproj until I integrate cartopy projections into grid.py etc. Also fixed missing import in grid.py of an exception and added a temporary try statement to remove a deprecation warning in lazy_dict.py. The try statement will be removed once we remove python 2.7 support.