### PR TITLE
FIX: CI fix. explicit add of GDAL for py2.7

### DIFF
--- a/continuous_integration/environment-2.7.yml
+++ b/continuous_integration/environment-2.7.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=2.7
+  - gdal
   - numpy
   - scipy
   - matplotlib


### PR DESCRIPTION
Our CI breaks for Python 2.7 at the geotiff creation. This seems due to a dependency and packaging issue with GDAL. Current env seems to pull GDAL from a Cartopy dep. Now we try specifically installing GDAL