### PR TITLE
Fix for reading ECCC ODIM files

### DIFF
--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -335,7 +335,7 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
             sweep_nbins = sweep_data.shape[1]
             fdata[start:start + rays_in_sweep, :sweep_nbins] = sweep_data[:]
             # set data to NaN if its beyond the range of this sweep
-            fdata[start:start + rays_in_sweep, sweep_nbins:max_nbins].data = np.nan
+            fdata[start:start + rays_in_sweep, sweep_nbins:max_nbins] = np.nan
             start += rays_in_sweep
         # create field dictionary
         field_dic = filemetadata(field_name)

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -228,8 +228,10 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
         rscale = [hfile[d]['where'].attrs['rscale'] for d in datasets]
         if any(rscale != rscale[0]):
             raise ValueError('range scale changes between sweeps')
-        nbins = int(hfile['dataset1']['where'].attrs['nbins'])
-        _range['data'] = (np.arange(nbins, dtype='float32') * rscale[0] +
+        all_sweeps_nbins = [hfile[d]['where'].attrs['nbins'] for d in datasets]
+        # check for max range off all sweeps
+        max_nbins = max(all_sweeps_nbins)
+        _range['data'] = (np.arange(max_nbins, dtype='float32') * rscale[0] +
                           rstart[0] * 1000.)
         _range['meters_to_center_of_first_gate'] = rstart[0] * 1000.
         _range['meters_between_gates'] = float(rscale[0])
@@ -325,13 +327,15 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
         field_name = filemetadata.get_field_name(_to_str(odim_field))
         if field_name is None:
             continue
-        fdata = np.ma.zeros((total_rays, nbins), dtype='float32')
+        fdata = np.ma.zeros((total_rays, max_nbins), dtype='float32')
         start = 0
         # loop over the sweeps, copy data into correct location in data array
         for dset, rays_in_sweep in zip(datasets, rays_per_sweep):
             sweep_data = _get_odim_h5_sweep_data(hfile[dset][h_field_key])
             sweep_nbins = sweep_data.shape[1]
             fdata[start:start + rays_in_sweep, :sweep_nbins] = sweep_data[:]
+            # mask data if its beyond the range of this sweep
+            fdata[start:start + rays_in_sweep, sweep_nbins:max_nbins].mask = np.ma.masked
             start += rays_in_sweep
         # create field dictionary
         field_dic = filemetadata(field_name)

--- a/pyart/aux_io/odim_h5.py
+++ b/pyart/aux_io/odim_h5.py
@@ -334,8 +334,8 @@ def read_odim_h5(filename, field_names=None, additional_metadata=None,
             sweep_data = _get_odim_h5_sweep_data(hfile[dset][h_field_key])
             sweep_nbins = sweep_data.shape[1]
             fdata[start:start + rays_in_sweep, :sweep_nbins] = sweep_data[:]
-            # mask data if its beyond the range of this sweep
-            fdata[start:start + rays_in_sweep, sweep_nbins:max_nbins].mask = np.ma.masked
+            # set data to NaN if its beyond the range of this sweep
+            fdata[start:start + rays_in_sweep, sweep_nbins:max_nbins].data = np.nan
             start += rays_in_sweep
         # create field dictionary
         field_dic = filemetadata(field_name)


### PR DESCRIPTION
Current ODIM reader assumes the number of bins between sweeps is constant, as long as range start and scale are constant between sweeps. This doesn't hold true for new data from ECCC S-Band radars, range can be variable between sweeps. Proposed fix checks all sweeps for the `nbins` attribute, and finds the max.  Axis 1 of the numpy array for field data `fdata` is set to `max_nbins` rather than just `nbins` read from the first sweep. If a sweep has less bins than the max, these are set to `NaN`s. File is attached for testing.
[2018050823_12_ODIMH5_PVOL6S_VOL_CASRA.h5.zip](https://github.com/ARM-DOE/pyart/files/3122169/2018050823_12_ODIMH5_PVOL6S_VOL_CASRA.h5.zip)

