### PR TITLE
FIX: Possible fix for upload failure for wheels.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -94,8 +94,9 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          pattern: wheels-*
           path: dist
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.12

--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -498,9 +498,7 @@ def feature_detection(
             "valid_min": 0,
             "valid_max": 3,
             "comment_1": (
-                "{} = No surface echo/Undefined, {} = Background echo, {} = Features, {} = weak echo".format(
-                    nosfcecho, bkgd_val, feat_val, weakecho
-                )
+                f"{nosfcecho} = No surface echo/Undefined, {bkgd_val} = Background echo, {feat_val} = Features, {weakecho} = weak echo"
             ),
         }
     }
@@ -583,9 +581,7 @@ def feature_detection(
             "valid_min": 0,
             "valid_max": 3,
             "comment_1": (
-                "{} = No surface echo/Undefined, {} = Background echo, {} = Features, {} = weak echo".format(
-                    nosfcecho, bkgd_val, feat_val, weakecho
-                )
+                f"{nosfcecho} = No surface echo/Undefined, {bkgd_val} = Background echo, {feat_val} = Features, {weakecho} = weak echo"
             ),
         }
 
@@ -596,9 +592,7 @@ def feature_detection(
             "valid_min": 0,
             "valid_max": 3,
             "comment_1": (
-                "{} = No surface echo/Undefined, {} = Background echo, {} = Features, {} = weak echo".format(
-                    nosfcecho, bkgd_val, feat_val, weakecho
-                )
+                f"{nosfcecho} = No surface echo/Undefined, {bkgd_val} = Background echo, {feat_val} = Features, {weakecho} = weak echo"
             ),
         }
 


### PR DESCRIPTION
When each os wheels zip is created, they are stored with macos.zip etc etc. I'm wondering if its having a hard time finding the wheels within each. I looked up some docs and looks like if there is multiple artifacts, might be able to download from each. Might be a solution...