### PR TITLE
FIX: Fix builds for latest scipy

### DIFF
--- a/pyart/retrieve/comp_z.py
+++ b/pyart/retrieve/comp_z.py
@@ -8,7 +8,7 @@ import copy
 import numpy as np
 from netCDF4 import num2date
 from pandas import to_datetime
-from scipy.interpolate import interp2d
+from scipy.interpolate import RectBivariateSpline
 
 from pyart.core import Radar
 
@@ -103,10 +103,10 @@ def composite_reflectivity(radar, field="reflectivity", gatefilter=None):
 
         else:
             # Configure the intperpolator
-            z_interpolator = interp2d(ranges, az, z, kind="linear")
+            z_interpolator = RectBivariateSpline(az, ranges, z)
 
             # Apply the interpolation
-            z = z_interpolator(ranges, azimuth_final)
+            z = z_interpolator(azimuth_final, ranges)
 
         # if first sweep, create new dim, otherwise concat them up
         if sweep == minimum_sweep:

--- a/tests/retrieve/test_comp_z.py
+++ b/tests/retrieve/test_comp_z.py
@@ -3,7 +3,7 @@
 import copy
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_equal
+from numpy.testing import assert_array_almost_equal, assert_equal
 
 import pyart
 
@@ -85,7 +85,7 @@ def test_composite_z():
 
     # choose a random az
     random_az = np.random.randint(0, 720)
-    assert_array_equal(
+    assert_array_almost_equal(
         compz.fields["composite_reflectivity"]["data"][random_az, :],
         np.arange(0, z.shape[1]),
     )


### PR DESCRIPTION
Fix the deprecated interp2d in composite z calculation
- [x] Closes #1605 
- [x] Tests added
- [x] Documentation reflects changes
