### PR TITLE
FIX: Fix the colormap in xradar examples

### DIFF
--- a/examples/xradar/plot_grid_xradar.py
+++ b/examples/xradar/plot_grid_xradar.py
@@ -36,5 +36,5 @@ grid = pyart.map.grid_from_radars(
 
 display = pyart.graph.GridMapDisplay(grid)
 display.plot_grid(
-    "reflectivity_horizontal", level=0, vmin=-20, vmax=60, cmap="ChaseSpectral"
+    "reflectivity_horizontal", level=0, vmin=-20, vmax=60, cmap="pyart_ChaseSpectral"
 )

--- a/examples/xradar/plot_xradar.py
+++ b/examples/xradar/plot_xradar.py
@@ -26,5 +26,5 @@ radar = pyart.xradar.Xradar(tree)
 # Plot the Reflectivity Field (corrected_reflectivity_horizontal)
 display = pyart.graph.RadarMapDisplay(radar)
 display.plot_ppi(
-    "corrected_reflectivity_horizontal", cmap="ChaseSpectral", vmin=-20, vmax=70
+    "corrected_reflectivity_horizontal", cmap="pyart_ChaseSpectral", vmin=-20, vmax=70
 )


### PR DESCRIPTION
Fix the colormaps used in the xradar suite of examples

- [x] Tests added
- [x] Documentation reflects changes
