### PR TITLE
Add check if radars tuple is not empty

### DIFF
--- a/pyart/map/gates_to_grid.py
+++ b/pyart/map/gates_to_grid.py
@@ -72,6 +72,9 @@ def map_gates_to_grid(
     if isinstance(radars, Radar):
         radars = (radars, )
 
+    if len(radars) == 0:
+        raise ValueError('Length of radars tuple cannot be zero')
+
     skip_transform = False
     if len(radars) == 1 and grid_origin_alt is None and grid_origin is None:
         skip_transform = True

--- a/pyart/map/grid_mapper.py
+++ b/pyart/map/grid_mapper.py
@@ -77,6 +77,9 @@ def grid_from_radars(radars, grid_shape, grid_limits,
     if isinstance(radars, Radar):
         radars = (radars, )
 
+    if len(radars) == 0:
+        raise ValueError('Length of radars tuple cannot be zero')
+
     # map the radar(s) to a cartesian grid
     if gridding_algo == 'map_to_grid':
         grids = map_to_grid(radars, grid_shape, grid_limits, **kwargs)


### PR DESCRIPTION
In some edge cases (in my case when radars tuple is created in a loop) the empty tuple can be passed to the `gates_to _grid` or `map_to_grid` functions. In that case`tuple index out of range` error occures when `radars[0].altitude['data']` is acessed, and it is not always obvious what is the cause of that error.

I propose to add a simple check if `radars` tuple length is equal to 0. If yes then ValueError exception is raised with a more meaningful error message indicating what the issue is.
The placement of that `if` statement is just after conversion of single `Radar` object into `radars` tuple, so that tuple length can be checked without worring about edge cases. 
In this solution also length of `gatefilters` tuple is implicitly checked as `gatefilters` must have the same length as `radars`. 