### PR TITLE
Fix timezone handling in datetime calculation

### DIFF
--- a/pyart/io/mdv_grid.py
+++ b/pyart/io/mdv_grid.py
@@ -109,7 +109,7 @@ def write_grid_mdv(filename, grid, mdv_field_names=None, field_write_order=None)
     d["max_ny"] = ny
     d["max_nz"] = nz
     td = datetime.datetime.now(datetime.timezone.utc) - datetime.datetime(
-        1970, 1, 1, 0, 0
+        1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
     )
     d["time_written"] = int(
         round(td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6


### PR DESCRIPTION
Fixes otherwise inevitable crash, as per https://github.com/ARM-DOE/pyart/issues/1820

Shouldn't affect any changes in normal operation, because without the fix, the function in unusable. It also doesn't involve any data coming into the function, just local, current time and epoch 0.