### PR TITLE
FIX: Pin previous version of shapely

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -21,6 +21,7 @@ dependencies:
   - glpk
   - cftime
   - setuptools
+  - shapely<1.8.3
   - pip
   - pip:
     - pooch

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - s3fs
   - glpk
   - cftime
+  - shapely<1.8.3
   - pip
   - pip:
       - pydata-sphinx-theme<0.9.0


### PR DESCRIPTION
With the recent release of Shapely (1.8.3), there are some errors popping up in Cartopy (see [#2067](https://github.com/SciTools/cartopy/issues/2067)).

We need to pin the previous version of shapely until this issue is resolved.