### PR TITLE
FIX: read_sigmet time_ordered bug

### DIFF
--- a/pyart/io/sigmet.py
+++ b/pyart/io/sigmet.py
@@ -464,7 +464,7 @@ def _is_time_ordered_by_reversal(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
     start = 0
     for nrays in rays_per_sweep:
         if nrays == 0 or nrays == 1:
@@ -488,7 +488,7 @@ def _is_time_ordered_by_roll(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
     start = 0
     for nrays in rays_per_sweep:
         if nrays == 0 or nrays == 1:
@@ -516,7 +516,7 @@ def _is_time_ordered_by_reverse_roll(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
     start = 0
     for nrays in rays_per_sweep:
         if nrays == 0 or nrays == 1:
@@ -553,7 +553,7 @@ def _time_order_data_and_metadata_roll(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
 
     start = 0
     for nrays in rays_per_sweep:
@@ -592,7 +592,7 @@ def _time_order_data_and_metadata_reverse(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
 
     start = 0
     for nrays in rays_per_sweep:
@@ -631,7 +631,7 @@ def _time_order_data_and_metadata_full(data, metadata, rays_per_sweep):
         ref_time = data['XHDR'].copy()
         ref_time.shape = ref_time.shape[:-1]
     else:
-        ref_time = metadata[metadata.keys()[0]]['time'].astype('int32')
+        ref_time = metadata[list(metadata.keys())[0]]['time'].astype('int32')
 
     start = 0
     for nrays in rays_per_sweep:


### PR DESCRIPTION
When use read_sigmet to load IRIS/Sigmet Rad data with time_ordered='sequential', it will display error messages.
In this file, "metadata.keys()[0]" should be "list(metadata.keys())[0]"