### PR TITLE
FIX: Ensure backwards compatibility with datatree/new versions of xarray

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [macos, ubuntu, windows]
 
     steps:

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -12,7 +12,7 @@ dependencies:
   - wradlib
   - cartopy
   - cvxopt
-  - xarray<=2024.9.0
+  - xarray>=2024.10.0
   - metpy
   - pytest-cov
   - pytest-mpl
@@ -25,7 +25,7 @@ dependencies:
   - shapely
   - ruff
   - mda-xdrlib
-  - xradar<=0.7.0
+  - xradar>=0.8.0
   - pooch
   - versioneer
   - black

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - metpy
   - cartopy
   - cvxopt
-  - xarray<=2024.9.0
+  - xarray>=2024.10.0
   - sphinx<7.2
   - ipython
   - pandoc
@@ -34,7 +34,7 @@ dependencies:
   - pre_commit
   - cmweather
   - mda-xdrlib
-  - xradar<=0.7.0
+  - xradar>=0.8.0
   - dask
   - pip
   - pip:

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -7,15 +7,21 @@ import copy
 
 import numpy as np
 import pandas as pd
+
 try:
+    from xarray.core import formatting, formatting_html
+    from xarray.core.datatree import DataTree
     from xarray.core.extensions import register_datatree_accessor
     from xarray.core.treenode import NodePath
-    from xarray.core.datatree import DataTree
-    from xarray.core import formatting, formatting_html
 except ImportError:
-    from datatree import register_datatree_accessor
-    from datatree import DataTree, formatting, formatting_html
+    from datatree import (
+        DataTree,
+        formatting,
+        formatting_html,
+        register_datatree_accessor,
+    )
     from datatree.treenode import NodePath
+
 from xarray import DataArray, Dataset, concat
 from xarray.core import utils
 from xradar.accessors import XradarAccessor

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -5,11 +5,17 @@ Utilities for interfacing between xradar and Py-ART
 
 import copy
 
-import datatree
 import numpy as np
 import pandas as pd
-from datatree import DataTree, formatting, formatting_html
-from datatree.treenode import NodePath
+try:
+    from xarray.core.extensions import register_datatree_accessor
+    from xarray.core.treenode import NodePath
+    from xarray.core.datatree import DataTree
+    from xarray.core import formatting, formatting_html
+except ImportError:
+    from datatree import register_datatree_accessor
+    from datatree import DataTree, formatting, formatting_html
+    from datatree.treenode import NodePath
 from xarray import DataArray, Dataset, concat
 from xarray.core import utils
 from xradar.accessors import XradarAccessor
@@ -807,7 +813,7 @@ def _point_altitude_data_factory(grid):
     return _point_altitude_data
 
 
-@datatree.register_datatree_accessor("pyart")
+@register_datatree_accessor("pyart")
 class XradarDataTreeAccessor(XradarAccessor):
     """Adds a number of pyart specific methods to datatree.DataTree objects."""
 

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -18,8 +18,8 @@ except ImportError:
         DataTree,
         formatting,
         formatting_html,
-        register_datatree_accessor,
     )
+    from datatree.extensions import register_datatree_accessor
     from datatree.treenode import NodePath
 
 from xarray import DataArray, Dataset, concat

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ cftime
 fsspec
 s3fs
 open_radar_data
-xradar<=0.7.0
+xradar>=0.8.0
 pandas
 mda-xdrlib
-xarray<=2024.9.0
+xarray>=2024.10.0
 cartopy
 pint


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

xarray-datatree has been merged to xarray>=2024.10.0. Since xarray version is not pinned, this will cause ImportErrors unless addressed. This is PR is an attempt towards a phased transition to using `xarray.datatree`.