### PR TITLE
FIX: Fix wrong coordinate configuration for xarray

### DIFF
--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -337,8 +337,8 @@ class Grid:
                 coords={
                     "time": (["time"], time),
                     "z": (["z"], z),
-                    "lat": (["y"], lat[:, 0]),
-                    "lon": (["x"], lon[0, :]),
+                    "lat": (["y", "x"], lat),
+                    "lon": (["y", "x"], lon),
                     "y": (["y"], y),
                     "x": (["x"], x),
                 },

--- a/pyart/graph/gridmapdisplay.py
+++ b/pyart/graph/gridmapdisplay.py
@@ -120,7 +120,6 @@ class GridMapDisplay:
         add_grid_lines=True,
         ticks=None,
         ticklabs=None,
-        imshow=False,
         **kwargs
     ):
         """
@@ -193,9 +192,6 @@ class GridMapDisplay:
             Colorbar custom tick label locations.
         ticklabs : array
             Colorbar custom tick labels.
-        imshow : bool
-            If used, plot uses ax.imshow instead of ax.pcolormesh.
-            Default is False.
 
         """
         ds = self.grid.to_xarray()
@@ -254,26 +250,15 @@ class GridMapDisplay:
         if norm is not None:  # if norm is set do not override with vmin/vmax
             vmin = vmax = None
 
-        if imshow:
-            pm = ds[field][0, level].plot.imshow(
-                x="lon",
-                y="lat",
-                cmap=cmap,
-                vmin=vmin,
-                vmax=vmax,
-                add_colorbar=False,
-                **kwargs
-            )
-        else:
-            pm = ds[field][0, level].plot.pcolormesh(
-                x="lon",
-                y="lat",
-                cmap=cmap,
-                vmin=vmin,
-                vmax=vmax,
-                add_colorbar=False,
-                **kwargs
-            )
+        pm = ds[field][0, level].plot.pcolormesh(
+            x="lon",
+            y="lat",
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            add_colorbar=False,
+            **kwargs
+        )
 
         self.mappables.append(pm)
         self.fields.append(field)

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -90,8 +90,6 @@ def test_grid_to_xarray():
 
     lon, lat = pyart.core.Grid.get_point_longitude_latitude(grid)
     time = np.array([netCDF4.num2date(grid.time["data"][0], grid.time["units"])])
-    lon = lon
-    lat = lat
     z = grid.z["data"]
     y = grid.y["data"]
     x = grid.x["data"]

--- a/tests/core/test_grid.py
+++ b/tests/core/test_grid.py
@@ -90,8 +90,8 @@ def test_grid_to_xarray():
 
     lon, lat = pyart.core.Grid.get_point_longitude_latitude(grid)
     time = np.array([netCDF4.num2date(grid.time["data"][0], grid.time["units"])])
-    lon = lon[0, :]
-    lat = lat[:, 0]
+    lon = lon
+    lat = lat
     z = grid.z["data"]
     y = grid.y["data"]
     x = grid.x["data"]

--- a/tests/graph/test_gridmapdisplay.py
+++ b/tests/graph/test_gridmapdisplay.py
@@ -28,20 +28,6 @@ def test_gridmapdisplay_simple(outfile=None):
 @pytest.mark.skipif(
     not pyart.graph.gridmapdisplay._CARTOPY_AVAILABLE, reason="Cartopy is not installed"
 )
-def test_gridmapdisplay_imshow(outfile=None):
-    # test basic GridMapDisplay functionality.
-    grid = pyart.testing.make_target_grid()
-    display = pyart.graph.GridMapDisplay(grid)
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
-    display.plot_grid("reflectivity", imshow=True, vmin=-5, vmax=35, ax=ax)
-    if outfile:
-        fig.savefig(outfile)
-
-
-@pytest.mark.skipif(
-    not pyart.graph.gridmapdisplay._CARTOPY_AVAILABLE, reason="Cartopy is not installed"
-)
 def test_gridmapdisplay_fancy(outfile=None):
     import cartopy.crs as ccrs
 


### PR DESCRIPTION
Closes #1389 

This ensures we use 2D latitude/longitude for the `to_xarray()` method for grids.