### PR TITLE
FIX: add_gate_area now returns only positive values

### DIFF
--- a/pyart/core/radar.py
+++ b/pyart/core/radar.py
@@ -526,7 +526,7 @@ class Radar(object):
 
         dca, daz = np.meshgrid(annular_area,d_azimuths)
 
-        area = dca * daz
+        area = np.abs(dca * daz)
         return area
 
     def get_gate_lat_lon_alt(self, sweep, reset_gate_coords=False,


### PR DESCRIPTION
Take absolute value of gate area to avoid returning negative areas. This covers cases where azimuth is decreasing instead of increasing. Thanks to John Krause for the suggestion.