### PR TITLE
FIX: Phase processing code throwing deprecation warnings for scipy.ndimage.filters.convolve1d

### DIFF
--- a/pyart/correct/phase_proc.py
+++ b/pyart/correct/phase_proc.py
@@ -358,7 +358,7 @@ def smooth_and_trim_scan(x, window_len=11, window='hanning'):
         The smoothed signal with length equal to the input signal.
 
     """
-    from scipy.ndimage.filters import convolve1d
+    from scipy.ndimage import convolve1d
 
     if x.ndim != 2:
         raise ValueError("smooth only accepts 2 dimension arrays.")
@@ -1151,7 +1151,7 @@ def phase_proc_lp(radar, offset, debug=False, self_const=60000.0,
     sobel = sobel/(abs(sobel).sum())
     sobel = sobel[::-1]
     gate_spacing = (radar.range['data'][1] - radar.range['data'][0]) / 1000.
-    kdp = (scipy.ndimage.filters.convolve1d(proc_ph['data'], sobel, axis=1) /
+    kdp = (scipy.ndimage.convolve1d(proc_ph['data'], sobel, axis=1) /
            ((window_len / 3.0) * 2.0 * gate_spacing))
 
     # copy the KDP metadata from existing field or create anew
@@ -1349,7 +1349,7 @@ def phase_proc_lp_gf(radar, gatefilter=None, debug=False, self_const=60000.0,
     sobel = sobel / (abs(sobel).sum())
     sobel = sobel[::-1]
     gate_spacing = (radar.range['data'][1] - radar.range['data'][0]) / 1000.
-    kdp = (scipy.ndimage.filters.convolve1d(proc_ph['data'], sobel, axis=1) /
+    kdp = (scipy.ndimage.convolve1d(proc_ph['data'], sobel, axis=1) /
            ((window_len / 3.0) * 2.0 * gate_spacing))
 
     # copy the KDP metadata from existing field or create anew

--- a/pyart/correct/phase_proc.py
+++ b/pyart/correct/phase_proc.py
@@ -1300,6 +1300,12 @@ def phase_proc_lp_gf(radar, gatefilter=None, debug=False, self_const=60000.0,
 
         start_gate = 0
 
+        if len(radar.range['data'][start_gate:end_gate]) <= 5:
+            mysoln = np.zeros_like(
+                    proc_ph['data'][start_ray:end_ray, start_gate:end_gate])
+            proc_ph['data'][start_ray:end_ray, start_gate:end_gate] = mysoln
+            continue
+
         A_Matrix = construct_A_matrix(
             len(radar.range['data'][start_gate:end_gate]),
             St_Gorlv_differential_5pts)
@@ -1332,6 +1338,7 @@ def phase_proc_lp_gf(radar, gatefilter=None, debug=False, self_const=60000.0,
 
         proc_ph['data'][start_ray:end_ray, start_gate:end_gate] = mysoln
 
+    print("Done LP")
     last_gates = proc_ph['data'][start_ray:end_ray, -16]
     proc_ph['data'][start_ray:end_ray, -16:] = \
         np.meshgrid(np.ones([16]), last_gates)[1]

--- a/pyart/correct/phase_proc.py
+++ b/pyart/correct/phase_proc.py
@@ -1338,7 +1338,6 @@ def phase_proc_lp_gf(radar, gatefilter=None, debug=False, self_const=60000.0,
 
         proc_ph['data'][start_ray:end_ray, start_gate:end_gate] = mysoln
 
-    print("Done LP")
     last_gates = proc_ph['data'][start_ray:end_ray, -16]
     proc_ph['data'][start_ray:end_ray, -16:] = \
         np.meshgrid(np.ones([16]), last_gates)[1]


### PR DESCRIPTION
The phase processing code is throwing deprecation warnings for using scipy.ndimage.filters.convolve1d. It looks like that function is moving to scipy.ndimage.convolve1d. This fix would take care of the deprecation warning.