### PR TITLE
FIX: Fix failing CI by pinning older metpy versions

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy
   - cvxopt
   - xarray
-  - metpy
+  - metpy<1.6
   - pytest-cov
   - pytest-mpl
   - coveralls

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - netcdf4
   - pytest
   - wradlib
-  - metpy
+  - metpy<1.6
   - cartopy
   - cvxopt
   - xarray


### PR DESCRIPTION
Until #1500 is resolved, let's pin to the non-latest release of MetPy for the doc/CI system. Once the upstream issue is resolved, we can remove these pins.

- [x] Tests added
- [x] Documentation reflects changes
