### PR TITLE
ENH: Support for Sigmet PMI, LOG, CSP

### DIFF
--- a/pyart/default_config.py
+++ b/pyart/default_config.py
@@ -977,6 +977,12 @@ sigmet_field_mapping = {
     'UNKNOWN_64': None,                         # Unknown field
     'UNKNOWN_65': None,                         # Unknown field
     'UNKNOWN_66': None,                         # Unknown field
+    'PMI8': None,                               # (75) Polarimetric Meteo Index
+    'PMI16': None,                              # (76) Polarimetric Meteo Index
+    'LOG8': None,                               # (77) Log receiver SNR
+    'LOG16': None,                              # (78) Log receiver SNR
+    'CSP8': None,                               # (77) Doppler channel clutter power
+    'CSP16': None,                              # (78) Doppler channel clutter power
     # there may be more field, add as needed
 }
 

--- a/pyart/io/_sigmetfile.pyx
+++ b/pyart/io/_sigmetfile.pyx
@@ -533,13 +533,13 @@ SIGMET_DATA_TYPES = {
     72: 'DBTE16',       # Total Power Enhanced
     73: 'DBZE8',
     74: 'DBZE16',       # Clutter Corrected Reflectivity Enhanced
+    75: 'PMI8',
+    76: 'PMI16',
+    77: 'LOG8',
+    78: 'LOG16',
+    79: 'CSP8',
+    80: 'CSP16',
     # Uknown fields, do not know internal names, some may be user defined.
-    75: 'UNKNOWN_75',
-    76: 'UNKNOWN_76',
-    77: 'UNKNOWN_77',
-    78: 'UNKNOWN_78',
-    79: 'UNKNOWN_79',
-    80: 'UNKNOWN_80',
     81: 'UNKNOWN_81',
     82: 'UNKNOWN_82',
     83: 'UNKNOWN_83',
@@ -616,6 +616,8 @@ def convert_sigmet_data(data_type, data, nbins):
         'SNR16',    # Signal to noise ratio, 2-byte
         'DBTE16',   # Total Power Enhanced, 2-byte
         'DBZE16',   # Clutter corrected reflectivity enhanced, 2-byte
+        'LOG16',    # Log receiver signal-to-noise ratio (dB), 2-byte
+        'CSP16',    # Doppler channel clutter power ratio of dBT to -dBZ, 2-byte
     ]
 
     like_sqi = [
@@ -623,6 +625,7 @@ def convert_sigmet_data(data_type, data, nbins):
         'RHOV',     # " "
         'RHOHV',    # 1-byte RhoHV Format, section 4.3.23
         'SQI',      # 1-byte Signal Quality Index Format, section 4.3.26
+        'PMI8',      # 1-byte Polarimetric Meteo Index, section 4.4.28
     ]
 
     like_sqi2 = [
@@ -630,6 +633,7 @@ def convert_sigmet_data(data_type, data, nbins):
         'RHOH2',    # " "
         'RHOHV2',   # 2-byte RhoHV Format, section 4.3.24
         'SQI2',     # 2-byte Signal Quality Index Format, section 4.3.27
+        'PMI16',    # 2-byte Polarimetric Meteo Index, section 4.4.29
     ]
 
     like_dbt = [
@@ -640,6 +644,8 @@ def convert_sigmet_data(data_type, data, nbins):
         'SNR8',     # Signal to noise ratio, 1-byte
         'DBTE8',    # Total power enhanced, 1-byte
         'DBZE8',    # Clutter corrected reflectivity enhanced, 1-byte
+        'LOG8',     # Log receiver signal-to-noise ratio (dB), 1-byte
+        'CSP8',     # Doppler channel clutter power ratio of dBT to -dBZ, 1-byte
     ]
 
     if data_type_name in like_dbt2:


### PR DESCRIPTION
Hi! I added support for reading PMI, LOG and CSP data types from Sigmet files for personal use and thought that they might useful for others as well, so here's a pull request! 

I did not add the `_sigmetfile.c` changes here, since running cython seemed to add some numpy version changes or something, and I was not sure which changes were actually related to this pull request. But if I should also add that file, I'll be happy to do so!

These data types are listed in the 2021 version of the IRIS Programming guide, so the section numbers in the comments refer to that. 