### PR TITLE
fix writing IRIS sigmet files to UF

### DIFF
--- a/pyart/io/uf_write.py
+++ b/pyart/io/uf_write.py
@@ -247,6 +247,10 @@ class UFRayCreator(object):
         range_start = self.radar.range['meters_to_center_of_first_gate']
         range_start -= (range_step / 2.)  # range bin center to edge
         range_start_km, range_start_m = divmod(range_start, 1000)
+        if isinstance(range_start_m, np.ndarray):
+            range_start_m = range_start_m[0]
+        if isinstance(range_step, np.ndarray):
+            range_step = range_step[0]
         header['range_start_km'] = int(range_start_km)
         header['range_start_m'] = int(round(range_start_m))
         header['range_spacing_m'] = int(round(range_step))


### PR DESCRIPTION
When a radar object originally read in from sigmet file generated by IRIS is written to UF using `pyart.io.write_uf`, the range_start_m and range_step vars are single-object arrays. When these are subsequently rounded to integers by `round()`, the arrays give a traceback.

I fixed this by checking to see if these values were arrays, and if so, accessing the first value of these arrays. There may be a better implementation for fixing this, I'm not sure. I've attached an example IRIS sigmet file here (unzip the file first): [ADR220322013706.zip](https://github.com/ARM-DOE/pyart/files/9172328/ADR220322013706.zip)