### PR TITLE
FIX: Pytest fails now due to behaviour in image testing.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  CIBW_TEST_REQUIRES: pytest
-  CIBW_TEST_COMMAND: "pytest {project}/tests"
+  CIBW_TEST_REQUIRES: pytest pytest-mpl
+  CIBW_TEST_COMMAND: "pytest --mpl {project}/tests"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Having pytest-mpl installed should fix the issue.

@mgrover1 Can you double check if this is the correct spot and syntax to add pytest mpl to the wheels test.