### PR TITLE
FIX: Xradar accessor excluded necessary attributes for pyart.columnsect

### DIFF
--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -341,7 +341,6 @@ class Xradar:
             data=np.expand_dims(self.xradar["longitude"].values, axis=0)
         )
         self.longitude.update(self.combined_sweeps.longitude.attrs)
-            
         self.altitude = dict(
             data=np.expand_dims(self.xradar["altitude"].values, axis=0)
         )


### PR DESCRIPTION
This fix adds some attributes to the xradar to PyART accessor that were left out in the conversion but necessary for the pyart.columnsect utilities to operate.