### PR TITLE
Drop Support for Python 3.8 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [macos, ubuntu, windows]
 
     steps:


### PR DESCRIPTION
They have started dropping support for Python 3.8 over in Xarray (https://github.com/pydata/xarray/pull/7461) and since xarray is a dependency, as well as other xarray-related packages, we should drop support in the tests for this.