### PR TITLE
MNT: Mispelling of embelish

### DIFF
--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -89,8 +89,8 @@ class GridMapDisplay(object):
                   colorbar_label=None, colorbar_orient='vertical',
                   ax=None, fig=None, lat_lines=None,
                   lon_lines=None, projection=None,
-                  embelish=True, ticks=None, ticklabs=None,
-                  imshow=False, **kwargs):
+                  embellish=True, ticks=None, ticklabs=None,
+            w=False, **kwargs):
         """
         Plot the grid using xarray and cartopy.
 
@@ -151,7 +151,7 @@ class GridMapDisplay(object):
         projection : cartopy.crs class
             Map projection supported by cartopy. Used for all subsequent calls
             to the GeoAxes object generated. Defaults to PlateCarree.
-        emblish : bool
+        embellish : bool
             True by default. Set to False to supress drawinf of coastlines
             etc... Use for speedup when specifying shapefiles.
             Note that lat lon labels only work with certain projections.
@@ -233,7 +233,7 @@ class GridMapDisplay(object):
         self.mappables.append(pm)
         self.fields.append(field)
 
-        if embelish:
+        if embellish:
             # Create a feature for States/Admin 1 regions at 1:50m
             # from Natural Earth
             states = self.cartopy_states()

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -90,7 +90,7 @@ class GridMapDisplay(object):
                   ax=None, fig=None, lat_lines=None,
                   lon_lines=None, projection=None,
                   embellish=True, ticks=None, ticklabs=None,
-            w=False, **kwargs):
+                  imshow=False, **kwargs):
         """
         Plot the grid using xarray and cartopy.
 

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -114,7 +114,7 @@ class RadarMapDisplay(RadarDisplay):
             width=None, height=None, lon_0=None, lat_0=None,
             resolution='110m', shapefile=None, shapefile_kwargs=None,
             edges=True, gatefilter=None,
-            filter_transitions=True, embelish=True, raster=False,
+            filter_transitions=True, embellish=True, raster=False,
             ticks=None, ticklabs=None, alpha=None, edgecolors='face', **kwargs):
         """
         Plot a PPI volume sweep onto a geographic map.
@@ -210,7 +210,7 @@ class RadarMapDisplay(RadarDisplay):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             not plotted.
-        embelish: bool
+        embellish: bool
             True by default. Set to False to supress drawing of coastlines
             etc.. Use for speedup when specifying shapefiles.
             Note that lat lon labels only work with certain projections.
@@ -303,7 +303,7 @@ class RadarMapDisplay(RadarDisplay):
             pm.set_rasterized(True)
 
         # add embelishments
-        if embelish is True:
+        if embellish is True:
             # Create a feature for States/Admin 1 regions at 1:resolution
             # from Natural Earth
             states_provinces = cartopy.feature.NaturalEarthFeature(

--- a/pyart/graph/radarmapdisplay_basemap.py
+++ b/pyart/graph/radarmapdisplay_basemap.py
@@ -104,7 +104,7 @@ class RadarMapDisplayBasemap(RadarDisplay):
             min_lon=None, max_lon=None, min_lat=None, max_lat=None,
             width=None, height=None, lon_0=None, lat_0=None,
             resolution='h', shapefile=None, edges=True, gatefilter=None,
-            basemap=None, filter_transitions=True, embelish=True,
+            basemap=None, filter_transitions=True, embellish=True,
             ticks=None, ticklabs=None, raster=False, alpha=None,
             edgecolors='face', **kwargs):
         """
@@ -208,7 +208,7 @@ class RadarMapDisplayBasemap(RadarDisplay):
             coordinates themselved as the gate edges, resulting in a plot
             in which the last gate in each ray and the entire last ray are not
             not plotted.
-        embelish: bool
+        embellish: bool
             True by default. Set to false to supress drawing of coastlines
             etc.. Use for speedup when specifying shapefiles.
         basemap: Basemap instance
@@ -280,7 +280,7 @@ class RadarMapDisplayBasemap(RadarDisplay):
                 'The cylindrical equidistant projection is not supported')
 
         # add embelishments
-        if embelish is True:
+        if embellish is True:
             basemap.drawcoastlines(linewidth=1.25)
             basemap.drawstates()
             basemap.drawparallels(

--- a/pyart/graph/tests/test_radarmapdisplay.py
+++ b/pyart/graph/tests/test_radarmapdisplay.py
@@ -41,7 +41,7 @@ def test_radarmapdisplay_cartopy_preexisting_ax(outfile=None):
     fig = plt.figure()
     ax = plt.axes(projection=cartopy.crs.PlateCarree())
     ax.add_image(Stamen('terrain-background'), 6)
-    display.plot_ppi_map('reflectivity_horizontal', 0, ax=ax, embelish=False)
+    display.plot_ppi_map('reflectivity_horizontal', 0, ax=ax, embellish=False)
     if outfile:
         fig.savefig(outfile)
     plt.close()


### PR DESCRIPTION
Pointed out by David Wolff embellish was mispelled, this is a fix for that.