### PR TITLE
Rename Gatemapper Example to Execute

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6
   - gdal
   - numpy
-  - scipy
+  - scipy>=1.8
   - matplotlib
   - pandas
   - netcdf4

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.6
   - gdal
   - numpy
   - scipy>=1.7

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.6
   - gdal
   - numpy
-  - scipy>=1.8
+  - scipy>=1.7
   - matplotlib
   - pandas
   - netcdf4

--- a/examples/mapping/plot_compare_two_radars_gatemapper.py
+++ b/examples/mapping/plot_compare_two_radars_gatemapper.py
@@ -43,7 +43,7 @@ radar_se = pyart.io.read_cfradial(xsapr_se_file)
 # adequate match), using the tol variable.
 
 gatefilter = pyart.filters.GateFilter(radar_sw)
-gatefilter.exclude_below('reflectivity_horizontal', 0)
+gatefilter.exclude_below('reflectivity_horizontal', 20)
 gmapper = pyart.map.GateMapper(radar_sw,
                                radar_se,
                                tol=500.,
@@ -87,8 +87,6 @@ disp2.plot_ppi_map('reflectivity_horizontal',
                    lat_lines=np.arange(36, 37.25, .25),
                    lon_lines=np.arange(-98, -96.75, .25))
 
-plt.show()
-
 ######################################
 # Now, we can compare our original field from the southwestern radar,
 # to the new remapped field - there are similarities...
@@ -124,8 +122,6 @@ disp2.plot_ppi_map('reflectivity_horizontal',
                    max_lon=-97,
                    lat_lines=np.arange(36, 37.25, .25),
                    lon_lines=np.arange(-98, -96.75, .25))
-
-plt.show()
 
 ######################################
 # **Calculate and Plot the Difference**
@@ -168,7 +164,6 @@ disp1.plot_ppi_map('reflectivity_bias',
                    lat_lines=np.arange(36, 37.25, .25),
                    lon_lines=np.arange(-98, -96.75, .25))
 
-plt.show()
 
 ######################################
 # **Plot a Histogram for Comparison**
@@ -190,6 +185,9 @@ bins = np.arange(-10, 60, 1)
 # Create the 2D histogram using the flattened numpy arrays
 hist = np.histogram2d(refl_se.flatten(), refl_sw.flatten(), bins=bins)[0]
 hist = np.ma.masked_where(hist == 0, hist)
+
+# Setup our figure
+fig = plt.figure(figsize=(8, 6))
 
 # Create a 1-1 comparison
 x, y = np.meshgrid((bins[:-1] + bins[1:])/2., (bins[:-1] + bins[1:])/2.)

--- a/examples/mapping/plot_compare_two_radars_gatemapper.py
+++ b/examples/mapping/plot_compare_two_radars_gatemapper.py
@@ -15,7 +15,6 @@ print(__doc__)
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
-import sys
 import warnings
 
 import pyart
@@ -42,9 +41,6 @@ radar_se = pyart.io.read_cfradial(xsapr_se_file)
 # We also need to set a tolerance distance (difference in meters
 # between the source and destination gate allowed for an
 # adequate match), using the tol variable.
-
-# Make sure to set this for the kdtree algorithm used with Gatemapper
-sys.setrecursionlimit(10000)
 
 gatefilter = pyart.filters.GateFilter(radar_sw)
 gatefilter.exclude_below('reflectivity_horizontal', 20)

--- a/examples/mapping/plot_compare_two_radars_gatemapper.py
+++ b/examples/mapping/plot_compare_two_radars_gatemapper.py
@@ -15,6 +15,7 @@ print(__doc__)
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
+import sys
 import warnings
 
 import pyart
@@ -41,6 +42,9 @@ radar_se = pyart.io.read_cfradial(xsapr_se_file)
 # We also need to set a tolerance distance (difference in meters
 # between the source and destination gate allowed for an
 # adequate match), using the tol variable.
+
+# Make sure to set this for the kdtree algorithm used with Gatemapper
+sys.setrecursionlimit(10000)
 
 gatefilter = pyart.filters.GateFilter(radar_sw)
 gatefilter.exclude_below('reflectivity_horizontal', 20)


### PR DESCRIPTION
Currently, the GateMapper example is not executing, which is leading to figures not being created. This renames that file, and adds a more restrictive reflectivity filter.