### PR TITLE
Change default weighting function to Barnes2 

### DIFF
--- a/examples/mapping/plot_map_one_radar_to_grid.py
+++ b/examples/mapping/plot_map_one_radar_to_grid.py
@@ -20,7 +20,7 @@ import pyart
 RADAR_FILE = '110635.mdv'
 radar = pyart.io.read_mdv(RADAR_FILE)
 
-# mask out last 10 gates of each ray, this removes the "ring" around th radar.
+# mask out last 10 gates of each ray, this removes the "ring" around the radar.
 radar.fields['reflectivity']['data'][:, -10:] = np.ma.masked
 
 # exclude masked gates from the gridding

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -303,7 +303,7 @@ def read_cfradial(filename, field_names=None, additional_metadata=None,
     if radar_calibration == {}:
         radar_calibration = None
 
-    # do not close file is field loading is delayed
+    # do not close file if field loading is delayed
     if not delay_field_loading:
         ncobj.close()
     return Radar(

--- a/pyart/map/gates_to_grid.py
+++ b/pyart/map/gates_to_grid.py
@@ -19,7 +19,7 @@ def map_gates_to_grid(
         radars, grid_shape, grid_limits, grid_origin=None,
         grid_origin_alt=None, grid_projection=None,
         fields=None, gatefilters=False, map_roi=True,
-        weighting_function='Barnes', toa=17000.0, roi_func='dist_beam',
+        weighting_function='Barnes2', toa=17000.0, roi_func='dist_beam',
         constant_roi=None, z_factor=0.05, xy_factor=0.02, min_radius=500.0,
         h_factor=1.0, nb=1.5, bsp=1.0, **kwargs):
     """

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -257,7 +257,7 @@ class NNLocator:
 def map_to_grid(radars, grid_shape, grid_limits, grid_origin=None,
                 grid_origin_alt=None, grid_projection=None,
                 fields=None, gatefilters=False,
-                map_roi=True, weighting_function='Barnes', toa=17000.0,
+                map_roi=True, weighting_function='Barnes2', toa=17000.0,
                 copy_field_data=True, algorithm='kd_tree', leafsize=10.,
                 roi_func='dist_beam', constant_roi=None,
                 z_factor=0.05, xy_factor=0.02, min_radius=500.0,


### PR DESCRIPTION
`pyart.map.map_gates_to_grid` and `pyart.map.map_to_grid` emit deprecation warning that Barnes weighting function is deprecated, and suggest using Barnes 2. 

I propose changing the default weighting function to Barnes 2 in those two functions. Therefore less experienced PyART users will not be confused which function they should use. Advanced users still can change the function manually by kwargs. 

This PR also includes a few typo corrections in the documentation.