### PR TITLE
FIX: Use new api to toggle top and right labels

### DIFF
--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -324,8 +324,8 @@ class RadarMapDisplay(RadarDisplay):
                                  cartopy.crs.Mercator()]:
                 gl = ax.gridlines(xlocs=lon_lines, ylocs=lat_lines,
                                   draw_labels=True)
-                gl.xlabels_top = False
-                gl.ylabels_right = False
+                gl.top_labels = False
+                gl.right_labels = False
 
             elif isinstance(ax.projection, cartopy.crs.LambertConformal):
                 ax.figure.canvas.draw()


### PR DESCRIPTION
Currently, when you create a plot using the GridMapDisplay, the plot returns the following error

```python
/ccsopen/home/mgrover/mgrover/sail-radar-dev/lib/python3.9/site-packages/cartopy/mpl/gridliner.py:451: UserWarning: The .xlabels_top attribute is deprecated. Please use .top_labels to toggle visibility instead.
  warnings.warn('The .xlabels_top attribute is deprecated. Please '
/ccsopen/home/mgrover/mgrover/sail-radar-dev/lib/python3.9/site-packages/cartopy/mpl/gridliner.py:487: UserWarning: The .ylabels_right attribute is deprecated. Please use .right_labels to toggle visibility instead.
  warnings.warn('The .ylabels_right attribute is deprecated. Please '
```

This solves that issue by using the new, suggested methods