### PR TITLE
FIX: Use existing time extraction in Py-ART in columnsect

### DIFF
--- a/pyart/util/columnsect.py
+++ b/pyart/util/columnsect.py
@@ -9,6 +9,7 @@ import pandas as pd
 import xarray as xr
 
 from ..core.transforms import antenna_vectors_to_cartesian
+from .datetime_utils import datetime_from_radar
 
 
 def column_vertical_profile(
@@ -350,8 +351,7 @@ def get_field_location(radar, latitude, longitude):
 
     # Determine the time at the center of each ray within the column
     # Define the start of the radar volume as a numpy datetime object for xr
-    # We take advantage of the "seconds since " portion of the units string
-    base_time = pd.to_datetime(radar.time["units"][14:]).to_numpy()
+    base_time = np.datetime64(datetime_from_radar(radar).isoformat())
     # Convert Py-ART radar object time (time since volume start) to time delta
     # Add to base time to have sequential time within the xr Dataset
     # for easier future merging/work


### PR DESCRIPTION
Instead of using the units attribute separately, use the existing utility in Py-ART that deals with this more robustly

- [x] Closes #1527 
- [ ] Tests added
- [x] Documentation reflects changes
