### PR TITLE
ENH: xarray grid output

### DIFF
--- a/pyart/core/grid.py
+++ b/pyart/core/grid.py
@@ -315,106 +315,117 @@ class Grid:
             in a one dimensional array.
 
         """
-
         lon, lat = self.get_point_longitude_latitude()
         z = self.z["data"]
         y = self.y["data"]
         x = self.x["data"]
 
-        time = np.array([num2date(self.time["data"][0], self.time["units"])])
+        time = np.array(
+            [num2date(self.time["data"][0], units=self.time["units"])],
+            dtype="datetime64[ns]",
+        )
 
         ds = xarray.Dataset()
-        for field in list(self.fields.keys()):
-            field_data = self.fields[field]["data"]
+        for field, field_info in self.fields.items():
+            field_data = field_info["data"]
             data = xarray.DataArray(
                 np.ma.expand_dims(field_data, 0),
                 dims=("time", "z", "y", "x"),
                 coords={
-                    "time": (["time"], time),
-                    "z": (["z"], z),
+                    "time": time,
+                    "z": z,
                     "lat": (["y", "x"], lat),
                     "lon": (["y", "x"], lon),
-                    "y": (["y"], y),
-                    "x": (["x"], x),
+                    "y": y,
+                    "x": x,
                 },
             )
-            for meta in list(self.fields[field].keys()):
+
+            for meta, value in field_info.items():
                 if meta != "data":
-                    data.attrs.update({meta: self.fields[field][meta]})
+                    data.attrs.update({meta: value})
 
             ds[field] = data
 
-            ds.lon.attrs = [
-                ("long_name", "longitude of grid cell center"),
-                ("units", "degree_E"),
-                ("standard_name", "Longitude"),
-            ]
-            ds.lat.attrs = [
-                ("long_name", "latitude of grid cell center"),
-                ("units", "degree_N"),
-                ("standard_name", "Latitude"),
-            ]
+        ds.lon.attrs = [
+            ("long_name", "longitude of grid cell center"),
+            ("units", "degree_E"),
+            ("standard_name", "Longitude"),
+        ]
+        ds.lat.attrs = [
+            ("long_name", "latitude of grid cell center"),
+            ("units", "degree_N"),
+            ("standard_name", "Latitude"),
+        ]
 
-            ds.z.attrs = get_metadata("z")
-            ds.y.attrs = get_metadata("y")
-            ds.x.attrs = get_metadata("x")
+        ds.z.attrs = get_metadata("z")
+        ds.y.attrs = get_metadata("y")
+        ds.x.attrs = get_metadata("x")
 
-            ds.z.encoding["_FillValue"] = None
-            ds.lat.encoding["_FillValue"] = None
-            ds.lon.encoding["_FillValue"] = None
+        for attr in [ds.z, ds.lat, ds.lon]:
+            attr.encoding["_FillValue"] = None
 
-            # Delayed import
-            from ..io.grid_io import _make_coordinatesystem_dict
+        # Delayed import
+        from ..io.grid_io import _make_coordinatesystem_dict
 
-            ds["ProjectionCoordinateSystem"] = xarray.DataArray(
-                data=np.array(1, dtype="int32"),
-                dims=None,
-                attrs=_make_coordinatesystem_dict(self),
+        ds["ProjectionCoordinateSystem"] = xarray.DataArray(
+            data=np.array(1, dtype="int32"),
+            attrs=_make_coordinatesystem_dict(self),
+        )
+
+        # write the projection dictionary as a scalar
+        projection = self.projection.copy()
+        # NetCDF does not support boolean attribute, covert to string
+        if "_include_lon_0_lat_0" in projection:
+            include = projection["_include_lon_0_lat_0"]
+            projection["_include_lon_0_lat_0"] = ["false", "true"][include]
+        ds["projection"] = xarray.DataArray(
+            data=np.array(1, dtype="int32"),
+            dims=None,
+            attrs=projection,
+        )
+
+        for attr_name in [
+            "origin_latitude",
+            "origin_longitude",
+            "origin_altitude",
+            "radar_altitude",
+            "radar_latitude",
+            "radar_longitude",
+            "radar_time",
+        ]:
+            if hasattr(self, attr_name):
+                attr_data = getattr(self, attr_name)
+                if attr_data is not None:
+                    if "radar_time" not in attr_name:
+                        attr_value = np.ma.expand_dims(attr_data["data"][0], 0)
+                    else:
+                        attr_value = [
+                            np.array(
+                                num2date(
+                                    attr_data["data"][0],
+                                    units=attr_data["units"],
+                                ),
+                                dtype="datetime64[ns]",
+                            )
+                        ]
+                    dims = ("nradar",)
+                    ds[attr_name] = xarray.DataArray(
+                        attr_value, dims=dims, attrs=get_metadata(attr_name)
+                    )
+
+        if "radar_time" in ds.variables:
+            ds.radar_time.attrs.pop("calendar")
+
+        if self.radar_name is not None:
+            radar_name = self.radar_name["data"][0]
+            ds["radar_name"] = xarray.DataArray(
+                np.array([b"".join(radar_name)], dtype="S4"),
+                dims=("nradar"),
+                attrs=get_metadata("radar_name"),
             )
-
-            if self.origin_latitude is not None:
-                ds["origin_latitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.origin_latitude["data"][0], 0),
-                    dims=("time"),
-                    attrs=get_metadata("origin_latitude"),
-                )
-
-            if self.origin_longitude is not None:
-                ds["origin_longitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.origin_longitude["data"][0], 0),
-                    dims=("time"),
-                    attrs=get_metadata("origin_longitude"),
-                )
-
-            if self.origin_altitude is not None:
-                ds["origin_altitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.origin_altitude["data"][0], 0),
-                    dims=("time"),
-                    attrs=get_metadata("origin_altitude"),
-                )
-
-            if self.radar_altitude is not None:
-                ds["radar_altitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.radar_altitude["data"][0], 0),
-                    dims=("nradar"),
-                    attrs=get_metadata("radar_altitude"),
-                )
-
-            if self.radar_latitude is not None:
-                ds["radar_latitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.radar_latitude["data"][0], 0),
-                    dims=("nradar"),
-                    attrs=get_metadata("radar_latitude"),
-                )
-
-            if self.radar_longitude is not None:
-                ds["radar_longitude"] = xarray.DataArray(
-                    np.ma.expand_dims(self.radar_longitude["data"][0], 0),
-                    dims=("nradar"),
-                    attrs=get_metadata("radar_longitude"),
-                )
-
-            ds.close()
+        ds.attrs = self.metadata
+        ds.close()
         return ds
 
     def add_field(self, field_name, field_dict, replace_existing=False):


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Implementation of https://github.com/ARM-DOE/pyart/discussions/1476#discussion-5735867

To streamline the process of extracting a subset from `pyart.core.grid` or the grid object, I propose to add a few more variables to the `xarray dataset` that mirrors the grid object. When this `xarray dataset` is written to a `NetCDF` file, it becomes equivalent to the original `pyart.core.grid` object.

How can this be utilized?

```python
import pyart

# Reading a grid from a netcdf file
grid = pyart.io.read_grid("file.nc")

# Converting the grid to an xarray dataset
ds = grid.to_xarray()

# Slicing the dataset based on x and y coordinates
ds = ds.sel(x=slice(5000, 70000), y=slice(5000, 70000), drop=True)

# Saving the sliced dataset to a new netcdf file
ds.to_netcdf("outfile.nc")
```

Subsequently, it is possible to read the modified dataset using `pyart` as follows:

```python
# Reading the modified dataset with pyart
grid_small = pyart.io.read_grid("outfile.nc")
```

This enhances the process of working with grid data, making it more convenient and efficient for users. 
