### PR TITLE
Update accessor.py

### DIFF
--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -79,4 +79,4 @@ class Xradar:
             self.xradar = self.xradar.xradar.georeference()
 
         data = self.xradar[f"sweep_{sweep}"].xradar.georeference()
-        return data["x"].values, data["y"].values, data["x"].values
+        return data["x"].values, data["y"].values, data["z"].values


### PR DESCRIPTION
The function claims to return ```x, y, and z``` values, but it actually returns ```x, y, and x``` values. Is this discrepancy unintentional? If it's an error, please feel free to accept this pull request. If not, I apologize for any confusion arising from my pull request.





