### PR TITLE
DEP: Update to only support python 3.10+ wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312*"
+          CIBW_BUILD: "cp310-* cp311-* cp312*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
           MACOSX_DEPLOYMENT_TARGET: "10.9" # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently


### PR DESCRIPTION
In accordance with NEP/scientific python support, only support wheels for 3.10+

- [x] Tests added
- [x] Documentation reflects changes
