### PR TITLE
Attempt to grab icao from Nexrad header

### DIFF
--- a/pyart/io/nexrad_archive.py
+++ b/pyart/io/nexrad_archive.py
@@ -138,6 +138,8 @@ def read_nexrad_archive(filename, field_names=None, additional_metadata=None,
     vcp_pattern = nfile.get_vcp_pattern()
     if vcp_pattern is not None:
         metadata['vcp_pattern'] = vcp_pattern
+    if 'icao' in nfile.volume_header.keys():
+        metadata['instrument_name'] = nfile.volume_header['icao'].decode()
 
     # scan_type
     scan_type = 'ppi'


### PR DESCRIPTION
This is a wee fix to grab the icao name from the volume header that exists. I believe it should work for either python2 or 3.

Also, if I followed the keywords correctly, it doesn't appear that [volume_header](https://github.com/ARM-DOE/pyart/blob/master/pyart/io/nexrad_level2.py#L110) or vcp keywords in the `NEXRADLevel2File` object are used?