### PR TITLE
Fix in filter_psidp in case of scalar mask

### DIFF
--- a/pyart/retrieve/kdp_proc.py
+++ b/pyart/retrieve/kdp_proc.py
@@ -1033,6 +1033,8 @@ def filter_psidp(radar, psidp_field=None, rhohv_field=None, minsize_seq=5,
     psidp_o = radar.fields[psidp_field]['data']
     rhohv = radar.fields[rhohv_field]['data']
 
+    if np.isscalar(psidp_o.mask): # Ensure 2D mask
+        psidp_o.mask = np.zeros((psidp_o.shape)) + psidp_o.mask
     if not isinstance(psidp_o, np.ma.masked_array):
         psidp_o = np.ma.array(psidp_o, mask=np.isnan(psidp_o))
 


### PR DESCRIPTION
I noticed that when writing a netCDF using write_cfradial for example, in the case a pyart field has a mask with all False (i.e. no masked values), it gets "compressed" to a single scalar boolean False. Parts of the Kdp processing codes couldn't handle that properly and assumed the mask to always be 2D. This fixes this particular case.
