### PR TITLE
FIX: Str for warning of coefficient band used was wrong.

### DIFF
--- a/pyart/retrieve/qpe.py
+++ b/pyart/retrieve/qpe.py
@@ -572,7 +572,7 @@ def _get_coeff_rkdp(freq):
 
     warn('Radar frequency out of range. '
          + 'Coefficients only applied to S, C or X band. '
-         + freq_band + ' band coefficients will be used.')
+         + freq_band_aux + ' band coefficients will be used.')
 
     return coeff_rkdp_dict[freq_band_aux]
 
@@ -629,7 +629,7 @@ def _get_coeff_ra(freq):
 
     warn('Radar frequency out of range. '
          + 'Coefficients only applied to S, C or X band. '
-         + freq_band + ' band coefficients will be used.')
+         + freq_band_aux + ' band coefficients will be used.')
 
     return coeff_ra_dict[freq_band_aux]
 


### PR DESCRIPTION
The variable used in the warning was wrong, as NoneType errors were being created, freq_band_aux was the correct variable.