### PR TITLE
CI: Removing basemap as dependency in unit tests, support ends soon 2020, fails CI with 2.7.

### DIFF
--- a/continuous_integration/environment-2.7.yml
+++ b/continuous_integration/environment-2.7.yml
@@ -9,7 +9,6 @@ dependencies:
   - matplotlib
   - netcdf4
   - pytest
-  - basemap
   - trmm_rsl
   - wradlib
   - cartopy

--- a/continuous_integration/environment-3.6.yml
+++ b/continuous_integration/environment-3.6.yml
@@ -9,7 +9,6 @@ dependencies:
   - matplotlib
   - netcdf4
   - pytest
-  - basemap
   - trmm_rsl
   - wradlib
   - cartopy

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -10,7 +10,6 @@ dependencies:
   - matplotlib
   - netcdf4
   - pytest
-  - basemap
   - trmm_rsl
   - wradlib
   - cartopy


### PR DESCRIPTION
Basemap plotting code will still exist in pyart, but there will be no support for it. 