### PR TITLE
FIX: Add if check for which org running pyart build docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy-website:
     runs-on: macos-latest
+    if: github.repository == 'ARM-DOE/pyart'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install PyART
         env:
           RSL_PATH: ${{ env.MAMBA_ROOT_PREFIX }}/pkgs/trmm_rsl-1.49-hac89ed1_5
+        shell: bash -l {0}
         run: |
           python -m pip install -e . --no-deps --force-reinstall
       # Build the website

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -51,6 +51,7 @@ jobs:
           RSL_PATH: ${{ env.MAMBA_ROOT_PREFIX }}/pkgs/trmm_rsl-1.49-hac89ed1_5
         run: |
           cd doc
+          make clean
           make html
       # Push the book's HTML to github-pages
       - name: GitHub Pages action

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -44,7 +44,7 @@ jobs:
           RSL_PATH: ${{ env.MAMBA_ROOT_PREFIX }}/pkgs/trmm_rsl-1.49-hac89ed1_5
         shell: bash -l {0}
         run: |
-          python -m pip install -e . --no-deps --force-reinstall
+          pip install -e . --no-deps --force-reinstall
       # Build the website
       - name: Build the site
         env:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           RSL_PATH: ${{ env.MAMBA_ROOT_PREFIX }}/pkgs/trmm_rsl-1.49-hac89ed1_5
         run: |
-          pip install -e .
+          python -m pip install -e . --no-deps --force-reinstall
       # Build the website
       - name: Build the site
         env:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,8 +22,7 @@ import re
 import sys
 
 
-cwd = Path.cwd().resolve()
-sys.path.insert(0, str(cwd))
+sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- General configuration ------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -60,7 +60,7 @@ exclude_patterns = ['_build', '**.ipynb_checkpoints']
 extensions.append('sphinx_gallery.gen_gallery')
 sphinx_gallery_conf = {
     'examples_dirs': '../../examples',
-    'gallery_dirs': 'examples'
+    'gallery_dirs': './examples'
 }
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,9 +16,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+from pathlib import Path
+import re
+import sys
+
+
+cwd = Path.cwd().resolve()
+sys.path.insert(0, str(cwd))
+sys.path.insert(0, str(cwd.parent.parent))
 
 
 # -- General configuration ------------------------------------------------
@@ -30,9 +36,6 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-import os
-import re
-import sys
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -101,7 +104,7 @@ author = 'Py-ART developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
-# built documents.
+# built documents.h
 #
 import pyart
 # The short X.Y version (including the .devXXXX suffix if present)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,9 @@ import re
 import sys
 
 
-# sys.path.insert(0, os.path.abspath('../..'))
+cwd = Path.cwd().resolve()
+sys.path.insert(0, str(cwd))
+sys.path.insert(0, str(cwd.parent.parent.parent))
 
 
 # -- General configuration ------------------------------------------------
@@ -59,7 +61,7 @@ exclude_patterns = ['_build', '**.ipynb_checkpoints']
 # only include examples if the BUILD_PYART_EXAMPLES env. variable is set
 extensions.append('sphinx_gallery.gen_gallery')
 sphinx_gallery_conf = {
-    'examples_dirs': '../../examples',
+    'examples_dirs': str(cwd.parent.parent / 'examples'),
     'gallery_dirs': './examples'
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ import re
 import sys
 
 
-sys.path.insert(0, os.path.abspath('../..'))
+# sys.path.insert(0, os.path.abspath('../..'))
 
 
 # -- General configuration ------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,7 +24,6 @@ import sys
 
 cwd = Path.cwd().resolve()
 sys.path.insert(0, str(cwd))
-sys.path.insert(0, str(cwd.parent.parent))
 
 
 # -- General configuration ------------------------------------------------

--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -58,30 +58,40 @@ except DistributionNotFound:
     # package is not installed
     __version__ = '0.0.0'
 
+
 try:
-    if _sys.version_info[:2] >= (3, 4):
-        import importlib as _importlib
-        specs = _importlib.util.find_spec('pytest')
-        specs.loader.load_module()
-    else:
-        import imp as _imp
-        _imp.find_module('pytest')
-except (AttributeError, ImportError) as error:
-    def _test(verbose=False):
-        """
-        This would invoke the Py-ART test suite, but pytest couldn't
-        be imported so the test suite can not run.
-        """
-        raise ImportError("Could not load pytest. Unit tests not available."
-                            " To run unit tests, please install pytest.")
-else:
-    def _test(verbose=False):
-        """
-        Invoke the Py-ART test suite.
-        """
-        import pytest
-        pkg_dir = _osp.abspath(_osp.dirname(__file__))
-        args = [pkg_dir, '--pyargs', 'pyart']
-        if verbose:
-            args.extend(['-v', '-s'])
-        pytest.main(args=args)
+     if _sys.version_info[:2] >= (3, 4):
+         import importlib as _importlib
+         specs = _importlib.util.find_spec('pytest')
+         specs.loader.load_module()
+     else:
+         import imp as _imp
+         _imp.find_module('pytest')
+ except (AttributeError, ImportError) as error:
+     def _test(verbose=False):
+         """
+         This would invoke the Py-ART test suite, but pytest couldn't
+         be imported so the test suite can not run.
+         """
+         raise ImportError("Could not load pytest. Unit tests not available."
+                             " To run unit tests, please install pytest.")
+ else:
+     def _test(verbose=False):
+         """
+         Invoke the Py-ART test suite.
+         """
+         import pytest
+         pkg_dir = _osp.abspath(_osp.dirname(__file__))
+         args = [pkg_dir, '--pyargs', 'pyart']
+         if verbose:
+             args.extend(['-v', '-s'])
+         pytest.main(args=args)
+
+ # Do not use `test` as function name as this leads to a recursion problem
+ # with the pytest test suite.
+ #test = _test
+ #test_verbose = _functools.partial(test, verbose=True)
+ #test_verbose.__doc__ = test.__doc_
+
+ #vdict = get_version()
+ #__version__ = vdict['version']_

--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -62,7 +62,7 @@ try:
     if _sys.version_info[:2] >= (3, 4):
         import importlib as _importlib
         specs = _importlib.util.find_spec('pytest')
-        specs.loader.exec_module()
+        specs.loader.load_module()
     else:
         import imp as _imp
         _imp.find_module('pytest')

--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -57,3 +57,31 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = '0.0.0'
+
+try:
+    if _sys.version_info[:2] >= (3, 4):
+        import importlib as _importlib
+        specs = _importlib.util.find_spec('pytest')
+        specs.loader.exec_module()
+    else:
+        import imp as _imp
+        _imp.find_module('pytest')
+except (AttributeError, ImportError) as error:
+    def _test(verbose=False):
+        """
+        This would invoke the Py-ART test suite, but pytest couldn't
+        be imported so the test suite can not run.
+        """
+        raise ImportError("Could not load pytest. Unit tests not available."
+                            " To run unit tests, please install pytest.")
+else:
+    def _test(verbose=False):
+        """
+        Invoke the Py-ART test suite.
+        """
+        import pytest
+        pkg_dir = _osp.abspath(_osp.dirname(__file__))
+        args = [pkg_dir, '--pyargs', 'pyart']
+        if verbose:
+            args.extend(['-v', '-s'])
+        pytest.main(args=args)

--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -60,32 +60,32 @@ except DistributionNotFound:
 
 
 try:
-     if _sys.version_info[:2] >= (3, 4):
-         import importlib as _importlib
-         specs = _importlib.util.find_spec('pytest')
-         specs.loader.load_module()
-     else:
-         import imp as _imp
-         _imp.find_module('pytest')
- except (AttributeError, ImportError) as error:
-     def _test(verbose=False):
-         """
-         This would invoke the Py-ART test suite, but pytest couldn't
-         be imported so the test suite can not run.
-         """
-         raise ImportError("Could not load pytest. Unit tests not available."
-                             " To run unit tests, please install pytest.")
- else:
-     def _test(verbose=False):
-         """
-         Invoke the Py-ART test suite.
-         """
-         import pytest
-         pkg_dir = _osp.abspath(_osp.dirname(__file__))
-         args = [pkg_dir, '--pyargs', 'pyart']
-         if verbose:
-             args.extend(['-v', '-s'])
-         pytest.main(args=args)
+    if _sys.version_info[:2] >= (3, 4):
+        import importlib as _importlib
+        specs = _importlib.util.find_spec('pytest')
+        specs.loader.load_module()
+    else:
+        import imp as _imp
+        _imp.find_module('pytest')
+except (AttributeError, ImportError) as error:
+    def _test(verbose=False):
+        """
+        This would invoke the Py-ART test suite, but pytest couldn't
+        be imported so the test suite can not run.
+        """
+        raise ImportError("Could not load pytest. Unit tests not available."
+                            " To run unit tests, please install pytest.")
+else:
+    def _test(verbose=False):
+        """
+        Invoke the Py-ART test suite.
+        """
+        import pytest
+        pkg_dir = _osp.abspath(_osp.dirname(__file__))
+        args = [pkg_dir, '--pyargs', 'pyart']
+        if verbose:
+            args.extend(['-v', '-s'])
+        pytest.main(args=args)
 
  # Do not use `test` as function name as this leads to a recursion problem
  # with the pytest test suite.


### PR DESCRIPTION
Currently, we are running the build docs workflow on forks since we are missing the if check