### PR TITLE
FIX: join_radar also joins pulse repititon times iparam

### DIFF
--- a/pyart/util/radar_utils.py
+++ b/pyart/util/radar_utils.py
@@ -160,6 +160,11 @@ def join_radar(radar1, radar2):
                 np.append(
                     radar1.instrument_parameters['number_of_pulses']['data'],
                     radar2.instrument_parameters['number_of_pulses']['data']))
+        if 'prt' in new_radar.instrument_parameters:
+            new_radar.instrument_parameters['prt']['data'] = (
+                np.append(
+                    radar1.instrument_parameters['prt']['data'],
+                    radar2.instrument_parameters['prt']['data']))
 
     if ((radar1.ray_angle_res is not None) and
             (radar2.ray_angle_res is not None)):


### PR DESCRIPTION
In the current version of py-ART, joining two radar files using `pyart.util.join_radar(rdr1, rdr2)` produces a radar object that contains PRT data only from `rdr1`. 

This commit appends the PRT data from `rdr2`

This is necessary because if the joined radar object is then exported to universal format using `pyart.io.write_uf`, the rays from the second radar object don't have PRT data, causing an out-of-bounds array traceback.