### PR TITLE
Update link to mailing list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Important Links
 - Official source code repository: https://github.com/ARM-DOE/pyart
 - HTML documentation: https://arm-doe.github.io/pyart/
 - Examples: https://arm-doe.github.io/pyart/examples
-- Mailing List: https://groups.google.com/group/pyart-users/
+- Mailing List: https://openradar.discourse.group/tag/py-art
 - Issue Tracker: https://github.com/ARM-DOE/pyart/issues
 
 


### PR DESCRIPTION
Use the Open Radar community link for the mailing list.

- [x] Documentation reflects changes
