### PR TITLE
CI: Update ci to use python 3.13, 3.12 and 3.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [macos, ubuntu, windows]
 
     steps:

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -7,7 +7,7 @@ Required Dependencies
 
 Py-ART requires the following software.
 
-* Python__ 3.9x, 3.10x or 3.11x
+* Python__ 3.11x, 3.12x or 3.13x
 
 __ http://www.python.org
 

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Other related open source software for working with weather radar data:
 Dependencies
 ============
 
-Py-ART is tested to work under Python 3.9, 3.10, 3.11, and 3.12.
+Py-ART is tested to work under Python 3.11, 3.12, and 3.13.
 
 The required dependencies to install Py-ART in addition to Python are:
 
@@ -287,6 +287,10 @@ The latest source code can be obtained with the command::
 
 If you are planning on making changes that you would like included in Py-ART,
 forking the repository is highly recommended.
+
+Getting help
+------------
+Py-ART has a `Discussion Forum <https://github.com/ARM-DOE/pyart/discussions>`_ where you can ask questions and request help.
 
 Contributing
 -------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -200,7 +200,7 @@ Additional detail on installing Py-ART can be found in the installation section.
 Dependencies
 ============
 
-Py-ART is tested to work under Python 3.9, 3.10, 3.11, and 3.12.
+Py-ART is tested to work under Python 3.11, 3.12, and 3.13.
 
 The required dependencies to install Py-ART in addition to Python are:
 
@@ -271,7 +271,7 @@ functionality is available of the following modules are installed.
 
 Getting help
 ============
-Py-ART has a `mailing list <https://groups.google.com/forum/#!forum/pyart-users>`_ where you can ask questions and request help.
+Py-ART has a `Discussion Forum <https://github.com/ARM-DOE/pyart/discussions>`_ where you can ask questions and request help.
 
 Contributing
 ============

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.13
   - numpy
   - scipy
   - matplotlib


### PR DESCRIPTION
CI: Update ci to use python 3.13, 3.12 and 3.11. CI should work as it now does for the Py-ART conda-forge recipe. Also updated docs to remove google groups

- [x] Documentation reflects changes
