### PR TITLE
ADD: Add ablog to docs using conda not pip

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -36,9 +36,9 @@ dependencies:
   - mda-xdrlib
   - xradar>=0.8.0
   - dask
+  - ablog
   - pip
   - pip:
       - pooch
       - versioneer
-      - ablog
       - -e ..

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - cartopy
   - cvxopt
   - xarray>=2024.10.0
-  - sphinx<7.2
+  - sphinx==7.1.2
   - ipython
   - pandoc
   - pkg-config

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_gallery.gen_gallery",
     "sphinx_design",
+    "nbsphinx",
     "myst_nb",
     "ablog",
 ]


### PR DESCRIPTION
Install ablog in the environment using conda

- [x] Closes #xxxx
- [x] Tests added
- [x] Documentation reflects changes
