### PR TITLE
FIX: Fix the small typo in xradar grid example

### DIFF
--- a/examples/xradar/plot_grid_xradar.py
+++ b/examples/xradar/plot_grid_xradar.py
@@ -1,7 +1,7 @@
 """
-==================================
-Plot a PPI Using Xradar and Py-ART
-==================================
+=================================
+Grid Data Using Xradar and Py-ART
+=================================
 
 An example which uses xradar and Py-ART to grid a PPI file.
 


### PR DESCRIPTION
Fix the typo in the title of the xradar gridding example

- [x] Tests added
- [x] Documentation reflects changes
