### PR TITLE
drop pkg_resources as a runtime requirement

### DIFF
--- a/pyart/__init__.py
+++ b/pyart/__init__.py
@@ -22,7 +22,7 @@ from os import environ as _environ
 if "PYART_QUIET" not in _environ:
     print(_citation_text)
 
-from pkg_resources import DistributionNotFound, get_distribution
+import importlib.metadata as _importlib_metadata
 
 # import subpackages
 # print out helpful message if build fails or importing from source tree
@@ -48,7 +48,7 @@ from .config import load_config  # noqa
 
 # Get the version
 try:
-    __version__ = get_distribution("arm_pyart").version
-except DistributionNotFound:
+    __version__ = _importlib_metadata.version("arm_pyart")
+except _importlib_metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"

--- a/pyart/testing/example_data.py
+++ b/pyart/testing/example_data.py
@@ -1,4 +1,5 @@
-import pkg_resources
+import importlib.resources
+
 import pooch
 
 DATASETS = pooch.create(
@@ -8,7 +9,7 @@ DATASETS = pooch.create(
 )
 
 
-with pkg_resources.resource_stream("pyart.testing", "registry.txt") as registry_file:
+with open(importlib.resources.files("pyart.testing") / "registry.txt") as registry_file:
     DATASETS.load_registry(registry_file)
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,9 @@ CLASSIFIERS = """\
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: C
     Programming Language :: Cython
     Topic :: Scientific/Engineering
@@ -265,6 +263,7 @@ setup(
     packages=find_packages(exclude=["docs"]),
     include_package_data=True,
     scripts=SCRIPTS,
+    python_requires=">=3.9",
     install_requires=requirements,
     setup_requires="setuptools_scm",
     license=LICENSE,


### PR DESCRIPTION
`pkg_resources` is deprecated https://setuptools.pypa.io/en/latest/history.html#v67-5-0

Note to reviewers: it's not perfectly clear to me which versions of Python are still supported as various sources differ:
- from PyPI classifiers: 3.6-3.10
- from 1.14.5 wheels: 3.8-3.11
- from test matrix: 3.9-3.11

Are the classifiers are just out of date ? I did the maximal effort to keep compatibility with Python<3.8 here, but if 3.9 is already the minimal supported version this PR can be simplified.