### PR TITLE
FIX: update join_radar to also append instrument parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ The Python ARM Radar Toolkit (Py-ART)
 
 |GithubCI| |CodeCovStatus|
 
-|AnacondaCloud| |CondaDownloads|
+|AnacondaCloud| |PyPiDownloads| |CondaDownloads|
 
 |DocsUsers| |DocsGuides|
 
@@ -18,6 +18,9 @@ The Python ARM Radar Toolkit (Py-ART)
 
 .. |AnacondaCloud| image:: https://anaconda.org/conda-forge/arm_pyart/badges/version.svg
     :target: https://anaconda.org/conda-forge/arm_pyart
+
+.. |PyPiDownloads| image:: https://img.shields.io/pypi/dm/arm_pyart.svg
+    :target: https://pypi.org/project/arm-pyart/
 
 .. |CondaDownloads| image:: https://anaconda.org/conda-forge/arm_pyart/badges/downloads.svg
     :target: https://anaconda.org/conda-forge/arm_pyart/files

--- a/pyart/util/radar_utils.py
+++ b/pyart/util/radar_utils.py
@@ -198,7 +198,7 @@ def join_radar(radar1, radar2):
             new_field[sh1[0]:, 0:sh2[1]] = radar2.fields[var]['data']
             new_radar.fields[var]['data'] = new_field
         else:
-            warn("Field "+var+" not present in both radars")
+            print("Field "+var+" not present in both radars")
             fields_to_remove.append(var)
 
     if fields_to_remove:

--- a/pyart/util/tests/test_radar_utils.py
+++ b/pyart/util/tests/test_radar_utils.py
@@ -10,6 +10,24 @@ def test_is_vpt():
     pyart.util.to_vpt(radar)
     assert pyart.util.is_vpt(radar)
 
+def test_join_radar():
+    radar1 = pyart.testing.make_empty_ppi_radar(10, 36, 3)
+    radar1.instrument_parameters = {
+        'nyquist_velocity': {'data': np.array([6] * 3)}
+    }
+    field = {'data': np.ones((36 * 3, 10))}
+    radar1.add_field('f1', field)
+    radar1.add_field('f2', field)
+    radar2 = pyart.testing.make_empty_ppi_radar(10, 36, 4)
+    radar2.instrument_parameters = {
+        'nyquist_velocity': {'data': np.array([8] * 4)}
+    }
+    field = {'data': np.ones((36 * 4, 10))}
+    radar2.add_field('f1', field)
+
+    radar3 = pyart.util.join_radar(radar1, radar2)
+    assert 'f1' in radar3.fields
+    assert len(radar3.instrument_parameters['nyquist_velocity']['data']) == 7
 
 def test_to_vpt():
     # single scan


### PR DESCRIPTION
Hi dear Py-ART team,

The join_radar function in Py-ART has the problem that it does not merge instrument parameters. This is an issue for certain functions for example _dealias_region_based_, which expects a nyquist_velocity value for every sweep. I think there is currently no way to use this function on a multi sweep scan obtained with join_radar. In our MeteoSwiss version we use the function in this PR, which also merges the most important instrument parameters and is able to merge radar objects which have different variables (by merging only the variables that they have in common).
The code below for example fails for me with the current Py-ART version with error

_nyquist_vel = [radar.get_nyquist_vel(i, check_uniform) for i in 
return(nyq_vel[0])
TypeError: only size-1 arrays can be converted to Python scalars_

 but works with this fix.  
````

for i,f in enumerate(files):
    radar =  pyart.io.read_cfradial(f)
    if i == 0:
        mradar = radar
    else:
        mradar = pyart.util.join_radar(mradar, radar)
    
    
wind = pyart.correct.dealias_region_based(mradar, ref_vel_field = 'velocity')

````
Cheers,
Daniel