### PR TITLE
FIX: Fix link to cookbooks in user guide

### DIFF
--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -2,7 +2,7 @@
 User Guide
 ==========
 
-We recommend checking out the `Radar Cookbook https://cookbooks.projectpythia.org/radar-cookbook/README.html>`_ to get started!
+We recommend checking out the `Radar Cookbook <https://cookbooks.projectpythia.org/radar-cookbook/README.html>`_ to get started!
 
 We also have a collection of installation, and contribution instructions listed below.
 


### PR DESCRIPTION
Fix the link to the cookbooks - currently, it's not rendering the link correctly due to a missing `<` symbol