### PR TITLE
FIX: Fix setting scan_mode when scan_name is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           environment-file: continuous_integration/environment-ci.yml
           activate-environment: pyart-dev
           cache-downloads: true
-          python-version: ${{ matrix.python-version }}
+          create-args: python=${{ matrix.python-version }}
 
       - name: Fetch all history for all tags and branches
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: continuous_integration/environment-ci.yml
-          activate-environment: pyart-dev
+          environment-name: pyart-dev
           cache-downloads: true
           create-args: python=${{ matrix.python-version }}
 

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytest-cov
   - pytest-mpl
   - coveralls
-  - libnetcdf<=4.9.1
+  - libnetcdf
   - flake8
   - fsspec
   - glpk

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -192,7 +192,9 @@ def read_cfradial(
         ray_angle_res = None
 
     # Uses ARM scan name if present.
-    if hasattr(ncobj, "scan_name"):
+    if not hasattr(ncobj, "scan_name"):
+        ncobj.scan_name = ""
+    elif len(ncobj.scan_name) > 0:
         mode = ncobj.scan_name
     else:
         # first sweep mode determines scan_type

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -193,9 +193,11 @@ def read_cfradial(
 
     # Uses ARM scan name if present.
     if not hasattr(ncobj, "scan_name"):
-        ncobj.scan_name = ""
-    elif len(ncobj.scan_name) > 0:
-        mode = ncobj.scan_name
+        scan_name = ""
+    else:
+        scan_name = ncobj.scan_name
+    if len(scan_name) > 0:
+        mode = scan_name
     else:
         # first sweep mode determines scan_type
         try:


### PR DESCRIPTION
This fixes reading in the scan_mode when the scan_name is an empty string

- [x] Closes #1481 
- [x] Tests added
- [x] Documentation reflects changes
