### PR TITLE
Created  new eaxmple

### DIFF
--- a/examples/plotting/plot_grid_data_overlay.py
+++ b/examples/plotting/plot_grid_data_overlay.py
@@ -23,7 +23,7 @@ import pyart
 # read in the NEXRAD data, create the display
 fname = '20110520100000_nexrad_grid.nc'
 grid = pyart.io.read_grid(fname)
-display = pyart.graph.GridMapDisplay(grid)
+display = pyart.graph.GridMapDisplayBasemap(grid)
 
 # create the figure
 font = {'size': 10}

--- a/examples/plotting/plot_grid_three_panel.py
+++ b/examples/plotting/plot_grid_three_panel.py
@@ -24,7 +24,7 @@ import pyart
 # read in the NEXRAD data, create the display
 fname = '20110520100000_nexrad_grid.nc'
 grid = pyart.io.read_grid(fname)
-display = pyart.graph.GridMapDisplay(grid)
+display = pyart.graph.GridMapDisplayBasemap(grid)
 
 # create the figure
 font = {'size': 16}

--- a/examples/plotting/plot_three_panel_gridmapdisplay.py
+++ b/examples/plotting/plot_three_panel_gridmapdisplay.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-# In[18]:
-
-
 """
 ===========================================
 Create a 3 pannel plot using GridMapDisplay
@@ -16,20 +10,20 @@ and longitude slice using xarray and a cartopy background
 
 print(__doc__)
 
-#Author: Jason Hemedinger
-#License: BSD 3 clause
+# Author: Jason Hemedinger
+# License: BSD 3 clause
 
 import numpy as np
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 import pyart
 
-#Read in the gridded file, create GridMapDisplay object
+# Read in the gridded file, create GridMapDisplay object
 filename = '20110520100000_nexrad_grid.nc'
 radar = pyart.io.read_grid(filename)
 display = pyart.graph.GridMapDisplay(radar)
 
-#Setting projection, figure size, and panel sizes.
+# Setting projection, figure size, and panel sizes.
 projection = ccrs.PlateCarree()
 
 fig = plt.figure(figsize=[15,7])
@@ -38,21 +32,21 @@ map_panel_axes = [0.05, 0.05, .4, .80]
 x_cut_panel_axes = [0.55, 0.10, .4, .25]
 y_cut_panel_axes = [0.55, 0.50, .4, .25]
 
-#Set parameters.
+# Set parameters.
 level = 1
 vmin = -8
 vmax = 64
 lat = 36.5
 lon = -97.7
 
-#Panel 1: PPI plot of the second tilt.
+# Panel 1: PPI plot of the second tilt.
 ax1 = fig.add_axes(map_panel_axes, projection=projection)
 display.plot_grid('REF', 1, vmin=vmin, vmax=vmax,
                   projection=projection,
                   cmap='pyart_HomeyerRainbow')
 display.plot_crosshairs(lon=lon, lat=lat)
 
-#Panel 2: longitude slice
+# Panel 2: longitude slice
 ax2 = fig.add_axes(x_cut_panel_axes)
 display.plot_longitude_slice('REF', lon=lon, lat=lat,
                              vmin=vmin, vmax=vmax,
@@ -71,10 +65,3 @@ ax3.set_xlim([-50, 50])
 
 plt.show()
 plt.close()
-
-
-# In[ ]:
-
-
-
-

--- a/examples/plotting/plot_three_panel_gridmapdisplay.py
+++ b/examples/plotting/plot_three_panel_gridmapdisplay.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# In[18]:
+
+
+"""
+===========================================
+Create a 3 pannel plot using GridMapDisplay
+===========================================
+
+An example that creates a 3 pannel plot of a PPI, latitude slice,
+and longitude slice using xarray and a cartopy background
+
+"""
+
+print(__doc__)
+
+#Author: Jason Hemedinger
+#License: BSD 3 clause
+
+import numpy as np
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import pyart
+
+#Read in the gridded file, create GridMapDisplay object
+filename = '20110520100000_nexrad_grid.nc'
+radar = pyart.io.read_grid(filename)
+display = pyart.graph.GridMapDisplay(radar)
+
+#Setting projection, figure size, and panel sizes.
+projection = ccrs.PlateCarree()
+
+fig = plt.figure(figsize=[15,7])
+
+map_panel_axes = [0.05, 0.05, .4, .80]
+x_cut_panel_axes = [0.55, 0.10, .4, .25]
+y_cut_panel_axes = [0.55, 0.50, .4, .25]
+
+#Set parameters.
+level = 1
+vmin = -8
+vmax = 64
+lat = 36.5
+lon = -97.7
+
+#Panel 1: PPI plot of the second tilt.
+ax1 = fig.add_axes(map_panel_axes, projection=projection)
+display.plot_grid('REF', 1, vmin=vmin, vmax=vmax,
+                  projection=projection,
+                  cmap='pyart_HomeyerRainbow')
+display.plot_crosshairs(lon=lon, lat=lat)
+
+#Panel 2: longitude slice
+ax2 = fig.add_axes(x_cut_panel_axes)
+display.plot_longitude_slice('REF', lon=lon, lat=lat,
+                             vmin=vmin, vmax=vmax,
+                             cmap='pyart_HomeyerRainbow')
+
+ax2.set_ylim([0, 15])
+ax2.set_xlim([-50, 50])
+
+#Panel 3: latitud slice
+ax3 = fig.add_axes(y_cut_panel_axes)
+display.plot_latitude_slice('REF', lon=lon, lat=lat,
+                           vmin=vmin, vmax=vmax,
+                        cmap='pyart_HomeyerRainbow')
+ax3.set_ylim([0, 15])
+ax3.set_xlim([-50, 50])
+
+plt.show()
+plt.close()
+
+
+# In[ ]:
+
+
+
+

--- a/pyart/graph/tests/test_gridmapdisplay_basemap.py
+++ b/pyart/graph/tests/test_gridmapdisplay_basemap.py
@@ -15,7 +15,7 @@ RESOLUTION = 'c'    # crude resolution to speed up tests
 
 @pytest.mark.skipif(not pyart.graph.gridmapdisplay_basemap._BASEMAP_AVAILABLE,
                     reason="Basemap is not installed.")
-def test_gridmapdisplay_simple(outfile=None):
+def test_gridmapdisplay_simple_basemap(outfile=None):
     # test basic GridMapDisplay functionality
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplayBasemap(grid)
@@ -29,7 +29,7 @@ def test_gridmapdisplay_simple(outfile=None):
 
 @pytest.mark.skipif(not pyart.graph.gridmapdisplay_basemap._BASEMAP_AVAILABLE,
                     reason="Basemap is not installed.")
-def test_gridmapdisplay_fancy(outfile=None):
+def test_gridmapdisplay_fancy_basemap(outfile=None):
     # test a bunch of GridMapDisplay functionality
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplayBasemap(grid)
@@ -84,7 +84,7 @@ def test_plot_basemap_not_using_corners(outfile=None):
 
 @pytest.mark.skipif(not pyart.graph.gridmapdisplay_basemap._BASEMAP_AVAILABLE,
                     reason="Basemap is not installed.")
-def test_generate_filename():
+def test_generate_filename_basemap():
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplayBasemap(grid)
     filename = display.generate_filename('reflectivity', 0)
@@ -93,7 +93,7 @@ def test_generate_filename():
 
 @pytest.mark.skipif(not pyart.graph.gridmapdisplay_basemap._BASEMAP_AVAILABLE,
                     reason="Basemap is not installed.")
-def test_generate_titles():
+def test_generate_titles_basemap():
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplayBasemap(grid)
 
@@ -114,7 +114,7 @@ def test_get_basemap():
 
 @pytest.mark.skipif(not pyart.graph.gridmapdisplay_basemap._BASEMAP_AVAILABLE,
                     reason="Basemap is not installed.")
-def test_error_raising():
+def test_error_raising_basemap():
     grid = pyart.testing.make_target_grid()
     display = pyart.graph.GridMapDisplayBasemap(grid)
 
@@ -127,5 +127,5 @@ def test_error_raising():
 
 
 if __name__ == "__main__":
-    test_gridmapdisplay_simple('figure_gridmapdisplay_simple.png')
-    test_gridmapdisplay_fancy('figure_gridmapdisplay_fancy.png')
+    test_gridmapdisplay_simple('figure_gridmapdisplay_simple_basemap.png')
+    test_gridmapdisplay_fancy('figure_gridmapdisplay_fancy_basemap.png')


### PR DESCRIPTION
Created a new example that using the updated GridMapDisplay Class that shows how to set up axes and projection since it uses cartopy instead of basemap. Updated old examples so they use GridMapDisplayBasemap. Updated the unittest for test_gridmapdisplay_basemap and added an _basemap to the functions that needed them so they wouldn't have the same names as those in test_gridmapdisplay.py