### PR TITLE
FIX: Fix to exclude_fields to still work when include_fields is None.

### DIFF
--- a/pyart/io/cfradial.py
+++ b/pyart/io/cfradial.py
@@ -314,6 +314,8 @@ def read_cfradial(
         field_name = filemetadata.get_field_name(key)
         if field_name is None:
             if exclude_fields is not None and key in exclude_fields:
+                if include_fields is None:
+                    continue
                 if key not in include_fields:
                     continue
             if include_fields is None or key in include_fields:


### PR DESCRIPTION
This is a minor fix that will fix the error that is thrown when include_fields is None and exclude_fields is not None. With this behavior, I assume that we are including every field that is not in exclude_fields (like the documentation states is the assumption with include_fields) for pyart.io.read_cfradial.
- [x] Documentation reflects changes
