### PR TITLE
DOC: Added two pyart examples (VAD and hydrometeors)

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -28,3 +28,4 @@ dependencies:
     - cibuildwheel
     - pooch
     - versioneer
+    - git+https://github.com/openradar/open-radar-data

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - shapely<1.8.3
   - pip
   - pip:
+      - git+https://github.com/openradar/open-radar-data
       - pydata-sphinx-theme<0.9.0
       - sphinx_gallery
       - sphinx-copybutton

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -28,7 +28,7 @@ nwp_temp = pyart.io.read_cfradial(filename)
 radar.add_field('temperature', nwp_temp.fields['temperature'])
 
 # Compute attenuation
-out = pyart.correct.calculate_attenuation_zphi(radar, fzl = 4200,
+out = pyart.correct.calculate_attenuation_zphi(radar,
                            phidp_field = 'uncorrected_differential_phase',
                            temp_field = 'temperature',
                            temp_ref = 'temperature')
@@ -80,3 +80,5 @@ ax.set_aspect('equal', 'box')
 # MH = melting hail
 # IH/HDG = dry hail / high density graupel
 
+
+# %%

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -11,10 +11,11 @@ Calculates a hydrometeor classification and displays the results
 # License: BSD 3 clause
 
 import numpy as np
-import pyart
-from pyart.testing import get_test_data
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+
+import pyart
+from pyart.testing import get_test_data
 
 # Read in a sample file
 filename = get_test_data('MLL2217907250U.003.nc')
@@ -28,41 +29,43 @@ nwp_temp = pyart.io.read_cfradial(filename)
 radar.add_field('temperature', nwp_temp.fields['temperature'])
 
 # Compute attenuation
-out = pyart.correct.calculate_attenuation_zphi(radar,
-                           phidp_field = 'uncorrected_differential_phase',
-                           temp_field = 'temperature',
-                           temp_ref = 'temperature')
+out = pyart.correct.calculate_attenuation_zphi(
+    radar,
+    phidp_field='uncorrected_differential_phase',
+    temp_field='temperature',
+    temp_ref='temperature')
 spec_at, pia, cor_z, spec_diff_at, pida, cor_zdr = out
 radar.add_field('corrected_reflectivity', cor_z)
 radar.add_field('corrected_differential_reflectivity', cor_zdr)
 radar.add_field('specific_attenuation', spec_at)
 
 # Compute KDP
-kdp, _, _ = pyart.retrieve.kdp_maesaka(radar,
-                                       psidp_field = 'uncorrected_differential_phase')
+kdp, _, _ = pyart.retrieve.kdp_maesaka(
+    radar, psidp_field='uncorrected_differential_phase')
 radar.add_field('specific_differential_phase', kdp)
 
 # Compute hydrometeor classification
-hydro = pyart.retrieve.hydroclass_semisupervised(radar,
-                                 refl_field =  'corrected_reflectivity',
-                                 zdr_field = 'corrected_differential_reflectivity',
-                                 kdp_field = 'specific_differential_phase',
-                                 rhv_field = 'uncorrected_cross_correlation_ratio',
-                                 temp_field = 'temperature')
+hydro = pyart.retrieve.hydroclass_semisupervised(
+    radar,
+    refl_field='corrected_reflectivity',
+    zdr_field='corrected_differential_reflectivity',
+    kdp_field='specific_differential_phase',
+    rhv_field='uncorrected_cross_correlation_ratio',
+    temp_field='temperature')
 
 radar.add_field('radar_echo_classification', hydro)
 
 # Display hydrometeor classification with categorical colormap
-fig, ax = plt.subplots(1,1, figsize=(6,6))
+fig, ax = plt.subplots(1,1, figsize=(6, 6))
 display = pyart.graph.RadarDisplay(radar)
 
 labels = ['NC','AG', 'CR', 'LR', 'RP', 'RN', 'VI', 'WS', 'MH', 'IH/HDG']
 ticks = np.arange(len(labels))
-boundaries = np.arange(-0.5, len(labels) )
+boundaries = np.arange(-0.5, len(labels))
 norm = mpl.colors.BoundaryNorm(boundaries, 256)
 
-cax = display.plot_ppi('radar_echo_classification', 0, ax = ax, 
-                 norm = norm, ticks = ticks, ticklabs = labels)
+cax = display.plot_ppi('radar_echo_classification', 0, ax=ax, 
+                       norm=norm, ticks=ticks, ticklabs=labels)
 
 ax.set_xlim([-50,50])
 ax.set_ylim([-50,50])

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -1,0 +1,82 @@
+
+"""
+=========================================
+Calculate and Plot hydrometeor classification
+=========================================
+
+Calculates a hydrometeor classification and displays the results
+"""
+
+# Author: Daniel Wolfensberger (daniel.wolfensberger@meteoswiss.ch)
+# License: BSD 3 clause
+
+import numpy as np
+import pyart
+from pyart.testing import get_test_data
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+# Read in a sample file
+filename = get_test_data('MLL2217907250U.003.nc')
+radar = pyart.io.read_cfradial(filename)
+
+# Read temperature preinterpolated from NWP model
+filename = get_test_data('20220628072500_savevol_COSMO_LOOKUP_TEMP.nc')
+nwp_temp = pyart.io.read_cfradial(filename)
+
+# Add temperature to radar object as new field
+radar.add_field('temperature', nwp_temp.fields['temperature'])
+
+# Compute attenuation
+out = pyart.correct.calculate_attenuation_zphi(radar, fzl = 4200,
+                           phidp_field = 'uncorrected_differential_phase',
+                           temp_field = 'temperature',
+                           temp_ref = 'temperature')
+spec_at, pia, cor_z, spec_diff_at, pida, cor_zdr = out
+radar.add_field('corrected_reflectivity', cor_z)
+radar.add_field('corrected_differential_reflectivity', cor_zdr)
+radar.add_field('specific_attenuation', spec_at)
+
+# Compute KDP
+kdp, _, _ = pyart.retrieve.kdp_maesaka(radar,
+                                       psidp_field = 'uncorrected_differential_phase')
+radar.add_field('specific_differential_phase', kdp)
+
+# Compute hydrometeor classification
+hydro = pyart.retrieve.hydroclass_semisupervised(radar,
+                                 refl_field =  'corrected_reflectivity',
+                                 zdr_field = 'corrected_differential_reflectivity',
+                                 kdp_field = 'specific_differential_phase',
+                                 rhv_field = 'uncorrected_cross_correlation_ratio',
+                                 temp_field = 'temperature')
+
+radar.add_field('radar_echo_classification', hydro)
+
+# Display hydrometeor classification with categorical colormap
+fig, ax = plt.subplots(1,1, figsize=(6,6))
+display = pyart.graph.RadarDisplay(radar)
+
+labels = ['NC','AG', 'CR', 'LR', 'RP', 'RN', 'VI', 'WS', 'MH', 'IH/HDG']
+ticks = np.arange(len(labels))
+boundaries = np.arange(-0.5, len(labels) )
+norm = mpl.colors.BoundaryNorm(boundaries, 256)
+
+cax = display.plot_ppi('radar_echo_classification', 0, ax = ax, 
+                 norm = norm, ticks = ticks, ticklabs = labels)
+
+ax.set_xlim([-50,50])
+ax.set_ylim([-50,50])
+ax.set_aspect('equal', 'box')
+
+# For info
+# NC = not classified
+# AG = aggregates
+# CR = ice crystals
+# LR = light rain
+# RP = rimed particles
+# RN = rain
+# VI = vertically oriented ice
+# WS = wet snow
+# MH = melting hail
+# IH/HDG = dry hail / high density graupel
+

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -18,11 +18,11 @@ import pyart
 from open_radar_data import DATASETS
 
 # Read in a sample file
-filename = get_test_data('MLL2217907250U.003.nc')
+filename = DATASETS.fetch('MLL2217907250U.003.nc')
 radar = pyart.io.read_cfradial(filename)
 
 # Read temperature preinterpolated from NWP model
-filename = get_test_data('20220628072500_savevol_COSMO_LOOKUP_TEMP.nc')
+filename = DATASETS.fetch('20220628072500_savevol_COSMO_LOOKUP_TEMP.nc')
 nwp_temp = pyart.io.read_cfradial(filename)
 
 # Add temperature to radar object as new field

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -79,6 +79,3 @@ ax.set_aspect('equal', 'box')
 # WS = wet snow
 # MH = melting hail
 # IH/HDG = dry hail / high density graupel
-
-
-# %%

--- a/examples/retrieve/plot_hydrometeor.py
+++ b/examples/retrieve/plot_hydrometeor.py
@@ -15,7 +15,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 import pyart
-from pyart.testing import get_test_data
+from open_radar_data import DATASETS
 
 # Read in a sample file
 filename = get_test_data('MLL2217907250U.003.nc')

--- a/examples/retrieve/plot_vad.py
+++ b/examples/retrieve/plot_vad.py
@@ -44,3 +44,5 @@ ax[0].set_xlabel('Wind speed [m/s]')
 ax[1].set_xlabel('Wind direction [deg]')
 ax[0].set_ylabel('Altitude [m]')
 fig.suptitle('Wind profile obtained from VAD')
+
+# %%

--- a/examples/retrieve/plot_vad.py
+++ b/examples/retrieve/plot_vad.py
@@ -44,5 +44,3 @@ ax[0].set_xlabel('Wind speed [m/s]')
 ax[1].set_xlabel('Wind direction [deg]')
 ax[0].set_ylabel('Altitude [m]')
 fig.suptitle('Wind profile obtained from VAD')
-
-# %%

--- a/examples/retrieve/plot_vad.py
+++ b/examples/retrieve/plot_vad.py
@@ -13,10 +13,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import pyart
-from pyart.testing import get_test_data
+from open_radar_data import DATASETS
 
 # Read in a sample file
-filename = get_test_data('MLA2119412050U.nc')
+filename = DATASETS.fetch('MLA2119412050U.nc')
 radar = pyart.io.read_cfradial(filename)
 
 # Loop on all sweeps and compute VAD

--- a/examples/retrieve/plot_vad.py
+++ b/examples/retrieve/plot_vad.py
@@ -10,34 +10,37 @@ Calculates a VAD and plots a vertical profile of wind
 # License: BSD 3 clause
 
 import numpy as np
+import matplotlib.pyplot as plt
+
 import pyart
 from pyart.testing import get_test_data
-import matplotlib.pyplot as plt
 
 # Read in a sample file
 filename = get_test_data('MLA2119412050U.nc')
 radar = pyart.io.read_cfradial(filename)
 
 # Loop on all sweeps and compute VAD
-zlevels = np.arange(100,5000,100) # height above radar
+zlevels = np.arange(100, 5000, 100) # height above radar
 u_allsweeps = []
 v_allsweeps = [] 
 
 for idx in range(radar.nsweeps):
     radar_1sweep = radar.extract_sweeps([idx])
-    vad = pyart.retrieve.vad_browning(radar_1sweep,
-                    'corrected_velocity', z_want = zlevels)
+    vad = pyart.retrieve.vad_browning(
+        radar_1sweep,
+        'corrected_velocity',
+        z_want=zlevels)
     u_allsweeps.append(vad.u_wind)
     v_allsweeps.append(vad.v_wind)
     
 # Average U and V over all sweeps and compute magnitude and angle
-u_avg = np.nanmean(np.array(u_allsweeps), axis = 0)
-v_avg = np.nanmean(np.array(v_allsweeps), axis = 0)
+u_avg = np.nanmean(np.array(u_allsweeps), axis=0)
+v_avg = np.nanmean(np.array(v_allsweeps), axis=0)
 orientation = np.rad2deg(np.arctan2(-u_avg, -v_avg))%360
 speed = np.sqrt(u_avg**2 + v_avg**2)
 
 # Display vertical profile of wind
-fig,ax = plt.subplots(1,2, sharey=True)
+fig, ax = plt.subplots(1, 2, sharey=True)
 ax[0].plot(speed*2, zlevels+radar.altitude['data'])
 ax[1].plot(orientation, zlevels+radar.altitude['data'])
 ax[0].set_xlabel('Wind speed [m/s]')

--- a/examples/retrieve/plot_vad.py
+++ b/examples/retrieve/plot_vad.py
@@ -1,0 +1,46 @@
+"""
+=========================================
+Calculate and Plot VAD profile
+=========================================
+
+Calculates a VAD and plots a vertical profile of wind
+"""
+
+# Author: Daniel Wolfensberger (daniel.wolfensberger@meteoswiss.ch)
+# License: BSD 3 clause
+
+import numpy as np
+import pyart
+from pyart.testing import get_test_data
+import matplotlib.pyplot as plt
+
+# Read in a sample file
+filename = get_test_data('MLA2119412050U.nc')
+radar = pyart.io.read_cfradial(filename)
+
+# Loop on all sweeps and compute VAD
+zlevels = np.arange(100,5000,100) # height above radar
+u_allsweeps = []
+v_allsweeps = [] 
+
+for idx in range(radar.nsweeps):
+    radar_1sweep = radar.extract_sweeps([idx])
+    vad = pyart.retrieve.vad_browning(radar_1sweep,
+                    'corrected_velocity', z_want = zlevels)
+    u_allsweeps.append(vad.u_wind)
+    v_allsweeps.append(vad.v_wind)
+    
+# Average U and V over all sweeps and compute magnitude and angle
+u_avg = np.nanmean(np.array(u_allsweeps), axis = 0)
+v_avg = np.nanmean(np.array(v_allsweeps), axis = 0)
+orientation = np.rad2deg(np.arctan2(-u_avg, -v_avg))%360
+speed = np.sqrt(u_avg**2 + v_avg**2)
+
+# Display vertical profile of wind
+fig,ax = plt.subplots(1,2, sharey=True)
+ax[0].plot(speed*2, zlevels+radar.altitude['data'])
+ax[1].plot(orientation, zlevels+radar.altitude['data'])
+ax[0].set_xlabel('Wind speed [m/s]')
+ax[1].set_xlabel('Wind direction [deg]')
+ax[0].set_ylabel('Altitude [m]')
+fig.suptitle('Wind profile obtained from VAD')


### PR DESCRIPTION
Closes #1260 

Dear pyart team,

Sorry for the long delay, I had to wait for the green light to share some of the data and had some fieldwork to do...

Here are two new examples for the pyart gallery taken from the erad2022 open radar course.

**plot_vad.py:**
Compute VAD for every sweep of a volumetric scan, compute a vertical profile of U and V wind components, display the results

**plot_hydrometeors.py:**
Compute attenuation and KDP, read temperature from another source and add it to radar object, compute hydrometeors, display the results on a PPI plot with a categorical colorbar

It requires three files to be acquired with the *get_test_data* method. I hosted the files [here ](https://www.swisstransfer.com/d/7d632b77-c120-4316-be80-13a3a750aca6). Could you please put them on https://adc.arm.gov/pyart/example_data ? Tell me if you'd prefer me to send them to you in some other way.

Thank you very much,
Cheers,
Daniel



