### PR TITLE
Remove pinning for specific cftime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 netCDF4
 matplotlib
 pooch
-cftime>=1.6.0
+cftime
 Cython
 fsspec
 s3fs


### PR DESCRIPTION
Remove the restrictive cftime version since they released 1.6.1 and removed the previous 1.6.0 version