### PR TITLE
ADD: Extract sweeps method to xradar object.

### DIFF
--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -955,9 +955,11 @@ class Xradar:
             Radar object which contains a copy of data from the selected
             sweeps.
         """
+        # Add proper indexing names
         sweeps_str = ["sweep_" + str(i) for i in sweeps]
         sweep_dict = {}
 
+        # Grab only selected sweeps while dropping old sweep information
         az_max_shape = self.xradar.children[sweeps_str[0]].azimuth.shape[0]
         range_max_shape = self.xradar.children[sweeps_str[0]].range.shape[0]
 
@@ -968,7 +970,10 @@ class Xradar:
                 drop=True,
             )
 
+        # Create new datatree containing selected sweeps
         dt_sweeps = DataTree(children=sweep_dict)
+
+        # Copys over attrs and modified sweep info
         dt_sweeps.attrs = self.xradar.attrs
         sweep_group_name_data = DataArray(
             self.xradar.sweep_group_name.values[sweeps],

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -409,9 +409,10 @@ class Xradar:
             "standard_name": "sweep_mode",
             "long_name": "Sweep mode",
         }
-        if "sweep_mode" in self.xradar["sweep_0"]:
+        sweep_list = list(self.xradar.children.keys())
+        if "sweep_mode" in self.xradar[sweep_list[0]]:
             sweep_mode["data"] = np.array(
-                self.nsweeps * [str(self.xradar["sweep_0"].sweep_mode.values)],
+                self.nsweeps * [str(self.xradar[sweep_list[0]].sweep_mode.values)],
                 dtype="S",
             )
         else:
@@ -955,6 +956,14 @@ class Xradar:
             Radar object which contains a copy of data from the selected
             sweeps.
         """
+
+        # parse and verify parameters
+        verify_sweeps = np.array(sweeps, dtype="int32")
+        if np.any(verify_sweeps > (self.nsweeps - 1)):
+            raise ValueError("invalid sweeps indices in sweeps parameter")
+        if np.any(verify_sweeps < 0):
+            raise ValueError("only positive sweeps can be extracted")
+
         # Add proper indexing names
         sweeps_str = ["sweep_" + str(i) for i in sweeps]
         sweep_dict = {}

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -409,7 +409,7 @@ class Xradar:
             "standard_name": "sweep_mode",
             "long_name": "Sweep mode",
         }
-        sweep_list = list(self.xradar.children.keys())
+        sweep_list = get_sweep_keys(self.xradar)
         if "sweep_mode" in self.xradar[sweep_list[0]]:
             sweep_mode["data"] = np.array(
                 self.nsweeps * [str(self.xradar[sweep_list[0]].sweep_mode.values)],

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import xarray as xr
 import xradar as xd
 from numpy.testing import assert_allclose, assert_almost_equal
@@ -130,6 +131,9 @@ def test_extract_sweeps():
     assert "sweep_7" not in test_radar.xradar.children.keys()
 
     assert np.round(test_radar.latitude["data"][0], 4) == 36.4908
+
+    pytest.raises(ValueError, radar.extract_sweeps, [0, 50])
+    pytest.raises(ValueError, radar.extract_sweeps, [-1, 1])
 
 
 def _check_attrs_similar(grid1, grid2, attr):

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -7,6 +7,7 @@ from open_radar_data import DATASETS
 import pyart
 
 filename = DATASETS.fetch("cfrad.20080604_002217_000_SPOL_v36_SUR.nc")
+filename_multiple_sweeps = DATASETS.fetch("swx_20120520_0641.nc")
 cfradial2_file = DATASETS.fetch("cfrad2.20080604_002217_000_SPOL_v36_SUR.nc")
 
 COMMON_MAP_TO_GRID_ARGS = {
@@ -112,6 +113,23 @@ def test_grid(filename=filename):
     )
     assert_allclose(grid.x["data"], np.arange(-100_000, 120_000, 20_000))
     assert_allclose(grid.fields["DBZ"]["data"][0, -1, 0], np.array(-0.511), rtol=1e-03)
+
+
+def test_extract_sweeps():
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+    sweeps = [0, 5, 6, 8]
+
+    test_radar = radar.extract_sweeps(sweeps)
+
+    assert test_radar.nsweeps == 5
+    assert "sweep_0" in test_radar.xradar.children.keys()
+    assert "sweep_7" not in test_radar.xradar.children.keys()
+
+    assert test_radar.latitude["data"][0] == 36.49083333
 
 
 def _check_attrs_similar(grid1, grid2, attr):

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -117,7 +117,7 @@ def test_grid(filename=filename):
 
 def test_extract_sweeps():
     dtree = xd.io.open_cfradial1_datatree(
-        filename,
+        filename_multiple_sweeps,
         optional=False,
     )
     radar = pyart.xradar.Xradar(dtree)

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -129,7 +129,7 @@ def test_extract_sweeps():
     assert "sweep_0" in test_radar.xradar.children.keys()
     assert "sweep_7" not in test_radar.xradar.children.keys()
 
-    assert test_radar.latitude["data"][0] == 36.49083333
+    assert np.round(test_radar.latitude["data"][0], 4) == 36.4908
 
 
 def _check_attrs_similar(grid1, grid2, attr):

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -125,7 +125,7 @@ def test_extract_sweeps():
 
     test_radar = radar.extract_sweeps(sweeps)
 
-    assert test_radar.nsweeps == 5
+    assert test_radar.nsweeps == 4
     assert "sweep_0" in test_radar.xradar.children.keys()
     assert "sweep_7" not in test_radar.xradar.children.keys()
 


### PR DESCRIPTION
I'm still encountering one issue I can't figure out at all...

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[19], line 1
----> 1 ds = pyart.map.grid_ppi_sweeps(radar)

File ~/dev/pyart/pyart/map/grid_mapper.py:974, in grid_ppi_sweeps(radar, target_sweeps, grid_size, grid_limits, max_z, el_rounding_frac, add_grid_altitude, **kwargs)
    971     target_sweeps = np.arange(radar.nsweeps)
    973 for sweep in target_sweeps:
--> 974     radar_sw = radar.extract_sweeps([sweep])
    975     sweep_grid = grid_from_radars(
    976         (radar_sw,),
    977         grid_shape=grid_shape,
   (...)
    981         **kwargs,
    982     )
    984     # Convert to xarray.Dataset and finalize

File ~/dev/pyart/pyart/xradar/accessor.py:983, in Xradar.extract_sweeps(self, sweeps)
    981 dt_sweeps['longitude'] = self.xradar.longitude
    982 dt_sweeps['altitude'] = self.xradar.altitude
--> 983 return dt_sweeps.pyart.to_radar()

File ~/dev/pyart/pyart/xradar/accessor.py:1089, in XradarDataTreeAccessor.to_radar(self, scan_type)
   1077 """
   1078 Add pyart radar object methods to the xradar datatree object
   1079 Parameters
   (...)
   1086     Datatree including pyart.Radar methods
   1087 """
   1088 dt = self.xarray_obj
-> 1089 return Xradar(dt, scan_type=scan_type)

File ~/dev/pyart/pyart/xradar/accessor.py:353, in Xradar.__init__(self, xradar, default_sweep, scan_type)
    347 self.projection = {"proj": "pyart_aeqd", "_include_lon_0_lat_0": True}
    348 self.sweep_number = {
    349     "standard_name": "sweep_number",
    350     "long_name": "Sweep number",
    351     "data": np.unique(self.combined_sweeps.sweep_number),
    352 }
--> 353 self.sweep_mode = self._determine_sweep_mode()
    354 self.instrument_parameters = self.find_instrument_parameters()
    355 self.init_gate_x_y_z()

File ~/dev/pyart/pyart/xradar/accessor.py:412, in Xradar._determine_sweep_mode(self)
    406 def _determine_sweep_mode(self):
    407     sweep_mode = {
    408         "units": "unitless",
    409         "standard_name": "sweep_mode",
    410         "long_name": "Sweep mode",
    411     }
--> 412     if "sweep_mode" in self.xradar["sweep_0"]:
    413         sweep_mode["data"] = np.array(
    414             self.nsweeps * [str(self.xradar["sweep_0"].sweep_mode.values)],
    415             dtype="S",
    416         )
    417     else:

File ~/mambaforge/envs/pyart_env/lib/python3.13/site-packages/xarray/core/datatree.py:924, in DataTree.__getitem__(self, key)
    920 elif isinstance(key, str):
    921     # TODO should possibly deal with hashables in general?
    922     # path-like: a name of a node/variable, or path to a node/variable
    923     path = NodePath(key)
--> 924     return self._get_item(path)
    925 elif utils.is_list_like(key):
    926     # iterable of variable names
    927     raise NotImplementedError(
    928         "Selecting via tags is deprecated, and selecting multiple items should be "
    929         "implemented via .subset"
    930     )

File ~/mambaforge/envs/pyart_env/lib/python3.13/site-packages/xarray/core/treenode.py:564, in TreeNode._get_item(self, path)
    562 else:
    563     if current_node.get(part) is None:
--> 564         raise KeyError(f"Could not find node at {path}")
    565     else:
    566         current_node = current_node.get(part)

KeyError: 'Could not find node at sweep_0'
```

- [ ] Closes #1734 
- [ ] Tests added
- [ ] Documentation reflects changes
