### PR TITLE
add verbose flag to qvp code

### DIFF
--- a/pyart/retrieve/qvp.py
+++ b/pyart/retrieve/qvp.py
@@ -27,7 +27,6 @@ def quasi_vertical_profile(radar, desired_angle=None, fields=None, gatefilter=No
         None will result in wanted_angle = 20.0
     verbose : bool
         boolean flag to turn the printing of radar tilts on or off. 
-        Can be very annoying if you process alot of files. 
 
     Other Parameters
     ----------------

--- a/pyart/retrieve/qvp.py
+++ b/pyart/retrieve/qvp.py
@@ -8,7 +8,7 @@ import numpy as np
 from ..core.transforms import antenna_to_cartesian
 
 
-def quasi_vertical_profile(radar, desired_angle=None, fields=None, gatefilter=None):
+def quasi_vertical_profile(radar, desired_angle=None, fields=None, gatefilter=None,verbose=False):
 
     """
     Quasi Vertical Profile.
@@ -25,6 +25,9 @@ def quasi_vertical_profile(radar, desired_angle=None, fields=None, gatefilter=No
     desired_angle : float
         Radar tilt angle to use for indexing radar field data.
         None will result in wanted_angle = 20.0
+    verbose : bool
+        boolean flag to turn the printing of radar tilts on or off. 
+        Can be very annoying if you process alot of files. 
 
     Other Parameters
     ----------------
@@ -63,9 +66,10 @@ def quasi_vertical_profile(radar, desired_angle=None, fields=None, gatefilter=No
     index = abs(radar.fixed_angle['data'] - desired_angle).argmin()
     radar_slice = radar.get_slice(index)
 
-    # Printing radar tilt angles and radar elevation
-    print(radar.fixed_angle['data'])
-    print(radar.elevation['data'][-1])
+    if verbose:
+        # Printing radar tilt angles and radar elevation
+        print(radar.fixed_angle['data'])
+        print(radar.elevation['data'][-1])
 
     # Setting field parameters
     # If fields is None then all radar fields pulled else defined field is used


### PR DESCRIPTION
While seeing all available radar tilts for each file is useful, I think it is unnecessary to have it print out every single time. So I have added a bool to the input where you can turn that print statement on-off, but default it is off. Feel free to switch it to default on. I just wanted control to turn it off so my progress bar worked properly. 