### PR TITLE
Change which directory docs are in

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,5 +52,5 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: doc/build/dirhtml
+          publish_dir: doc/build/html
           cname: https://arm-doe.github.io/pyart/


### PR DESCRIPTION
The docs page is currently blank - it was looking for `dirhtml` instead of `html` this fixes that issue