### PR TITLE
ADD: Time tolerance to GateMapper

### DIFF
--- a/examples/mapping/plot_compare_two_radars_gatemapper.py
+++ b/examples/mapping/plot_compare_two_radars_gatemapper.py
@@ -38,15 +38,16 @@ radar_se = pyart.io.read_cfradial(xsapr_se_file)
 # We are interested in mapping the southwestern radar to the
 # southeastern radar. Before running our gatemapper, we add a
 # filter for only positive reflectivity values.
-# We also need to set a tolerance distance (difference in meters
+# We also need to set a distance (meters) and time (seconds)
 # between the source and destination gate allowed for an
-# adequate match), using the tol variable.
+# adequate match), using the distance_tolerance/time_tolerance variables.
 
 gatefilter = pyart.filters.GateFilter(radar_sw)
 gatefilter.exclude_below('reflectivity_horizontal', 20)
 gmapper = pyart.map.GateMapper(radar_sw,
                                radar_se,
-                               tol=500.,
+                               distance_tolerance=500.,
+                               time_tolerance=60,
                                gatefilter_src=gatefilter)
 radar_sw_mapped_to_radar_se = gmapper.mapped_radar(['reflectivity_horizontal'])
 

--- a/pyart/map/gate_mapper.py
+++ b/pyart/map/gate_mapper.py
@@ -50,32 +50,43 @@ class GateMapper(object):
         The gatefilter to apply to the source radar data before mapping
     tol: float
         The difference in meters between the source and destination gate allowed for an adequate match.
+    time_tol: float
+        The difference in time between the source and destination radar rays.
     """
     def __init__(self, src_radar: Radar, dest_radar: Radar, tol=500.,
-                 gatefilter_src=None):
+                 gatefilter_src=None, time_tol=60.):
         gate_x = dest_radar.gate_x['data']
         gate_y = dest_radar.gate_y['data']
         gate_z = dest_radar.gate_altitude['data']
-        proj_dict = {'proj': 'pyart_aeqd', 'lon_0': dest_radar.longitude["data"],
+        proj_dict = {'proj': 'pyart_aeqd',
+                     'lon_0': dest_radar.longitude["data"],
                      'lat_0': dest_radar.latitude["data"]}
         self.src_radar_x, self.src_radar_y = geographic_to_cartesian(
             src_radar.longitude["data"], src_radar.latitude["data"],
             proj_dict)
-        data = np.stack([gate_x.flatten(), gate_y.flatten(), gate_z.flatten()], axis=1)
+        data = np.stack(
+            [gate_x.flatten(), gate_y.flatten(), gate_z.flatten()], axis=1)
         self._kdtree = KDTree(data)
         self.dest_radar = dest_radar
         self.src_radar = src_radar
+        self.src_radar_time = np.tile(src_radar.time["data"],
+                                      (1, src_radar.ngates)).flatten()
+        self.dest_radar_time = np.tile(dest_radar.time["data"],
+                                       (1, dest_radar.ngates)).flatten()
         if gatefilter_src is None:
             self.gatefilter_src = pyart.filters.GateFilter(self.src_radar)
             self.gatefilter_src.exclude_none()
         else:
             self.gatefilter_src = gatefilter_src
-
+        self._time_tolerance = time_tol
+        self._tolerance = tol
+        self.time_tolerance = time_tol
         self.tolerance = tol
 
     def __getitem__(self, key: tuple):
         """ Return the equivalent index in the destination radar's coordinates"""
-        x = (int(self._index_map[key[0], key[1], 0]), int(self._index_map[key[0], key[1], 1]))
+        x = (int(self._index_map[key[0], key[1], 0]),
+             int(self._index_map[key[0], key[1], 1]))
         if x[0] > 0:
             return x
         else:
@@ -92,6 +103,33 @@ class GateMapper(object):
             The current tolerance of the GateMapper in meters.
         """
         return self._tolerance
+
+    @property
+    def time_tolerance(self):
+        """
+        Getter for tolerance property of GateMapper class.
+
+        Returns
+        -------
+        time_tolerance: float
+            The current time tolerance of the GateMapper in meters.
+        """
+        return self._time_tolerance
+
+    @time_tolerance.setter
+    def time_tolerance(self, tol):
+        """
+        Setter for the time_tolerance property of GateMapper class. This will
+        also reset the mapping function inside GateMapper so that no additional
+        calls are needed to reset the tolerance.
+
+        Parameters
+        ----------
+        tol: float
+            The new tolerance of the GateMapper in meters.
+        """
+        self._time_tolerance = tol
+        self.tolerance = self._tolerance
 
     @tolerance.setter
     def tolerance(self, tol):
@@ -112,8 +150,12 @@ class GateMapper(object):
                                self.src_radar.gate_y["data"].flatten() + self.src_radar_y,
                                self.src_radar.gate_altitude["data"].flatten()], axis=1)
         dists, inds = self._kdtree.query(new_points, distance_upper_bound=tol)
-        inds = np.where(np.abs(dists) < tol, inds[:], -32767).astype(int)
+        inds[inds == len(self.dest_radar_time)] = inds[inds == len(self.dest_radar_time)] - 1
+        times = np.abs(self.src_radar_time - self.dest_radar_time[inds])
+        inds = np.where(np.logical_and(
+            times < self._time_tolerance, np.abs(dists) < tol), inds[:], -32767).astype(int)
         inds = np.reshape(inds, self.src_radar.gate_x["data"].shape)
+
         self._index_map[:, :, 0] = (inds / self.dest_radar.gate_x["data"].shape[1]).astype(int)
         self._index_map[:, :, 1] = (
                 inds - self.dest_radar.gate_x["data"].shape[1] *
@@ -142,9 +184,11 @@ class GateMapper(object):
 
         src_fields = {}
         for field in field_list:
-            mapped_radar.fields[field]['data'] = np.ma.masked_where(True, mapped_radar.fields[field]['data'])
+            mapped_radar.fields[field]['data'] = np.ma.masked_where(
+                True, mapped_radar.fields[field]['data'])
             src_fields[field] = np.ma.masked_where(
-                    self.gatefilter_src.gate_excluded, self.src_radar.fields[field]['data'])
+                    self.gatefilter_src.gate_excluded,
+                    self.src_radar.fields[field]['data'])
 
         for i in range(self.src_radar.nrays):
             for j in range(self.src_radar.ngates):

--- a/pyart/map/tests/test_gatemapper.py
+++ b/pyart/map/tests/test_gatemapper.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from copy import deepcopy
 
+
 def test_gatemapper():
     # Make fake radar with target
     old_radar = pyart.testing.make_target_radar()
@@ -11,10 +12,14 @@ def test_gatemapper():
     new_radar.longitude["data"] = old_radar.longitude["data"] + 0.001
     gate_mapper = pyart.map.GateMapper(new_radar, old_radar)
     mapped_radar = gate_mapper.mapped_radar(['reflectivity'])
-    assert gate_mapper[20, 20] == (25, 27)
+
+    # Test point outside of 1 min tolerance
+    assert gate_mapper[20, 20] == (None, None)
+    assert gate_mapper[4, 4] == (26, 11)
     assert mapped_radar.fields[
-        'reflectivity']['data'][25, 27] == old_radar.fields[
-                'reflectivity']['data'][20, 20]
+        'reflectivity']['data'][26, 11] == old_radar.fields[
+                'reflectivity']['data'][4, 4]
+
 
 def test_gatemapper_gatefilter():
     # Make fake radar with target
@@ -27,5 +32,5 @@ def test_gatemapper_gatefilter():
     gate_mapper = pyart.map.GateMapper(new_radar, old_radar,
                                        gatefilter_src=gatefilter)
     mapped_radar = gate_mapper.mapped_radar(['reflectivity'])
-    assert gate_mapper[20, 20] == (25, 27)
-    assert np.ma.is_masked(mapped_radar.fields['reflectivity']['data'][25, 27])
+    assert gate_mapper[4, 4] == (26, 11)
+    assert np.ma.is_masked(mapped_radar.fields['reflectivity']['data'][26, 11])


### PR DESCRIPTION
Added a time tolerance to the GateMapper function. Now you can exclude points that are out of synchronization when doing gate to gate comparisons.