### PR TITLE
colorbar_orient option to plot_ppi_map functions

### DIFF
--- a/pyart/graph/radarmapdisplay.py
+++ b/pyart/graph/radarmapdisplay.py
@@ -121,6 +121,7 @@ class RadarMapDisplay(RadarDisplay):
         title_flag=True,
         colorbar_flag=True,
         colorbar_label=None,
+        colorbar_orient="vertical",
         ax=None,
         fig=None,
         lat_lines=None,
@@ -197,6 +198,8 @@ class RadarMapDisplay(RadarDisplay):
         colorbar_label : str
             Colorbar label, None will use a default label generated from the
             field information.
+        colorbar_orient : 'vertical' or 'horizontal'
+            Colorbar orientation.
         ax : Cartopy GeoAxes instance
             If None, create GeoAxes instance using other keyword info.
             If provided, ax must have a Cartopy crs projection and projection
@@ -417,6 +420,7 @@ class RadarMapDisplay(RadarDisplay):
             self.plot_colorbar(
                 mappable=pm,
                 label=colorbar_label,
+                orient=colorbar_orient,
                 field=field,
                 fig=fig,
                 ax=ax,

--- a/pyart/graph/radarmapdisplay_basemap.py
+++ b/pyart/graph/radarmapdisplay_basemap.py
@@ -113,6 +113,7 @@ class RadarMapDisplayBasemap(RadarDisplay):
         title_flag=True,
         colorbar_flag=True,
         colorbar_label=None,
+        colorbar_orient="vertical",
         ax=None,
         fig=None,
         lat_lines=None,
@@ -191,6 +192,8 @@ class RadarMapDisplayBasemap(RadarDisplay):
         colorbar_label : str
             Colorbar label, None will use a default label generated from the
             field information.
+        colorbar_orient : 'vertical' or 'horizontal'
+            Colorbar orientation.
         ax : Axis
             Axis to plot on. None will use the current axis.
         fig : Figure
@@ -370,6 +373,7 @@ class RadarMapDisplayBasemap(RadarDisplay):
             self.plot_colorbar(
                 mappable=pm,
                 label=colorbar_label,
+                orient=colorbar_orient,
                 field=field,
                 fig=fig,
                 ax=ax,


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #1400
- [x] Documentation reflects changes

Adds `colorbar_orient` as an option to `pyart.graph.RadarMapDisplay.plot_ppi_map()` and `pyart.graph.RadarMapDisplayBasemap.plot_ppi_map()`.
Documentation changed to reflect this in as far as adding bits in the function docstrings, I don't know if any more than that is needed.
