### PR TITLE
MNT: Added warning catch for axes.

### DIFF
--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -202,7 +202,9 @@ class GridMapDisplay(object):
                         + " Overridding defined axes and using default "
                         + "axes with projection Mercator.",
                         UserWarning)
-                ax = plt.axes(projection=projection)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore")
+                    ax = plt.axes(projection=projection)
 
         # Define GeoAxes if None is provided.
         else:
@@ -215,7 +217,9 @@ class GridMapDisplay(object):
                     + " Overridding defined axes and using default "
                     + "axes with projection Mercator.",
                     UserWarning)
-            ax = plt.axes(projection=projection)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                ax = plt.axes(projection=projection)
 
         # plot the grid using xarray
         if norm is not None: # if norm is set do not override with vmin/vmax

--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -267,7 +267,9 @@ class RadarMapDisplay(RadarDisplay):
                         + " Overridding defined axes and using default "
                         + "axes with projection Lambert Conformal.",
                         UserWarning)
-                ax = plt.axes(projection=projection)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore")
+                    ax = plt.axes(projection=projection)
 
         # Define GeoAxes if None is provided.
         else:
@@ -281,7 +283,9 @@ class RadarMapDisplay(RadarDisplay):
                     + " Overridding defined axes and using default "
                     + "axes with projection Lambert Conformal.",
                     UserWarning)
-            ax = plt.axes(projection=projection)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")    
+                ax = plt.axes(projection=projection)
 
         if min_lon:
             ax.set_extent([min_lon, max_lon, min_lat, max_lat],


### PR DESCRIPTION
Catches matplotlib warnings for axes overwrite. Overwriting is done as axes doesn't generate as expected. Suppresses warning until matplotlib creates new axes instance.