### PR TITLE
MNT: Removing pandas import and converters.

### DIFF
--- a/pyart/graph/radardisplay.py
+++ b/pyart/graph/radardisplay.py
@@ -10,8 +10,6 @@ from matplotlib.dates import DateFormatter
 import numpy as np
 import netCDF4
 from scipy.interpolate import griddata
-from pandas.plotting import register_matplotlib_converters
-register_matplotlib_converters()
 
 from . import common
 from ..core.transforms import antenna_to_cartesian


### PR DESCRIPTION
Was a temp fix for np.datetime64 for python3.8, removing this no longer should be an issue and or required.