### PR TITLE
MNT: New warnings on literals, and a fix for said warnings.

### DIFF
--- a/pyart/aux_io/kazr_spectra.py
+++ b/pyart/aux_io/kazr_spectra.py
@@ -185,7 +185,7 @@ def _get_spectra(xrobj, time):
                                 len(xrobj.speclength.values)))
     the_spectra_locs[np.isnan(the_spectra_locs)] = -9999.0
     for i, locs in enumerate(the_spectra_locs):
-        if locs is not -9999.0:
+        if locs != -9999.0:
             the_spectra_loc[i, :] = xrobj.spectra.values[int(locs), :]
         else:
             the_spectra_loc[i, :] = np.nan*np.ones(len(

--- a/pyart/correct/phase_proc.py
+++ b/pyart/correct/phase_proc.py
@@ -491,7 +491,7 @@ def get_phidp_unf(radar, ncp_lev=0.4, rhohv_lev=0.6, debug=False, ncpts=20,
             # print x_ma.mask
             c = 1  # also do nothing
             x_ma.mask = True
-        if 'nowrap' is not None:
+        if nowrap is not None:
             # Start the unfolding a bit later in order to avoid false
             # jumps based on clutter
             unwrapped = copy.deepcopy(x_ma)
@@ -1428,7 +1428,7 @@ def get_phidp_unf_gf(radar, gatefilter, debug=False, ncpts=2, sys_phase=None,
         except AttributeError:
             c = 1  # also do nothing
             x_ma.mask = True
-        if 'nowrap' is not None:
+        if nowrap is not None:
             # Start the unfolding a bit later in order to avoid false
             # jumps based on clutter
             unwrapped = copy.deepcopy(x_ma)


### PR DESCRIPTION
The parameter nowrap wasn't being used correctly and in kazr spectra 'is not' should not have been used for checking a float.