### PR TITLE
ENH: Default scan_rate to target_scan_rate

### DIFF
--- a/pyart/aux_io/gamic_hdf5.py
+++ b/pyart/aux_io/gamic_hdf5.py
@@ -236,20 +236,21 @@ def read_gamic(filename, field_names=None, additional_metadata=None,
 
     # scan_rate
     scan_rate = filemetadata('scan_rate')
+    scan_rate['data'] = target_scan_rate['data']
     if scan_type == 'ppi':
         azs_names = ['az_speed', 'azimuth_speed']
         azs_name = azs_names[0]
         for azs_name in azs_names:
             if gfile.is_field_in_ray_header(azs_name):
+                scan_rate['data'] = gfile.ray_header(azs_name, 'float32')
                 break
-        scan_rate['data'] = gfile.ray_header(azs_name, 'float32')
     elif scan_type == 'rhi':
         els_names = ['el_speed', 'elevation_speed']
         els_name = els_names[0]
         for els_name in els_names:
             if gfile.is_field_in_ray_header(els_name):
+                scan_rate['data'] = gfile.ray_header(els_name, 'float32')
                 break
-        scan_rate['data'] = gfile.ray_header(els_name, 'float32')
     else:
         scan_rate = None
 


### PR DESCRIPTION
GAMIC's volume doesn't mandate the real scan_rate to be stored,
so we initialize scan_rate to the same value as the target_scan_rate.