### PR TITLE
FiX: add pinned version of numpy

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - gdal
-  - numpy
+  - numpy<1.23.0
   - scipy
   - matplotlib
   - netcdf4

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - gdal
-  - numpy
+  - numpy<1.23.0
   - scipy
   - matplotlib
   - pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<1.23.0
 scipy
 netCDF4
 matplotlib


### PR DESCRIPTION
It looks like the CI is failing with the new release of numpy, specifically when working with cftime... trying this as a fix