### PR TITLE
DOC: Enable readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+version: 2
+conda:
+  environment: doc/environment.yml
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"


### PR DESCRIPTION
Enable readthedocs by adding a configuration file

- [x] Closes #1624 
- [x] Tests added
- [x] Documentation reflects changes
