### PR TITLE
ADD: Nexrad Level 3 Product Version Checking

### DIFF
--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -831,6 +831,8 @@ nexrad_level3_metadata = {
                     '80: Big Drops (rain) (BD), '
                     '90: Graupel (GR), '
                     '100: Hail, possibly with rain (HA), '
+                    '110: Large Hail (LH), '
+                    '120: Giant Hail (GH), '
                     '140: Unknown Classification (UK), '
                     '150: Range Folded (RH)'),
         'coordinates': 'elevation azimuth range'},

--- a/pyart/io/nexrad_level3.py
+++ b/pyart/io/nexrad_level3.py
@@ -13,6 +13,15 @@ Class for reading data from NEXRAD Level 3 files.
 # below is followed.  Keeping the above comment lines would also be helpful
 # to direct other back to the Py-ART project and the source of this file.
 
+# -----
+# This file has been last updated to include basic functionality for:
+# "INTERFACE CONTROL DOCUMENT FOR THE RPG TO CLASS 1 USER"
+# RPG Build 18.0
+# Document Number 2620001X
+# Build Date 18 January 2018
+# Future builds may require updates to this file.
+# -----
+
 
 LICENSE = """
 Copyright (c) 2013, UChicago Argonne, LLC
@@ -59,6 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import bz2
 from datetime import datetime, timedelta
 import struct
+import warnings
 
 import numpy as np
 
@@ -120,6 +130,14 @@ class NEXRADLevel3File(object):
         # Read and decode 102 byte Product Description Block
         self.prod_descr = _unpack_from_buf(buf, bpos, PRODUCT_DESCRIPTION)
         bpos += 102
+
+        # Check product version number
+        ver = self.prod_descr['version']
+        supp_ver = SUPPORTED_VERSION_NUMBERS[self.msg_header['code']]
+        if ver > supp_ver:
+            warnings.warn('Radar product version is %d. Py-ART implementation \
+            supports max version of %d. Most recent product version has not \
+            yet been implemented/tested.' % (ver,supp_ver), UserWarning)
 
         # uncompressed symbology block if necessary
         if buf[bpos:bpos+2] == b'BZ':
@@ -327,7 +345,7 @@ def nexrad_level3_message_code(filename):
 
 
 # NEXRAD Level III file structures, sizes, and static data
-# The deails on these structures are documented in:
+# The details on these structures are documented in:
 # "INTERFACE CONTROL DOCUMENT FOR THE RPG TO CLASS 1 USER" RPG Build 13.0
 # Document Number 2620001T
 # Tables and page number refer to those in this document.
@@ -383,6 +401,42 @@ PRODUCT_RANGE_RESOLUTION = {
     186: 300.,
 }
 
+# Per "Products with Version Numbers" table in ICD
+SUPPORTED_VERSION_NUMBERS = {
+    19: 0,
+    20: 0,
+    25: 0,
+    27: 0,
+    28: 0,
+    30: 0,
+    32: 2,
+    34: 2,
+    56: 0,
+    78: 1,
+    79: 1,
+    80: 1,
+    94: 0,
+    99: 0,
+    134: 1,
+    135: 0,
+    138: 2,
+    159: 0,
+    161: 0,
+    163: 0,
+    165: 1,
+    169: 0,
+    170: 0,
+    171: 0,
+    172: 1,
+    173: 0,
+    174: 0,
+    175: 0,
+    176: 0,
+    177: 0,
+    181: 0,
+    182: 0,
+    186: 0,
+}
 
 # format of structure elements
 # Figure E-1, page E-1


### PR DESCRIPTION
While I was combing through the ICD I realized there's a version number for each product included in the product description block that should be a good way to check that the product hasn't changed to a new version that is not supported by Pyart. If it has it issues a warning which hopefully should cause someone to take a look at the most recent ICD and verify there are no major changes.

I used the product version numbers in the table on pages 3-35 and 3-36 of the ICD FOR THE RPG TO CLASS 1 USER - Build 18.0.

I did not add version checking for the metadata parts that come before each product's data. I think there's a potential for these to change from build to build in a way that could break something, but also a greater potential to result in annoying warnings for no reason.

The good news is version numbers don't seem to change often. I compared Build 18 to Build 13, which is what this was originally based on, and found that they only increased the version number for products 165 and 172. Both were relatively minor. I checked that the new files uploaded successfully and they did. I couldn't find the parameters the ICD mentions that have changed for 172; I assume Pyart doesn't parse these. For 165 I added the Large Hail and Giant Hail classifications for user interpretation of the classification codes.