### PR TITLE
Update rainbow_wrl.py

### DIFF
--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -282,7 +282,7 @@ def read_rainbow_wrl(
         # all sweeps have to have the same range resolution
         for i in range(nslices):
             slice_info = rbf["volume"]["scan"]["slice"][i]
-            if slice_info['rangestep'] != common_slice_info["rangestep"]:
+            if slice_info["rangestep"] != common_slice_info["rangestep"]:
                 raise ValueError("range resolution changes between sweeps")
 
     r_res = float(common_slice_info["rangestep"]) * 1000.0

--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -282,7 +282,7 @@ def read_rainbow_wrl(
         # all sweeps have to have the same range resolution
         for i in range(nslices):
             slice_info = rbf["volume"]["scan"]["slice"][i]
-            if (slice_info['rangestep'] != common_slice_info["rangestep"]):
+            if slice_info['rangestep'] != common_slice_info["rangestep"]:
                 raise ValueError("range resolution changes between sweeps")
 
     r_res = float(common_slice_info["rangestep"]) * 1000.0
@@ -354,7 +354,7 @@ def read_rainbow_wrl(
             slice_info["slicedata"]["rawdata"],
             rays_per_sweep[i],
             nbins_sweep[i],
-            maxbin
+            maxbin,
         )
 
     if bfile.endswith(".vol") or bfile.endswith(".azi"):

--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -278,6 +278,13 @@ def read_rainbow_wrl(
     sweep_end_ray_index["data"] = seri
 
     # range
+    if not single_slice:
+        # all sweeps have to have the same range resolution
+        for i in range(nslices):
+            slice_info = rbf["volume"]["scan"]["slice"][i]
+            if (slice_info['rangestep'] != common_slice_info["rangestep"]):
+                raise ValueError("range resolution changes between sweeps")
+
     r_res = float(common_slice_info["rangestep"]) * 1000.0
     if "start_range" in common_slice_info.keys():
         start_range = float(common_slice_info["start_range"]) * 1000.0

--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -286,6 +286,8 @@ def read_rainbow_wrl(
     _range["data"] = np.linspace(
         start_range + r_res / 2.0, float(maxbin - 1.0) * r_res + r_res / 2.0, maxbin
     ).astype("float32")
+    _range["meters_between_gates"] = r_res
+    _range["meters_to_center_of_first_gate"] = _range["data"][0]
 
     # containers for data
     t_fixed_angle = np.empty(nslices, dtype="float64")
@@ -342,7 +344,10 @@ def read_rainbow_wrl(
 
         # data
         fdata[ssri[i] : seri[i] + 1, :] = _get_data(
-            slice_info["slicedata"]["rawdata"], rays_per_sweep[i], nbins_sweep[i], maxbin
+            slice_info["slicedata"]["rawdata"],
+            rays_per_sweep[i],
+            nbins_sweep[i],
+            maxbin
         )
 
     if bfile.endswith(".vol") or bfile.endswith(".azi"):
@@ -485,9 +490,9 @@ def _get_data(rawdata, nrays, nbins, maxbin):
     mask = np.reshape(mask, [nrays, nbins])
 
     data_tmp = np.full((nrays, maxbin), get_fillvalue())
-    data_tmp[:nrays,:nbins] = data
+    data_tmp[:nrays, :nbins] = data
     mask_tmp = np.full((nrays, maxbin), True)
-    mask_tmp[:nrays,:nbins] = mask
+    mask_tmp[:nrays, :nbins] = mask
 
     masked_data = np.ma.array(data_tmp, mask=mask_tmp, fill_value=get_fillvalue())
 


### PR DESCRIPTION
Prevent the program from crashing when the number of bins changes between sweeps.

In my rb5 dataset, the number of bins would change between sweeps. Therefore,
I adjusted the array size to match the maximum number of bins.
(I'm not sure whether this is appropriate or safe.)
