### PR TITLE
FIX: remove macos arm builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [macOS, ubuntu, Windows]
-        include:
-          - os: macos-latest
-            PLAT: arm64
-            INTERFACE64: ""
-            platform: [x64]
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Our nightly builds are failing due to GitHub being unable to find the right macOS arm chip builds - this removes that system from our CI