### PR TITLE
FIX: A fix for a bug in grid io which had dimensions out of order.

### DIFF
--- a/pyart/io/grid_io.py
+++ b/pyart/io/grid_io.py
@@ -297,9 +297,9 @@ def write_grid(filename, grid, format='NETCDF4',
 
     # optionally write point_ variables
     if write_point_x_y_z:
-        _create_ncvar(grid.point_x, dset, 'point_x', ('z', 'x', 'y'))
-        _create_ncvar(grid.point_y, dset, 'point_y', ('z', 'x', 'y'))
-        _create_ncvar(grid.point_z, dset, 'point_z', ('z', 'x', 'y'))
+        _create_ncvar(grid.point_x, dset, 'point_x', ('z', 'y', 'x'))
+        _create_ncvar(grid.point_y, dset, 'point_y', ('z', 'y', 'x'))
+        _create_ncvar(grid.point_z, dset, 'point_z', ('z', 'y', 'x'))
     if write_point_lon_lat_alt:
         dims = ('z', 'y', 'x')
         _create_ncvar(grid.point_latitude, dset, 'point_latitude', dims)


### PR DESCRIPTION
In write point function, the z, y, x dimensions were flipped which was
different then the original data. NetCDF4 new broadcasted_shape function
caught this.