### PR TITLE
FIX: Elevation Angle for some products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .pydevproject
 *.rej
 .settings/
+.spyproject
 .*.sw[nop]
 .sw[nop]
 *.tmp

--- a/pyart/io/nexrad_level3.py
+++ b/pyart/io/nexrad_level3.py
@@ -191,7 +191,10 @@ class NEXRADLevel3File(object):
     def get_elevation(self):
         """ Return the sweep elevation angle in degrees. """
         hw30 = self.prod_descr['halfwords_30']
-        elevation = struct.unpack('>h', hw30)[0] * 0.1
+        if self.msg_header['code'] in ELEVATION_ANGLE:
+            elevation = struct.unpack('>h', hw30)[0] * 0.1
+        else:
+            elevation = None
         return elevation
 
     def get_volume_start_datetime(self):
@@ -347,6 +350,10 @@ def _int16_to_float16(val):
 
 
 _8_OR_16_LEVELS = [19, 20, 25, 27, 28, 30, 56, 78, 79, 80, 169, 171, 181]
+
+# List of product numbers for which Halfword 30 corresponds to sweep elev angle
+# Per Table V of the ICD
+ELEVATION_ANGLE = [19, 20, 25, 27, 28, 30, 56, 94, 99, 159, 161, 163, 165]
 
 PRODUCT_RANGE_RESOLUTION = {
     19: 1.,     # 124 nm

--- a/pyart/io/nexradl3_read.py
+++ b/pyart/io/nexradl3_read.py
@@ -136,8 +136,12 @@ def read_nexrad_level3(filename, field_names=None, additional_metadata=None,
     fixed_angle = filemetadata('fixed_angle')
     azimuth['data'] = nfile.get_azimuth()
     elev = nfile.get_elevation()
-    elevation['data'] = np.ones((nradials, ), dtype='float32') * elev
-    fixed_angle['data'] = np.array([elev], dtype='float32')
+    if elev is not None:
+        elevation['data'] = np.ones((nradials, ), dtype='float32') * elev
+        fixed_angle['data'] = np.array([elev], dtype='float32')
+    else:
+        elevation['data'] = None
+        fixed_angle['data'] = None
 
     nfile.close()
     return Radar(


### PR DESCRIPTION
Many Nexrad Level 3 files have elevation angle defined by Halfword 30 of the product description block, but not all. (Elevation angle is not relevant for all products.)

Added a list of products for which elevation angle is defined by Halfword 30 per Table V of the ICD. For products for which it is not defined added logic to return data as None.