### PR TITLE
FIX: Remove the metpy pin for doc build and CI

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy
   - cvxopt
   - xarray
-  - metpy<1.6
+  - metpy
   - pytest-cov
   - pytest-mpl
   - coveralls

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - netcdf4
   - pytest
   - wradlib
-  - metpy<1.6
+  - metpy
   - cartopy
   - cvxopt
   - xarray


### PR DESCRIPTION
Remove the pin for metpy versions, which was added there to resolve issues with the cross section functionality.

- [x] Closes #1500 
- [x] Tests added
- [x] Documentation reflects changes
