### PR TITLE
Fix RHI (.ele) file reader bug in rainbow_wrl.py (nbins_sweep undefined in single-slice case)

### DIFF
--- a/pyart/aux_io/rainbow_wrl.py
+++ b/pyart/aux_io/rainbow_wrl.py
@@ -253,6 +253,7 @@ def read_rainbow_wrl(
     if single_slice:
         rays_per_sweep[0] = int(common_slice_info["slicedata"]["rawdata"]["@rays"])
         maxbin = int(common_slice_info["slicedata"]["rawdata"]["@bins"])
+        nbins_sweep = np.array([maxbin], dtype="int32")
         ssri = np.array([0], dtype="int32")
         seri = np.array([rays_per_sweep[0] - 1], dtype="int32")
     else:


### PR DESCRIPTION
### This PR fixes a bug in the Py-ART Rainbow (.ele) reader when handling RHI elevation files with a single slice

**Problem:**
When reading RHI .ele files, the following error occurs if the file contains only one slice (nslices == 1 → single_slice = True):
UnboundLocalError: local variable 'nbins_sweep' referenced before assignment

The issue originates from the logic in pyart/aux_io/rainbow_wrl.py.
In the single_slice branch, nbins_sweep is never defined, but it is later referenced here:

fdata[ssri[i] : seri[i] + 1, :] = _get_data(
    slice_info["slicedata"]["rawdata"],
    rays_per_sweep[i],
    nbins_sweep[i],   # this remains undefined when single_slice == True
    maxbin,
)

**Cause:**
For RHI .ele files from IITM Radar (India), single-slice volumes are common. Since nbins_sweep is only created inside the else branch (multi-slice), it fails in single-slice cases.

**Fix:**
When single_slice == True, explicitly define nbins_sweep as an array with the correct bin count.
if single_slice:
    rays_per_sweep[0] = int(common_slice_info["slicedata"]["rawdata"]["@rays"])
    maxbin = int(common_slice_info["slicedata"]["rawdata"]["@bins"])
    nbins_sweep = np.array([maxbin], dtype="int32")   # Added line for reading elevation files for single slice
    ssri = np.array([0], dtype="int32")
    seri = np.array([rays_per_sweep[0] - 1], dtype="int32")

_Note:_ while reading single slice of .vol file the error does not occur, only for single slice of .ele rain bow files error used to occur, which can be resolved using that simple fix.

_Verified working on IITM C-band radar datasets (India)._
Thanks you
Nitig Singh