### PR TITLE
DOC: Add dedicated developers guide section

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - sphinx-design
   - sphinx-copybutton
   - nbsphinx
+  - pre_commit
   - pip
   - pip:
       - pooch

--- a/doc/source/dev/CONTRIBUTING.rst
+++ b/doc/source/dev/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../CONTRIBUTING.rst

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -1,0 +1,23 @@
+=================
+Developer's Guide
+=================
+
+.. toctree::
+   :maxdepth: 3
+   :hidden:
+
+   CONTRIBUTING
+
+This discusses information relevant to developing Py-ART.
+
+--------
+Versions
+--------
+Py-ART follows `semantic versioning <https://semver.org>`_ in its version number. This means
+that any Py-ART ``1.x`` release will be backwards compatible with an earlier ``1.y`` release. By
+"backward compatible", we mean that **correct** code that works on a ``1.y`` version will work
+on a future ``1.x`` version. It's always possible for bug fixes to change behavior or make
+incorrect code cease to work. Backwards-incompatible changes will only be allowed when changing
+to version ``2.0``. Such changes will be proceeded by `FutureWarning` as appropriate.
+For a version ``1.x.y``, we change ``x`` when we release new features, and ``y``
+when we make a release with only bug fixes.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,6 +12,13 @@ The Python ARM Radar Toolkit - Py-ART
 .. toctree::
    :maxdepth: 2
    :hidden:
+   :caption: Example Gallery
+
+   examples/index.rst
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
    :caption: Reference Guide
 
    API/index.rst
@@ -22,13 +29,6 @@ The Python ARM Radar Toolkit - Py-ART
    :caption: Developer's Guide
 
    dev/index.rst
-
-.. toctree::
-   :maxdepth: 2
-   :hidden:
-   :caption: Example Gallery
-
-   examples/index.rst
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Add a dedicated developer's guide section, which fixes the link to this on the main landing page.

- [x] Tests added
- [x] Documentation reflects changes
