### PR TITLE
FIX: Make datetime parsing more general for columnsect

### DIFF
--- a/pyart/util/columnsect.py
+++ b/pyart/util/columnsect.py
@@ -202,8 +202,8 @@ def get_field_location(radar, latitude, longitude):
 
     # Determine the time at the center of each ray within the column
     # Define the start of the radar volume as a numpy datetime object for xr
-    base_time = pd.to_datetime(radar.time['units'].split(' ')[-1].strip('Z'),
-                               format='%Y-%m-%dT%H:%M:%S').to_numpy()
+    # We take advantage of the "seconds since " portion of the units string
+    base_time = pd.to_datetime(radar.time['units'][14:]).to_numpy()
     # Convert Py-ART radar object time (time since volume start) to time delta
     # Add to base time to have sequential time within the xr Dataset
     # for easier future merging/work


### PR DESCRIPTION
Currently, we make an assumption about the format of the datetime string when parsing for the point extraction. This makes the date parsing more generic, using the "seconds since ..." information we know.