### PR TITLE
ENH: Use fsspec for io in pyart.io.common to read both local and remote files

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -18,6 +18,7 @@ dependencies:
   - flake8
   - pytest
   - Cython
+  - fsspec
   - pip
   - pip:
     - pooch

--- a/pyart/io/common.py
+++ b/pyart/io/common.py
@@ -8,6 +8,7 @@ import gzip
 
 import numpy as np
 import netCDF4
+import fsspec
 
 
 def prepare_for_read(filename):
@@ -34,7 +35,7 @@ def prepare_for_read(filename):
         return filename
 
     # look for compressed data by examining the first few bytes
-    fh = open(filename, 'rb')
+    fh = fsspec.open(filename, 'rb').open()
     magic = fh.read(3)
     fh.close()
 
@@ -44,7 +45,7 @@ def prepare_for_read(filename):
     if magic.startswith(b'BZh'):
         return bz2.BZ2File(filename, 'rb')
 
-    return open(filename, 'rb')
+    return fsspec.open(filename, 'rb').open()
 
 
 def stringarray_to_chararray(arr, numchars=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pooch
 cftime
 Cython
 versioneer
+fsspec


### PR DESCRIPTION
This allows the user to read data both from the local filesystem, and remote sources (ex. AWS), moving the `pyart.io.common` open file module to use `fsspec` instead of the default Python `open`