### PR TITLE
FIX: A fix for reversed ngates and nrays.

### DIFF
--- a/doc/source/notebooks/basic_ingest_using_test_radar_object.ipynb
+++ b/doc/source/notebooks/basic_ingest_using_test_radar_object.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "radar = pyart.testing.make_empty_ppi_radar(400, 667, 1)"
+    "radar = pyart.testing.make_empty_ppi_radar(667, 400, 1)"
    ]
   },
   {
@@ -674,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A fix for #916 the nrays and ngates in make_empty_ppi_radar were reversed. I fixed the revered inputs, the rest of the notebook should be fine as when the data for range and azimuth are populated they overwrite the incorrect numbers, but this fixes the incorrect empty object.