### PR TITLE
FIX: check uniformity of range_step, get consistent range_step for gamic reader

### DIFF
--- a/pyart/aux_io/gamic_hdf5.py
+++ b/pyart/aux_io/gamic_hdf5.py
@@ -164,7 +164,7 @@ def read_gamic(filename, field_names=None, additional_metadata=None,
 
     # range
     _range = filemetadata('range')
-    ngates = int(gfile.raw_scan0_group_attr('how', 'bin_count'))
+    ngates = gfile.max_num_gates
     range_start = float(gfile.raw_scan0_group_attr('how', 'range_start'))
     #n_samples insertion
     range_samples = int(gfile.raw_scan0_group_attr('how', 'range_samples')) 

--- a/pyart/aux_io/gamicfile.py
+++ b/pyart/aux_io/gamicfile.py
@@ -42,6 +42,11 @@ class GAMICFile(object):
         self.total_rays = sum(self.rays_per_sweep)
         self.gates_per_sweep = self.how_attrs('bin_count', 'int32')
         self.max_num_gates = max(self.gates_per_sweep)
+        # check uniformity of range_step, raise if not uniform
+        range_samples = self.how_attrs('range_samples', 'int32')
+        range_step = self.how_attrs('range_step', 'float') * range_samples
+        if len(np.unique(range_step)) > 1:
+            raise ValueError('range scale changes between sweeps')
         # starting and ending ray for each sweep
         self.start_ray = np.cumsum(np.append([0], self.rays_per_sweep[:-1]))
         self.end_ray = np.cumsum(self.rays_per_sweep) - 1


### PR DESCRIPTION
follow-up to #1337 