### PR TITLE
BUG: Fix to broken doc link

### DIFF
--- a/doc/source/userguide/contributors_guide.rst
+++ b/doc/source/userguide/contributors_guide.rst
@@ -20,8 +20,8 @@ Important Links
 ---------------
 
 - Official source code repository: https://github.com/ARM-DOE/pyart
-- HTML documentation: http://arm-doe.github.io/pyart-docs-travis/
-- Examples: http://arm-doe.github.io/pyart/dev/auto_examples/index.html
+- HTML documentation: https://arm-doe.github.io/pyart
+- Examples: https://arm-doe.github.io/pyart/examples/
 - Mailing List: http://groups.google.com/group/pyart-users/
 - Issue Tracker: https://github.com/ARM-DOE/pyart/issues
 


### PR DESCRIPTION
Not sure I built this correctly, but a fix to a broken doc link to the examples