### PR TITLE
FIX: Fix the name of download-upload-artifact action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: ./dist/*.whl
 
   build_sdist:
@@ -94,7 +94,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
           path: dist
 
       - name: Publish to PyPI


### PR DESCRIPTION
Fix the usage of the new upload/download artifact action

- [x] Closes #1523
- [x] Documentation reflects changes
