### PR TITLE
BUG: Update to Column Vertical Profile Handling of Defining Radar Basetime

### DIFF
--- a/pyart/util/columnsect.py
+++ b/pyart/util/columnsect.py
@@ -69,7 +69,7 @@ def column_vertical_profile(
     total_moment.update({"height": [], "time_offset": []})
 
     # Define the start of the radar volume
-    base_time = pd.to_datetime(radar.time["units"][14:]).to_numpy()
+    base_time = np.datetime64(pyart.util.datetime_from_radar(radar).isoformat(), "ns")
 
     # call the sphere_distance function
     dis = sphere_distance(

--- a/pyart/util/columnsect.py
+++ b/pyart/util/columnsect.py
@@ -69,7 +69,7 @@ def column_vertical_profile(
     total_moment.update({"height": [], "time_offset": []})
 
     # Define the start of the radar volume
-    base_time = np.datetime64(pyart.util.datetime_from_radar(radar).isoformat(), "ns")
+    base_time = np.datetime64(datetime_from_radar(radar).isoformat(), "ns")
 
     # call the sphere_distance function
     dis = sphere_distance(


### PR DESCRIPTION
Similar to `get_field_location`, definition of the start of the radar volume updated to use the utility `datetime_from_radar`