### PR TITLE
Update examples data link to adc

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,3 +1,3 @@
 The files used in these examples are available for download_.
 
-.. _download: https://engineering.arm.gov/~jhelmus/pyart_example_data/
+.. _download: https://adc.arm.gov/pyart/example_data/


### PR DESCRIPTION
Closes #1028 

This **should** be the last place in the docs that we need to change the link for