### PR TITLE
ENH:conv_strat_raut takes Xgrid;consistent naming

### DIFF
--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -11,7 +11,6 @@ import numpy as np
 # Local imports
 # Local imports
 from ..config import get_field_name, get_fillvalue, get_metadata
-from ..core import Grid
 from ..util.radar_utils import ma_broadcast_to
 from ._echo_class import _feature_detection, steiner_class_buff
 from ._echo_class_wt import calc_scale_break, wavelet_reclass

--- a/pyart/retrieve/echo_class.py
+++ b/pyart/retrieve/echo_class.py
@@ -1281,8 +1281,9 @@ def conv_strat_raut(
     conv_scale_km=25,
     min_reflectivity=5,
     conv_min_refl=25,
-    conv_core_threshold=42,
+    always_core_thres=42,
     override_checks=False,
+    conv_core_threshold=None,
 ):
     """
     A computationally efficient method to classify radar echoes into convective cores, mixed convection,
@@ -1293,8 +1294,8 @@ def conv_strat_raut(
 
     Parameters
     ----------
-    grid : PyART Grid
-        Grid object containing radar data.
+    grid : PyART Grid or Grid-like object
+        Grid or XGrid object containing radar data.
     refl_field : str
         Field name for reflectivity data in the Py-ART grid object.
     zr_a : float, optional
@@ -1324,14 +1325,21 @@ def conv_strat_raut(
     conv_min_refl : float, optional
         Reflectivity values lower than this threshold will be always considered as non-convective.
         Default is 25 dBZ. Recommended values are between 25 and 30 dBZ.
-    conv_core_threshold : float, optional
-        Reflectivities above this threshold are classified as convective cores if wavelet components are significant (See: conv_wt_threshold).
+    always_core_thres : float, optional
+        Threshold for points that are always convective. Reflectivities above this threshold are
+        classified as convective cores if wavelet components are significant (See: conv_wt_threshold).
         Default is 42 dBZ.
         Recommended value must be is greater than or equal to 40 dBZ. The algorithm is not sensitive to this value.
+        This parameter is named to match the other classifiers in this module
+        (e.g. ``conv_strat_yuter``, ``feature_detection``).
     override_checks : bool, optional
         If set to True, the function will bypass the sanity checks for above parameter values.
         This allows the user to use custom values for parameters, even if they fall outside
         the recommended ranges. The default is False.
+    conv_core_threshold : float, optional
+        Deprecated alias for ``always_core_thres``, kept for backward compatibility.
+        If provided, its value is used and a ``DeprecationWarning`` is emitted.
+        Default is None (use ``always_core_thres``).
 
     Returns
     -------
@@ -1355,11 +1363,40 @@ def conv_strat_raut(
 
     Raut, B. A., Louf, V., Gayatri, K., Murugavel, P., Konwar, M., & Prabhakaran, T. (2020). A multiresolution technique
     for the classification of precipitation echoes in radar data. IEEE Trans. Geosci. Remote Sens., 58(8), 5409-5415.
+
+    Examples
+    --------
+    Working directly from an xarray Dataset by wrapping it in a Grid-like
+    ``pyart.xradar.Xgrid`` (open with ``decode_times=False``, as required by
+    ``Xgrid``):
+
+    >>> import pyart, xarray as xr
+    >>> ds = xr.open_dataset("my_grid.nc", decode_times=False)
+    >>> xgrid = pyart.xradar.Xgrid(ds)
+    >>> result = pyart.retrieve.conv_strat_raut(xgrid, "reflectivity", cappi_level=0)
+    >>> xgrid.add_field("wt_reclass", result["wt_reclass"], replace_existing=True)
+    >>> ds_out = xgrid.to_xarray()
     """
 
-    # Check if the grid is a Py-ART Grid object
-    if not isinstance(grid, Grid):
-        raise TypeError("The 'grid' is not a Py-ART Grid object.")
+    # Accept any Grid-like object via duck typing, so that Grid wrappers such as
+    # pyart.xradar.Xgrid (built from a CF-compliant xarray Dataset) work too. We
+    # only rely on the attributes actually used below (.fields, .x, .y), which
+    # keeps this consistent with the other grid classifiers and avoids importing
+    # the optional xarray/xradar packages here.
+    if not (hasattr(grid, "fields") and hasattr(grid, "x") and hasattr(grid, "y")):
+        raise TypeError(
+            "The 'grid' must be a Py-ART Grid or a Grid-like object "
+            "(e.g. pyart.xradar.Xgrid) exposing .fields, .x and .y."
+        )
+
+    # Backward-compatible handling of the renamed 'conv_core_threshold' parameter.
+    if conv_core_threshold is not None:
+        warn(
+            "The 'conv_core_threshold' parameter is deprecated and will be "
+            "removed in a future release; use 'always_core_thres' instead.",
+            DeprecationWarning,
+        )
+        always_core_thres = conv_core_threshold
 
     # Check if dx and dy are the same, and warn if not
     dx = grid.x["data"][1] - grid.x["data"][0]
@@ -1378,9 +1415,9 @@ def conv_strat_raut(
 
     # Sanity checks for parameters if override_checks is False
     if not override_checks:
-        conv_core_threshold = max(
-            40, conv_core_threshold
-        )  # Ensure conv_core_threshold is at least 40 dBZ
+        always_core_thres = max(
+            40, always_core_thres
+        )  # Ensure always_core_thres is at least 40 dBZ
         core_wt_threshold = max(
             4, min(core_wt_threshold, 6)
         )  # core_wt_threshold should be between 4 and 6
@@ -1409,7 +1446,7 @@ def conv_strat_raut(
         scale_break=scale_break,
         min_reflectivity=min_reflectivity,
         conv_min_refl=conv_min_refl,
-        conv_core_threshold=conv_core_threshold,
+        conv_core_threshold=always_core_thres,
     )
 
     reclass = np.expand_dims(reclass, axis=0)
@@ -1434,7 +1471,7 @@ def conv_strat_raut(
                 "scale_break_used": int(scale_break_km),
                 "min_reflectivity": min_reflectivity,
                 "conv_min_refl": conv_min_refl,
-                "conv_core_threshold": conv_core_threshold,
+                "always_core_thres": always_core_thres,
             },
         }
     }

--- a/tests/retrieve/test_echo_class.py
+++ b/tests/retrieve/test_echo_class.py
@@ -420,3 +420,85 @@ def test_conv_strat_raut_results_correct():
     masked_reclass = np.expand_dims(masked_reclass, axis=0)
 
     assert_allclose(masked_reclass, wtclass["wt_reclass"]["data"], atol=0.1)
+
+
+def test_conv_strat_raut_accepts_xgrid():
+    """
+    conv_strat_raut should accept a Grid-like ``pyart.xradar.Xgrid`` built from a
+    CF-compliant xarray Dataset (duck typing) and produce the same
+    classification as the native Grid path.
+    """
+    pytest.importorskip("xarray")
+    pytest.importorskip("xradar")
+
+    grid_len = 32
+    grid = pyart.testing.make_gaussian_storm_grid(
+        min_value=5,
+        max_value=45,
+        grid_len=grid_len,
+        sigma=0.2,
+        mu=0,
+        masked_boundary=3,
+    )
+
+    # Reference classification from the native Grid path.
+    grid_result = pyart.retrieve.conv_strat_raut(grid, "reflectivity", cappi_level=0)
+
+    # Build a Grid-like Xgrid from an in-memory Dataset. grid.to_xarray()
+    # decodes time (dropping its "units" attr), so re-add one to satisfy Xgrid's
+    # decode_times=False guard; conv_strat_raut never uses the time field. Using
+    # the in-memory Dataset keeps float64 precision so the comparison is exact
+    # (a netCDF round-trip would pack to float32 and flip threshold-adjacent
+    # pixels between classes).
+    ds = grid.to_xarray()
+    ds["time"].attrs["units"] = "seconds since 2000-01-01T00:00:00Z"
+    xgrid = pyart.xradar.Xgrid(ds)
+
+    xgrid_result = pyart.retrieve.conv_strat_raut(xgrid, "reflectivity", cappi_level=0)
+
+    # Same output contract as the Grid path.
+    assert isinstance(xgrid_result, dict)
+    assert "wt_reclass" in xgrid_result
+    assert xgrid_result["wt_reclass"]["data"].shape == (1, grid_len, grid_len)
+
+    # Identical classification where the input reflectivity (cappi level 0) is
+    # valid (unmasked). Masked boundaries are represented differently (masked vs.
+    # NaN) between the two paths and are excluded from the comparison.
+    valid = ~np.ma.getmaskarray(grid.fields["reflectivity"]["data"][0])
+    assert_allclose(
+        np.asarray(xgrid_result["wt_reclass"]["data"])[0][valid],
+        np.asarray(grid_result["wt_reclass"]["data"])[0][valid],
+    )
+
+
+def test_conv_strat_raut_rejects_non_grid():
+    """conv_strat_raut should reject objects lacking the Grid surface."""
+    # Non-grid objects (e.g. None) have no .fields/.x/.y -> TypeError.
+    pytest.raises(TypeError, pyart.retrieve.conv_strat_raut, None, "reflectivity")
+    pytest.raises(TypeError, pyart.retrieve.conv_strat_raut, object(), "reflectivity")
+
+
+def test_conv_strat_raut_always_core_thres_alias():
+    """
+    The renamed ``always_core_thres`` works, and the deprecated
+    ``conv_core_threshold`` alias still works but emits a DeprecationWarning and
+    yields the same result (backward compatibility).
+    """
+    grid = pyart.testing.make_gaussian_storm_grid(
+        min_value=5, max_value=45, grid_len=32, sigma=0.2, mu=0, masked_boundary=3
+    )
+
+    # New name: no warning, recorded in the output parameters.
+    new = pyart.retrieve.conv_strat_raut(grid, "reflectivity", always_core_thres=44)
+    assert new["wt_reclass"]["parameters"]["always_core_thres"] == 44
+
+    # Deprecated alias: emits DeprecationWarning and gives an identical result.
+    with pytest.warns(DeprecationWarning):
+        old = pyart.retrieve.conv_strat_raut(
+            grid, "reflectivity", conv_core_threshold=44
+        )
+    assert old["wt_reclass"]["parameters"]["always_core_thres"] == 44
+    assert_allclose(
+        np.asarray(old["wt_reclass"]["data"]),
+        np.asarray(new["wt_reclass"]["data"]),
+    )


### PR DESCRIPTION
Refactored conv_strat_raut to use  xarray and Xgrid objects. Also, renamed conv_core_threshold to always_core_thres for consistency with other methods.

<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Tests added
- [x] Documentation reflects changes
- [x] AI agentic coding? Yes. OpenAI Codex
- [x] I read the code line by line and manually checked results and unit tests are valid.
