### PR TITLE
FIX: GateMapper will now map source field to destination radar even if field not in destination radar

### DIFF
--- a/pyart/map/gate_mapper.py
+++ b/pyart/map/gate_mapper.py
@@ -222,9 +222,15 @@ class GateMapper:
 
         src_fields = {}
         for field in field_list:
-            mapped_radar.fields[field]["data"] = np.ma.masked_where(
-                True, mapped_radar.fields[field]["data"]
-            )
+            if field in list(mapped_radar.fields.keys()):
+                mapped_radar.fields[field]["data"] = np.ma.masked_where(
+                    True, mapped_radar.fields[field]["data"]
+                )
+            else:
+                mapped_radar.fields[field] = deepcopy(self.src_radar.fields[field])
+                mapped_radar.fields[field]["data"] = np.ma.masked_where(
+                    True, np.ma.zeros((mapped_radar.nrays, mapped_radar.ngates))
+                )
             src_fields[field] = np.ma.masked_where(
                 self.gatefilter_src.gate_excluded, self.src_radar.fields[field]["data"]
             )

--- a/tests/map/test_gatemapper.py
+++ b/tests/map/test_gatemapper.py
@@ -11,18 +11,26 @@ def test_gatemapper():
     new_radar = deepcopy(old_radar)
     new_radar.latitude["data"] = old_radar.latitude["data"] + 0.001
     new_radar.longitude["data"] = old_radar.longitude["data"] + 0.001
-    gate_mapper = pyart.map.GateMapper(new_radar, old_radar)
+    old_radar.fields["reflectivity_copy"] = old_radar.fields["reflectivity"]
+    gate_mapper = pyart.map.GateMapper(old_radar, new_radar)
     mapped_radar = gate_mapper.mapped_radar(["reflectivity"])
 
     # Test point outside of 1 min tolerance
     assert gate_mapper[20, 20] == (None, None)
-    assert gate_mapper[4, 4] == (26, 11)
+    assert gate_mapper[40, 40] == (40, 33)
     assert (
-        mapped_radar.fields["reflectivity"]["data"][26, 11]
-        == old_radar.fields["reflectivity"]["data"][4, 4]
+        mapped_radar.fields["reflectivity"]["data"][40, 33]
+        == old_radar.fields["reflectivity"]["data"][40, 40]
     )
 
+    # Check case where source radar has field destination doesn't
+    mapped_radar = gate_mapper.mapped_radar(["reflectivity_copy"])
+    assert (
+        mapped_radar.fields["reflectivity_copy"]["data"][40, 33]
+        == old_radar.fields["reflectivity_copy"]["data"][40, 40]
+    )
 
+ 
 def test_gatemapper_gatefilter():
     # Make fake radar with target
     old_radar = pyart.testing.make_target_radar()

--- a/tests/map/test_gatemapper.py
+++ b/tests/map/test_gatemapper.py
@@ -30,7 +30,7 @@ def test_gatemapper():
         == old_radar.fields["reflectivity_copy"]["data"][40, 40]
     )
 
- 
+
 def test_gatemapper_gatefilter():
     # Make fake radar with target
     old_radar = pyart.testing.make_target_radar()


### PR DESCRIPTION
GateMapper would throw an error if a source field was being mapped onto the destination radar if the field existed in the source radar but not the destination. This made it hard to map the beam blockage flag onto the cmac radar object. 

I've added a test for this and reworked the test to make more sense (old and new were backwards).
- [x] Tests added
