### PR TITLE
ADD: Add to_radar() method to xradar objects

### DIFF
--- a/examples/xradar/plot_dealias_xradar.py
+++ b/examples/xradar/plot_dealias_xradar.py
@@ -23,7 +23,7 @@ filename = get_test_data("swx_20120520_0641.nc")
 tree = xd.io.open_cfradial1_datatree(filename)
 
 # Give the tree Py-ART radar methods
-radar = pyart.xradar.Xradar(tree)
+radar = tree.pyart.to_radar()
 
 # Determine the nyquist velocity using the maximum radial velocity from the first sweep
 nyq = radar["sweep_0"]["mean_doppler_velocity"].max().values

--- a/examples/xradar/plot_grid_xradar.py
+++ b/examples/xradar/plot_grid_xradar.py
@@ -21,7 +21,7 @@ filename = get_test_data("swx_20120520_0641.nc")
 tree = xd.io.open_cfradial1_datatree(filename)
 
 # Give the tree Py-ART radar methods
-radar = pyart.xradar.Xradar(tree)
+radar = tree.pyart.to_radar()
 
 # Grid using 11 vertical levels, and 101 horizontal grid cells at a resolution on 1 km
 grid = pyart.map.grid_from_radars(

--- a/examples/xradar/plot_xradar.py
+++ b/examples/xradar/plot_xradar.py
@@ -21,7 +21,7 @@ filename = get_test_data("swx_20120520_0641.nc")
 tree = xd.io.open_cfradial1_datatree(filename)
 
 # Give the tree Py-ART radar methods
-radar = pyart.xradar.Xradar(tree)
+radar = tree.pyart.to_radar()
 
 # Plot the Reflectivity Field (corrected_reflectivity_horizontal)
 display = pyart.graph.RadarMapDisplay(radar)

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -154,3 +154,16 @@ def test_grid_write_read():
         assert grid1.radar_name["data"] == grid2.radar_name["data"]
         assert grid1.nradar == grid2.nradar
         grid2.ds.close()
+
+
+def test_to_xradar_object():
+    """Test the to_radar_object"""
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = dtree.pyart.to_radar()
+    reflectivity = radar.get_field(0, "DBZ")
+    assert reflectivity.shape == (480, 996)
+    assert radar.nsweeps == 9
+    assert radar.ngates == 996


### PR DESCRIPTION
Add a to_radar() method to xradar using the accessor interface.

- [x] Closes #670 
- [x] Tests added
- [x] Documentation reflects changes
