### PR TITLE
DOC: Update to readme and contributors guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,10 @@ To update an older version of Py-ART to the latest release use::
 
     conda update -c conda-forge arm_pyart
 
+If you are using mamba::
+
+    mamba install arm_pyart
+
 If you do not wish to use Anaconda or Miniconda as a Python environment or want
 to use the latest, unreleased version of Py-ART see the section below on 
 **Installing from source**.
@@ -143,23 +147,27 @@ Other related open source software for working with weather radar data:
   
 * `BALTRAD <https://baltrad.eu/>`_ : Community-based weather radar networking.
 
-* `MMM-Py <https://github.com/nasa/MMM-Py>`_ : 
+* `MMM-Py <https://github.com/nasa/MMM-Py>`_ :
   Marshall MRMS Mosaic Python Toolkit.
 
-* `CSU_RadarTools <https://github.com/CSU-Radarmet/CSU_RadarTools>`_ : 
+* `CSU_RadarTools <https://github.com/CSU-Radarmet/CSU_RadarTools>`_ :
   Colorado State University Radar Tools.
 
 * `TRMM RSL <https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/>`_ :
   TRMM Radar Software Library.
 
-* `RadX <https://www.ral.ucar.edu/projects/titan/docs/radial_formats/radx.html>`_: 
+* `RadX <https://www.ral.ucar.edu/projects/titan/docs/radial_formats/radx.html>`_ :
   Radx C++ Software Package for Radial Radar Data.
+
+* `PyDDA <https://openradarscience.org/PyDDA/>`_ :
+  Software designed to retrieve wind kinematics in precipitation storm systems
+  from one or more Doppler weather radars.
 
 
 Dependencies
 ============
 
-Py-ART is tested to work under Python 3.6, 3.7 and 3.8
+Py-ART is tested to work under Python 3.6, 3.7, 3.8, 3.9 and 3.10
 
 The required dependencies to install Py-ART in addition to Python are:
 
@@ -167,6 +175,9 @@ The required dependencies to install Py-ART in addition to Python are:
 * `SciPy <https://www.scipy.org>`_
 * `matplotlib <https://matplotlib.org/>`_
 * `netCDF4 <https://github.com/Unidata/netcdf4-python>`_
+* `pooch <https://pypi.org/project/pooch/>`_
+* `Cython <https://cython.readthedocs.io/en/latest/>`_
+* `setuptools <https://setuptools.pypa.io/en/latest/index.html>`_
 
 A working C/C++ compiler is required for some optional modules. An easy method
 to install these dependencies is by using a 
@@ -249,6 +260,10 @@ To install for all users on Unix/Linux::
 
     python setup.py build
     sudo python setup.py install
+
+Development install using pip from within Py-ART directory::
+
+    pip install -e .
 
 
 Development

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ To update an older version of Py-ART to the latest release use::
 
 If you are using mamba::
 
-    mamba install arm_pyart
+    mamba install -c conda-forge arm_pyart
 
 If you do not wish to use Anaconda or Miniconda as a Python environment or want
 to use the latest, unreleased version of Py-ART see the section below on 

--- a/guides/contributors_guide.rst
+++ b/guides/contributors_guide.rst
@@ -60,6 +60,9 @@ To update an older version of Py-ART to the latest release use::
 
     conda update -c conda-forge arm_pyart
 
+If you are using mamba::
+
+    mamba install arm_pyart
 
 Resources
 ---------
@@ -70,6 +73,7 @@ Pyart:
 - https://github.com/EVS-ATMOS/pyart_short_course
 - https://www.youtube.com/watch?v=diiP-Q3bKZw
 - https://arm-doe.github.io/pyart/examples/
+- https://arm-doe.github.io/pyart/blog.html
 
 Git:
 
@@ -245,7 +249,7 @@ produces the same values. It works that, it takes known values that are
 obtained from the function, and when pytest is ran, it takes the test
 function and reruns the function and compares the results to the original.
 
-An example:
+An example continuing to use the VAD code above:
 
 .. code-block:: python
 
@@ -408,14 +412,18 @@ After fetching, a git merge is needed to pull in the changes.
 
 This is done by::
 
-        git merge upstream/master
+        git merge upstream/main
 
 To prevent a merge commit::
 
-        git merge --ff-only upstream/master
+        git merge --ff-only upstream/main
 
-After creating a pull request through GitHub, two outside checkers,
-Appveyor and TravisCI will determine if the code past all checks. If the
-code fails either tests, as the pull request sits, make changes to fix the
-code and when pushed to GitHub, the pull request will automatically update
-and TravisCI and Appveyor will automatically rerun.
+After creating a pull request through GitHub, GitHub Actions will determine
+if the code past all checks for multiple Python versions as well as Operating
+Systems. If the code fails either tests, as the pull request sits, we will
+provide guidance to make changes to fix the code. Once the code is fixed and
+committed to GitHub, GitHub Actions will automatically rerun. A documentation
+build will also run to update Py-ART's documentation with the new changes.
+Code coverage will also provided statistics if your new code is properly
+unit tested. PEP8 check will also run with changes to fix to keep the code
+to PEP8 standards.

--- a/guides/contributors_guide.rst
+++ b/guides/contributors_guide.rst
@@ -62,7 +62,7 @@ To update an older version of Py-ART to the latest release use::
 
 If you are using mamba::
 
-    mamba install arm_pyart
+    mamba install -c conda-forge arm_pyart
 
 Resources
 ---------


### PR DESCRIPTION
Removes reference of travis and appveyor. Adds new python support and mention of mamba. Closes #1105.