### PR TITLE
CI: Remove mamba 2.0 pin as pip install issues are resolved in 2.0.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
         uses: mamba-org/setup-micromamba@v2.0.4
         with:
           environment-file: continuous_integration/environment-ci.yml
-          micromamba-version: '2.0.0-0'
           init-shell: >-
             bash
           cache-downloads: true


### PR DESCRIPTION
Should be able to use pip installations in the environment yml file again if need be.