### PR TITLE
FIX: Revert to oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "setuptools_scm>=6.2",
   "wheel",
   "cython>=3.0",
-  "numpy>=2.0.0rc1"
+  "oldest-supported-numpy"
 ]
 
 [tool.black]


### PR DESCRIPTION
Revert to oldest-supported-numpy until cython tested.

- [x] Tests added
- [x] Documentation reflects changes
