### PR TITLE
MNT: Fix for setup.py registry file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ def configuration(parent_package='', top_path=None):
 
     config.add_subpackage('pyart')
     config.add_data_files(('pyart', '*.txt'))
+    config.add_data_files('pyart/testing/registry.txt')
 
     return config
 


### PR DESCRIPTION
Fix for missing registry path. Conda forge and pypi are working correctly, was missing from github repo downloads.