### PR TITLE
MNT: Revert setuptools, to avoid unwanted behavior.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import subprocess
 import glob
 from numpy import get_include
 
-from setuptools import find_namespace_packages, setup, Extension
+from setuptools import find_packages, setup, Extension
 from Cython.Build import cythonize
 import Cython
 
@@ -240,7 +240,7 @@ setup(
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,
     url=URL,
-    packages=find_namespace_packages(include=['pyart'], exclude=['docs']),
+    packages=find_packages(exclude=['docs']),
     include_package_data=True,
     scripts=SCRIPTS,
     install_requires=requirements,


### PR DESCRIPTION
Need to look into the difference more on find_namespace_packages and find_packages. Trying to avoid similar install error behavior as seen in ACT.  I switched to avoid warnings during the feedstock testing.