### PR TITLE
MAINT: Temp fix for warnings in colormap modules.

### DIFF
--- a/pyart/graph/cm.py
+++ b/pyart/graph/cm.py
@@ -61,6 +61,7 @@ colormaps are available within matplotlib with names 'pyart_COLORMAP':
 # Copyright (c) 2012-2013 Matplotlib Development Team; All Rights Reserved
 
 from __future__ import print_function, division
+import warnings
 
 import matplotlib as mpl
 import matplotlib.colors as colors
@@ -100,14 +101,15 @@ def revcmap(data):
 def _reverse_cmap_spec(spec):
     """Reverses cmap specification *spec*, can handle both dict and tuple
     type specs."""
-
-    if 'red' in spec:
-        return revcmap(spec)
-    else:
-        revspec = list(reversed(spec))
-        if len(revspec[0]) == 2:    # e.g., (1, (1.0, 0.0, 1.0))
-            revspec = [(1.0 - a, b) for a, b in revspec]
-        return revspec
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        if 'red' in spec:
+            return revcmap(spec)
+        else:
+            revspec = list(reversed(spec))
+            if len(revspec[0]) == 2:    # e.g., (1, (1.0, 0.0, 1.0))
+                revspec = [(1.0 - a, b) for a, b in revspec]
+            return revspec
 
 
 def _generate_cmap(name, lutsize):

--- a/pyart/graph/cm_colorblind.py
+++ b/pyart/graph/cm_colorblind.py
@@ -15,6 +15,8 @@ colormaps are available within matplotlib with names pyart_COLORMAP':
     * HomeyerRainbow
 """
 
+import warnings
+
 import matplotlib as mpl
 import matplotlib.colors as colors
 
@@ -23,16 +25,17 @@ from ._cm_colorblind import datad, yuv_rainbow_24
 
 
 def _generate_cmap(name, lutsize):
-    """Generates the requested cmap from it's name *name*.  The lut size is
+    """Generates the requested cmap from it's name *name*. The lut size is
     *lutsize*."""
 
     spec = datad[name]
-
     # Generate the colormap object.
-    if 'red' in spec:
-        return colors.LinearSegmentedColormap(name, spec, lutsize)
-    else:
-        return colors.LinearSegmentedColormap.from_list(name, spec, lutsize)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        if 'red' in spec:
+            return colors.LinearSegmentedColormap(name, spec, lutsize)
+        else:
+            return colors.LinearSegmentedColormap.from_list(name, spec, lutsize)
 
 cmap_d = dict()
 


### PR DESCRIPTION
From what I'm reading, there is some disagreement between numpy and python on comparisons. For now I added a ignore warning until I can find maybe a better solution.