### PR TITLE
MNT: Update arm_scan_name to be optional. Also dep warning fix.

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -56,6 +56,7 @@ def read_cfradial(
     exclude_fields=None,
     include_fields=None,
     delay_field_loading=False,
+    use_arm_scan_name=False,
     **kwargs,
 ):
     """
@@ -92,6 +93,10 @@ def read_cfradial(
         LazyLoadDict objects not dict objects. Delayed field loading will not
         provide any speedup in file where the number of gates vary between
         rays (ngates_vary=True) and is not recommended.
+    use_arm_scan_name : bool
+        Whether or not to get the sweep_mode information from the ARM scan_name
+        attribute. Default is False and will use the sweep_mode information as
+        defined in the cfradial standards.
 
     Returns
     -------
@@ -126,7 +131,7 @@ def read_cfradial(
     if "volume_number" in ncvars:
         if np.ma.isMaskedArray(ncvars["volume_number"][:]):
             metadata["volume_number"] = int(
-                np.ma.getdata(ncvars["volume_number"][:].flatten())
+                np.ma.getdata(ncvars["volume_number"][:].flatten())[0]
             )
         else:
             metadata["volume_number"] = int(ncvars["volume_number"][:])
@@ -191,20 +196,27 @@ def read_cfradial(
     else:
         ray_angle_res = None
 
-    # Uses ARM scan name if present.
-    if not hasattr(ncobj, "scan_name"):
-        scan_name = ""
-    else:
-        scan_name = ncobj.scan_name
-    if len(scan_name) > 0:
-        mode = scan_name
-    else:
-        # first sweep mode determines scan_type
-        try:
-            mode = netCDF4.chartostring(sweep_mode["data"][0])[()].decode("utf-8")
-        except AttributeError:
-            # Python 3, all strings are already unicode.
+    # Use ARM scan_name if chosen by the user
+    if use_arm_scan_name:
+        # Check if attribute actually exists
+        if not hasattr(ncobj, "scan_name"):
+            warning.warn(
+                UserWarning,
+                "No scan_name attribute present in dataset, using sweep_mode instead."
+            )
             mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
+        # Check if attribute is invalid of length 0
+        elif len(ncobj.scan_name) < 0 or ncobj.scan_name is None:
+            warning.warn(
+                UserWarning,
+                "Scan name contains no sweep information, using sweep_mode instead."
+            )
+            mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
+        else:
+            mode = ncobj.scan_name
+    else:
+        # Use sweep_mode if arm_scan_name isn't used. This is default
+        mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
 
     mode = mode.strip()
 

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -202,14 +202,14 @@ def read_cfradial(
         if not hasattr(ncobj, "scan_name"):
             warning.warn(
                 UserWarning,
-                "No scan_name attribute present in dataset, using sweep_mode instead."
+                "No scan_name attribute present in dataset, using sweep_mode instead.",
             )
             mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
         # Check if attribute is invalid of length 0
         elif len(ncobj.scan_name) < 0 or ncobj.scan_name is None:
             warning.warn(
                 UserWarning,
-                "Scan name contains no sweep information, using sweep_mode instead."
+                "Scan name contains no sweep information, using sweep_mode instead.",
             )
             mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
         else:

--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -200,14 +200,14 @@ def read_cfradial(
     if use_arm_scan_name:
         # Check if attribute actually exists
         if not hasattr(ncobj, "scan_name"):
-            warning.warn(
+            warnings.warn(
                 UserWarning,
                 "No scan_name attribute present in dataset, using sweep_mode instead.",
             )
             mode = netCDF4.chartostring(sweep_mode["data"][0])[()]
         # Check if attribute is invalid of length 0
         elif len(ncobj.scan_name) < 0 or ncobj.scan_name is None:
-            warning.warn(
+            warnings.warn(
                 UserWarning,
                 "Scan name contains no sweep information, using sweep_mode instead.",
             )


### PR DESCRIPTION
@mgrover1 My thought process for this was to have the arm_scan_name as an optional parameter as sweep_mode (from what im seeing in the cfradial document) contains the information we should be using by default. I'm leaving the option for arm_scan_name if the scan type is stored there instead. Idk if this is the best way forward for this? But figured I'd post the idea here.

- [x] Closes #1533
