### PR TITLE
DOC: Adding an example on how to read older nexrad data.

### DIFF
--- a/examples/io/read_older_nexrad_data_aws.py
+++ b/examples/io/read_older_nexrad_data_aws.py
@@ -21,11 +21,11 @@ import pyart
 # Read older NEXRAD Level 2 Data
 # ------------------------------
 #
-# Older NEXRAD files have the tendency to not contain some of the required
-# metadata for Py-ART's NEXRAD reader. This usually results in missing
-# latitude and longitude data, so after reading with Py-ART, both coordinates
-# have a value of 0. This example, we will show how to properly read in an
-# older NEXRAD file.
+# Older NEXRAD files prior to 2008, have the tendency to not contain some of
+# the required metadata for Py-ART's NEXRAD reader. This usually results in
+# missing latitude and longitude data, so after reading with Py-ART, both
+# coordinates have a value of 0. This example, we will show how to properly
+# read in an older NEXRAD file.
 #
 # First we want to get an older file from amazon web service:
 #

--- a/examples/io/read_older_nexrad_data_aws.py
+++ b/examples/io/read_older_nexrad_data_aws.py
@@ -1,0 +1,75 @@
+"""
+==================================================================
+Reading Older NEXRAD Data and Fixing Latitude and Longitude Issues
+==================================================================
+"""
+print(__doc__)
+
+
+# Author: Zachary Sherman (zsherman@anl.gov)
+# License: BSD 3 clause
+
+######################################
+# Import our required packages.
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+
+import pyart
+
+######################################%%
+# Read older NEXRAD Level 2 Data
+# ------------------------------
+#
+# Older NEXRAD files have the tendency to not contain some of the required
+# metadata for Py-ART's NEXRAD reader. This usually results in missing
+# latitude and longitude data, so after reading with Py-ART, both coordinates
+# have a value of 0. This example, we will show how to properly read in an
+# older NEXRAD file.
+#
+# First we want to get an older file from amazon web service:
+#
+#    ``s3://noaa-nexrad-level2/year/month/date/radarsite/{radarsite}{year}{month}{date}_{hour}{minute}{second}.gz``
+# 
+# Where in our case, we are using a sample data file from Handford, CA (KHGX)
+# on July 24, 2006, at 0203:38 UTC. This means our path would look like:
+
+aws_nexrad_level2_file = "s3://noaa-nexrad-level2/2006/07/24/KHNX/KHNX20060724_020338.gz"
+
+######################################
+# We can use the **pyart.io.read_nexrad_archive** module to access our data, passing in the filepath.
+
+radar = pyart.io.read_nexrad_archive(aws_nexrad_level2_file)
+
+######################################
+# Now let us take a look at the radar latitude and longitude data.
+print(radar.latitude['data'])
+print(radar.longitude['data'])
+
+######################################
+# This is clearly not correct! The problem is the reader could not find the
+# metadata (message 31) for the coordinates.
+#
+# Lucky for us, we can provide the station in Py-ART's NEXRAD reader, which will
+# pull the coordinate information from a save dictionary found within Py-ART.
+
+radar = pyart.io.read_nexrad_archive(aws_nexrad_level2_file, station='KHNX')
+
+######################################
+# Again, let us take a look at the radar latitude and longitude data.
+print(radar.latitude['data'])
+print(radar.longitude['data'])
+
+# Everything now looks correct as this is in Handord CA!
+
+##########################################
+# We can create a plot as well utilizing Cartopy to see how it looks.
+display = pyart.graph.RadarMapDisplay(radar)
+
+# Setting projection and ploting the first tilt.
+projection = ccrs.LambertConformal(central_latitude=radar.latitude['data'][0],
+                                   central_longitude=radar.longitude['data'][0])
+
+fig = plt.figure(figsize=(6,6))
+display.plot_ppi_map('reflectivity', 0, vmin=-20, vmax=54,
+                     projection=projection, resolution='10m')

--- a/examples/io/read_older_nexrad_data_aws.py
+++ b/examples/io/read_older_nexrad_data_aws.py
@@ -31,10 +31,12 @@ import pyart
 #
 #    ``s3://noaa-nexrad-level2/year/month/date/radarsite/{radarsite}{year}{month}{date}_{hour}{minute}{second}.gz``
 # 
-# Where in our case, we are using a sample data file from Handford, CA (KHGX)
-# on July 24, 2006, at 0203:38 UTC. This means our path would look like:
+# Where in our case, we are using a sample data file from Handford, CA (KHNX)
+# on July 24, 2006, at 0203:38 UTC. This means our path would look like this:
 
 aws_nexrad_level2_file = "s3://noaa-nexrad-level2/2006/07/24/KHNX/KHNX20060724_020338.gz"
+
+# Note: Older files do note contain the 'V06' but instead '.gz'
 
 ######################################
 # We can use the **pyart.io.read_nexrad_archive** module to access our data, passing in the filepath.

--- a/examples/io/read_older_nexrad_data_aws.py
+++ b/examples/io/read_older_nexrad_data_aws.py
@@ -62,7 +62,7 @@ radar = pyart.io.read_nexrad_archive(aws_nexrad_level2_file, station='KHNX')
 print(radar.latitude['data'])
 print(radar.longitude['data'])
 
-# Everything now looks correct as this is in Handord CA!
+# Everything now looks correct as this is in Handford CA!
 
 ##########################################
 # We can create a plot as well utilizing Cartopy to see how it looks.

--- a/examples/io/read_older_nexrad_data_aws.py
+++ b/examples/io/read_older_nexrad_data_aws.py
@@ -36,7 +36,7 @@ import pyart
 
 aws_nexrad_level2_file = "s3://noaa-nexrad-level2/2006/07/24/KHNX/KHNX20060724_020338.gz"
 
-# Note: Older files do note contain the 'V06' but instead '.gz'
+# Note: Older files do not contain the 'V06' but instead '.gz' in the AWS path.
 
 ######################################
 # We can use the **pyart.io.read_nexrad_archive** module to access our data, passing in the filepath.
@@ -53,7 +53,7 @@ print(radar.longitude['data'])
 # metadata (message 31) for the coordinates.
 #
 # Lucky for us, we can provide the station in Py-ART's NEXRAD reader, which will
-# pull the coordinate information from a save dictionary found within Py-ART.
+# pull the coordinate information from a dictionary found within Py-ART.
 
 radar = pyart.io.read_nexrad_archive(aws_nexrad_level2_file, station='KHNX')
 


### PR DESCRIPTION
This shows how to fix missing lat and lon metadata.
Closes #1354 