### PR TITLE
Add ci for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos, ubuntu, windows]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp3.11-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -22,7 +22,7 @@ dependencies:
   - glpk
   - cftime
   - setuptools
-  - shapely<1.8.3
+  - shapely
   - pip
   - pip:
     - cibuildwheel

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4
   - pytest
   - wradlib
-  - cartopy>=0.21.0
+  - cartopy
   - cvxopt
   - xarray
   - metpy
@@ -22,7 +22,7 @@ dependencies:
   - glpk
   - cftime
   - setuptools
-  - shapely
+  - shapely<1.8.3
   - pip
   - pip:
     - cibuildwheel

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4
   - pytest
   - wradlib
-  - cartopy
+  - cartopy>=0.21.0
   - cvxopt
   - xarray
   - metpy

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - s3fs
   - glpk
   - cftime
-  - shapely<1.8.3
+  - shapely
   - pip
   - pip:
       - pydata-sphinx-theme<0.9.0


### PR DESCRIPTION
Since Python 3.11 is now released, we should support this new Python version. Adding to CI/wheels.