### PR TITLE
FIX: Fix CAPPI to account for atmospheric refraction

### DIFF
--- a/pyart/retrieve/cappi.py
+++ b/pyart/retrieve/cappi.py
@@ -286,5 +286,5 @@ def create_cappi(
         sweep_end_ray_index=sweep_end_ray_index,
         azimuth={"data": azimuth_final},
         elevation={"data": elevation_final},
-        instrument_parameters=None,
+        instrument_parameters=radar.instrument_parameters,
     )


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes  #1764
- [x] Tests added
- [x] Documentation reflects changes

Updated CAPPI to honor radar geometry and the standard refractivity model. The routine now pulls gate heights from radar.gate_z (which already includes the 4/3 Earth-radius/curvature effect), aligns them to a common azimuth grid per sweep, and selects the nearest gates via that geometry. Field data interpolation now stays aligned with these refractivity-aware heights after Nyquist filtering, replacing the previous flat-Earth R*sin(elevation) approximation.
