### PR TITLE
CI: Added cartopy install to appveyor adapted travis.yml for 3.7 and added 3.7 environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,13 @@ matrix:
       env:
         - PYTHON_VERSION="3.6"
         - PYTEST_ARGS="-v --cov pyart"
-    - python: 3.6
+    - python: 3.7
       env:
-        - PYTHON_VERSION="3.6"
+        - PYTHON_VERSION="3.7"
+        - PYTEST_ARGS="-v --cov pyart"
+    - python: 3.7
+      env:
+        - PYTHON_VERSION="3.7"
         - PYTEST_ARGS="-v --pyargs pyart"
         - FROM_RECIPE="true"
 install: source continuous_integration/install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ install:
   # Install Py-ART dependecies
   - "conda install -y -q -c conda-forge numpy scipy matplotlib netcdf4 pytest pytest-cov cython"
   - "if \"%PYTHON_VERSION%\"==\"2.7\" (conda install -y -q -c conda-forge basemap)"
-
+  - "if \"%PYTHON_VERSION%\"==\"3.5\" (conda install -y -q -c conda-forge cartopy)"
   # Check that we have the expected version and architecture for Python
   # in the conda environment
   - "python --version"

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -1,0 +1,14 @@
+name: testenv
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - numpy
+  - scipy
+  - matplotlib
+  - netcdf4
+  - pytest
+  - trmm_rsl
+  - wradlib
+  - cartopy


### PR DESCRIPTION
New 3.7 environment, does not test basemap, only cartopy. From recipe build is now 3.7 instead of 3.6. Cartopy install added to appveyor.yml.