### PR TITLE
Update ARM name to remove climate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ The Python ARM Radar Toolkit, Py-ART, is an open source Python module
 containing a growing collection of weather radar algorithms and utilities
 build on top of the Scientific Python stack and distributed under the
 3-Clause BSD license. Py-ART is used by the 
-`Atmospheric Radiation Measurement (ARM) Climate Research Facility 
+`Atmospheric Radiation Measurement (ARM) User Facility 
 <http://www.arm.gov>`_ for working with data from a number of precipitation
 and cloud radars, but has been designed so that it can be used by others in
 the radar and atmospheric communities to examine, processes, and analyze


### PR DESCRIPTION
Currently, we refer to the ARM Climate Research Facility, which should be the updated ARM name - "ARM User Facility"