### PR TITLE
FIX: xradar accessor compatibility — coercion helper, Radar parity, masked fields, RHI support

### DIFF
--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -32,4 +32,4 @@ dependencies:
   - open-radar-data
   - ruff
   - cmweather
-  - s3fs
+  - s3fs>=2026.6.0

--- a/pyart/correct/bias_and_noise.py
+++ b/pyart/correct/bias_and_noise.py
@@ -11,7 +11,7 @@ import pint
 from scipy import signal
 
 from ..config import get_field_name, get_metadata
-from ..core.radar import Radar
+from ..xradar import to_pyart_radar
 
 
 def correct_noise_rhohv(
@@ -243,8 +243,7 @@ def calc_cloud_mask(
 
     """
 
-    if not isinstance(radar, Radar):
-        raise ValueError("Please use a valid Py-ART Radar object")
+    radar = to_pyart_radar(radar)
 
     if not isinstance(field, str):
         raise ValueError("Please specify a valid field name.")
@@ -330,8 +329,7 @@ def calc_noise_floor(radar, field, height):
 
     """
 
-    if not isinstance(radar, Radar):
-        raise ValueError("Please use a valid Py-ART Radar object.")
+    radar = to_pyart_radar(radar)
 
     # Range correct data and return the array from the Radar object
     data = range_correction(radar, field, height=height)
@@ -440,8 +438,7 @@ def range_correction(radar, field, height):
 
     """
 
-    if not isinstance(radar, Radar):
-        raise ValueError("Please use a valid Py-ART Radar object.")
+    radar = to_pyart_radar(radar)
 
     try:
         height_units = getattr(radar, height)["units"]

--- a/pyart/xradar/__init__.py
+++ b/pyart/xradar/__init__.py
@@ -1,2 +1,9 @@
+"""
+Utilities for interfacing between xradar/xarray and Py-ART.
+
+"""
+
 from .accessor import Xradar, Xgrid  # noqa
 from .accessor import to_pyart_radar  # noqa
+
+__all__ = [s for s in dir() if not s.startswith("_")]

--- a/pyart/xradar/__init__.py
+++ b/pyart/xradar/__init__.py
@@ -1,1 +1,2 @@
 from .accessor import Xradar, Xgrid  # noqa
+from .accessor import to_pyart_radar  # noqa

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -342,6 +342,19 @@ class Xgrid:
 
 
 class Xradar:
+    """
+    Wraps an xradar DataTree into a Py-ART Radar-like object.
+
+    Optional Radar attributes (None when absent in the source file):
+    ``antenna_transition``, ``rays_are_indexed``, ``ray_angle_res``,
+    ``target_scan_rate``, ``scan_rate``, ``altitude_agl``, ``rotation``,
+    ``tilt``, ``roll``, ``drift``, ``heading``, ``pitch``,
+    ``georefs_applied`` and ``radar_calibration`` are populated from the
+    DataTree when the corresponding variable/group is present, and are
+    ``None`` otherwise (never fabricated) -- matching how :class:`Radar`
+    treats these attributes for files that lack them.
+    """
+
     def __init__(self, xradar, default_sweep="sweep_0", scan_type=None):
         # Make sure that first dimension is azimuth
         self.xradar = apply_to_sweeps(xradar, ensure_dim)
@@ -392,7 +405,6 @@ class Xradar:
         )
         self.fixed_angle = dict(data=self.combined_sweeps.sweep_fixed_angle.values)
         self.fixed_angle.update(self.combined_sweeps.sweep_fixed_angle.attrs)
-        self.antenna_transition = None
         self.latitude = dict(
             data=np.expand_dims(self.xradar["latitude"].values, axis=0)
         )
@@ -427,10 +439,22 @@ class Xradar:
         self.init_gate_alt()
         self.init_rays_per_sweep()
 
-        # Extra methods needed for compatibility
-        self.rays_are_indexed = None
-        self.ray_angle_res = None
-        self.target_scan_rate = None
+        # Optional Radar attrs: looked up from the DataTree when present,
+        # else None (never fabricated). See class docstring.
+        self.antenna_transition = self._find_optional_attr("antenna_transition")
+        self.rays_are_indexed = self._find_optional_attr("rays_are_indexed")
+        self.ray_angle_res = self._find_optional_attr("ray_angle_res")
+        self.target_scan_rate = self._find_optional_attr("target_scan_rate")
+        self.scan_rate = self._find_optional_attr("scan_rate")
+        self.altitude_agl = self._find_optional_attr("altitude_agl")
+        self.rotation = self._find_optional_attr("rotation")
+        self.tilt = self._find_optional_attr("tilt")
+        self.roll = self._find_optional_attr("roll")
+        self.drift = self._find_optional_attr("drift")
+        self.heading = self._find_optional_attr("heading")
+        self.pitch = self._find_optional_attr("pitch")
+        self.georefs_applied = self._find_optional_attr("georefs_applied")
+        self.radar_calibration = self._find_radar_calibration()
 
     def __repr__(self):
         return formatting.datatree_repr(self.xradar)
@@ -523,6 +547,62 @@ class Xradar:
                 instrument_parameters[field] = field_dict
 
         return instrument_parameters
+
+    def _find_optional_attr(self, name):
+        """
+        Look up an optional Radar-style attribute by variable name.
+
+        Checks the combined (per-ray) sweeps dataset first, then the
+        root of the DataTree, for a variable named ``name``. Returns a
+        Radar-style ``dict(data=..., **attrs)`` if found, else ``None``
+        -- values are never fabricated when absent from the source file.
+
+        Parameters
+        ----------
+        name : str
+            Name of the variable to look up.
+
+        Returns
+        -------
+        dict or None
+        """
+        if name in self.combined_sweeps.variables:
+            da = self.combined_sweeps[name]
+        elif name in self.xradar.ds.variables:
+            da = self.xradar.ds[name]
+        else:
+            return None
+        dic = dict(data=np.asarray(da.values))
+        dic.update(da.attrs)
+        return dic
+
+    def _find_radar_calibration(self):
+        """
+        Look up the optional ``radar_calibration`` subgroup.
+
+        Mirrors :py:func:`find_instrument_parameters`'s handling of the
+        ``radar_parameters`` subgroup. Returns ``None`` if no
+        ``radar_calibration`` child node is present in the DataTree.
+
+        Returns
+        -------
+        dict or None
+        """
+        if "radar_calibration" not in list(self.xradar.children):
+            return None
+        calib_dict = self.xradar["radar_calibration"].ds.to_dict(data="array")
+        radar_calibration = calib_dict["data_vars"]
+        if not radar_calibration:
+            return None
+        for field in radar_calibration:
+            field_dict = radar_calibration[field]
+            if "attrs" in field_dict:
+                for param in field_dict["attrs"]:
+                    field_dict[param] = field_dict["attrs"][param]
+                del field_dict["attrs"]
+            if "dims" in field_dict:
+                del field_dict["dims"]
+        return radar_calibration
 
     def iter_start(self):
         """Return an iterator over the sweep start indices."""

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -40,6 +40,16 @@ from ..lazydict import LazyLoadDict
 
 
 class Xgrid:
+    """
+    Wraps a Cf-compliant xarray Dataset into a Py-ART Grid-like object.
+
+    Parameters
+    ----------
+    grid_ds : xarray.Dataset
+        The xarray Dataset to convert to a Py-ART grid. Times must not be
+        decoded (``decode_times=False``) when the Dataset is opened.
+    """
+
     def __init__(self, grid_ds):
         """
         Wraps a Cf-compliant xarray Dataset into a PyART Grid Object.
@@ -661,12 +671,19 @@ class Xradar:
             raise ValueError(err)
         # add the field
         self.fields[field_name] = dic
+        # The coordinate that uniquely identifies a ray within a sweep
+        # depends on the scan mode: azimuth for PPI-like sweeps, elevation
+        # for RHI sweeps (see _combine_sweeps for why "azimuth" cannot be
+        # used to drop_duplicates() on an RHI sweep).
+        ray_key = "elevation" if self.scan_type == "rhi" else "azimuth"
         for sweep in range(self.nsweeps):
-            sweep_ds = (
-                self.xradar[f"sweep_{sweep}"].to_dataset().drop_duplicates("azimuth")
-            )
+            sweep_ds = self.xradar[f"sweep_{sweep}"].to_dataset()
+            ray_dim = sweep_ds[ray_key].dims[0]
+            if ray_dim != ray_key:
+                sweep_ds = sweep_ds.swap_dims({ray_dim: ray_key})
+            sweep_ds = sweep_ds.drop_duplicates(ray_key)
             sweep_ds[field_name] = (
-                ("azimuth", "range"),
+                (ray_key, "range"),
                 self.fields[field_name]["data"][self.get_slice(sweep)],
             )
             attrs = dic.copy()
@@ -814,10 +831,15 @@ class Xradar:
                 var for var in ("x", "y", "z") if var in self.combined_sweeps.data_vars
             ]
             if conflicts:
-                georeferenced = self.combined_sweeps.drop_vars(
-                    conflicts
-                ).xradar.georeference()
-                data = georeferenced.sel(sweep_number=sweep)
+                # self.xradar is never mutated by this path (georeference()
+                # is only applied to the dropped-conflicts copy), so the
+                # result can be cached and reused across repeated calls
+                # instead of re-georeferencing the whole dataset every time.
+                if getattr(self, "_collision_georeferenced", None) is None:
+                    self._collision_georeferenced = self.combined_sweeps.drop_vars(
+                        conflicts
+                    ).xradar.georeference()
+                data = self._collision_georeferenced.sel(sweep_number=sweep)
                 return data["x"].values, data["y"].values, data["z"].values
             self.combined_sweeps = self.combined_sweeps.xradar.georeference()
 
@@ -930,14 +952,25 @@ class Xradar:
         self.gate_latitude = gate_latitude
 
     def _combine_sweeps(self):
+        # The coordinate that uniquely identifies a ray within a sweep
+        # depends on the scan mode: azimuth varies per ray for
+        # azimuth-surveillance (PPI-like) sweeps, while elevation varies per
+        # ray for RHI sweeps (azimuth is instead (near-)constant across an
+        # RHI sweep). This coordinate is used below both to drop duplicate
+        # rays (e.g. from overlapping transition rays between sweeps) and as
+        # the dimension aligned/stacked across sweeps -- using "azimuth" for
+        # RHI sweeps would drop_duplicates() every ray in the sweep down to
+        # one, since they all share the same azimuth.
+        ray_key = "elevation" if self.scan_type == "rhi" else "azimuth"
+
         # Loop through and extract the different datasets
         ds_list = []
         for sweep in self.sweep_group_names:
-            ds_list.append(
-                self.xradar[sweep]
-                .ds.drop_duplicates("azimuth")
-                .set_coords("sweep_number")
-            )
+            sweep_ds = self.xradar[sweep].ds
+            ray_dim = sweep_ds[ray_key].dims[0]
+            if ray_dim != ray_key:
+                sweep_ds = sweep_ds.swap_dims({ray_dim: ray_key})
+            ds_list.append(sweep_ds.drop_duplicates(ray_key).set_coords("sweep_number"))
 
         # Merge based on the sweep number
         merged = concat(
@@ -948,10 +981,10 @@ class Xradar:
             dim="sweep_number",
         )
 
-        # Stack the sweep number and azimuth together
-        stacked = merged.stack(gates=["sweep_number", "azimuth"]).transpose()
+        # Stack the sweep number and per-ray coordinate together
+        stacked = merged.stack(gates=["sweep_number", ray_key]).transpose()
 
-        # Select the valid azimuths
+        # Select the valid rays
         good_azimuths = stacked.time.dropna("gates", how="all").gates
         stacked = stacked.sel(gates=good_azimuths)
 
@@ -1079,8 +1112,14 @@ class Xradar:
         # 'x', 'y' or 'z' is never shadowed by a same-named coordinate.
         for field in self.combined_sweeps.data_vars:
             if self.combined_sweeps[field].dims == ("gates", "range"):
+                # Classic pyart.core.Radar fields are numpy.ma.MaskedArray,
+                # masked where a gate is missing. xarray/xradar decode a
+                # variable's _FillValue to NaN on load, so recover that mask
+                # here (masked_invalid also masks pre-existing NaNs/infs);
+                # dtype and attrs are preserved.
+                data = np.ma.masked_invalid(self.combined_sweeps[field].values)
                 fields[field] = {
-                    "data": self.combined_sweeps[field].values,
+                    "data": data,
                     **self.combined_sweeps[field].attrs,
                 }
         return fields
@@ -1152,7 +1191,7 @@ class Xradar:
 
         Returns
         -------
-        area : 2D array of size (ngates - 1, nrays - 1)
+        area : 2D array of size (nrays - 1, ngates - 1)
             Array containing the area (in m * m) of each gate in the sweep.
 
         """

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -28,6 +28,7 @@ from xradar.accessors import XradarAccessor
 from xradar.util import apply_to_sweeps, get_sweep_keys
 
 from ..config import get_metadata
+from ..core.radar import Radar
 from ..core.transforms import (
     antenna_vectors_to_cartesian,
     cartesian_to_geographic,
@@ -1124,6 +1125,38 @@ class XradarDataTreeAccessor(XradarAccessor):
         """
         dt = self.xarray_obj
         return Xradar(dt, scan_type=scan_type)
+
+
+def to_pyart_radar(radar):
+    """
+    Coerce a radar-like object into an object usable by Py-ART algorithms.
+
+    Parameters
+    ----------
+    radar : Radar, Xradar or xarray.DataTree
+        The object to coerce. `pyart.core.Radar` and `Xradar` instances are
+        returned unchanged (the latter duck-types `Radar`). An xradar
+        `xarray.DataTree` is wrapped into an `Xradar` instance.
+
+    Returns
+    -------
+    radar : Radar or Xradar
+        A Py-ART compatible radar object.
+
+    Raises
+    ------
+    TypeError
+        If `radar` is not a `Radar`, `Xradar`, or `xarray.DataTree` instance.
+
+    """
+    if isinstance(radar, (Radar, Xradar)):
+        return radar
+    if isinstance(radar, DataTree):
+        return Xradar(radar)
+    raise TypeError(
+        "radar must be a pyart.core.Radar, pyart.xradar.Xradar, or "
+        f"xarray.DataTree instance, got {type(radar)!r}"
+    )
 
 
 def ensure_dim(ds, dim="azimuth"):

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -665,6 +665,22 @@ class Xradar:
         """
         # Check to see if the data needs to be georeferenced
         if "x" not in self.xradar[f"sweep_{sweep}"].coords:
+            # xradar.georeference() assigns x/y/z as coordinates, which
+            # would silently overwrite any data variable with the same
+            # name (e.g. a GAMIC 'z' reflectivity moment, see GH #1765).
+            # Georeference a version with any colliding moments dropped so
+            # that those moments are left untouched in combined_sweeps.
+            conflicts = [
+                var
+                for var in ("x", "y", "z")
+                if var in self.combined_sweeps.data_vars
+            ]
+            if conflicts:
+                georeferenced = self.combined_sweeps.drop_vars(
+                    conflicts
+                ).xradar.georeference()
+                data = georeferenced.sel(sweep_number=sweep)
+                return data["x"].values, data["y"].values, data["z"].values
             self.combined_sweeps = self.combined_sweeps.xradar.georeference()
 
         data = self.combined_sweeps.sel(sweep_number=sweep)
@@ -917,7 +933,10 @@ class Xradar:
 
     def _find_fields(self, ds):
         fields = {}
-        for field in self.combined_sweeps.variables:
+        # Only consider data variables, not coordinates (e.g. the x/y/z
+        # coordinates added by xradar.georeference()), so a moment named
+        # 'x', 'y' or 'z' is never shadowed by a same-named coordinate.
+        for field in self.combined_sweeps.data_vars:
             if self.combined_sweeps[field].dims == ("gates", "range"):
                 fields[field] = {
                     "data": self.combined_sweeps[field].values,

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -4,6 +4,7 @@ Utilities for interfacing between xradar and Py-ART
 """
 
 import copy
+import sys
 
 import numpy as np
 import pandas as pd
@@ -34,6 +35,7 @@ from ..core.transforms import (
     cartesian_to_geographic,
     cartesian_vectors_to_geographic,
 )
+from ..exceptions import MissingOptionalDependency
 from ..lazydict import LazyLoadDict
 
 
@@ -112,6 +114,63 @@ class Xgrid:
             projparams["lon_0"] = self.origin_longitude["data"][0]
             projparams["lat_0"] = self.origin_latitude["data"][0]
         return projparams
+
+    @property
+    def projection_proj(self):
+        """Return a pyproj.Proj instance as specified by the projection attribute.
+
+        Raises a ValueError if the pyart_aeqd projection is specified.
+        """
+        try:
+            import pyproj
+        except ImportError as err:
+            raise MissingOptionalDependency(
+                "PyProj is required to create a Proj instance but it "
+                "is not installed"
+            ) from err
+        projparams = self.get_projparams()
+
+        if isinstance(projparams, dict) and projparams["proj"] == "pyart_aeqd":
+            raise ValueError(
+                "Proj instance can not be made for the pyart_aeqd projection"
+            )
+        return pyproj.Proj(projparams)
+
+    def write(
+        self,
+        filename,
+        format="NETCDF4",
+        arm_time_variables=False,
+        arm_alt_lat_lon_variables=False,
+    ):
+        """
+        Write the Xgrid object to a NetCDF file.
+
+        Parameters
+        ----------
+        filename : str
+            Filename to save to.
+        format : str, optional
+            NetCDF format, one of 'NETCDF4', 'NETCDF4_CLASSIC',
+            'NETCDF3_CLASSIC' or 'NETCDF3_64BIT'.
+        arm_time_variables : bool, optional
+            True to write the ARM standard time variables base_time and
+            time_offset. False will not write these variables.
+        arm_alt_lat_lon_variables : bool, optional
+            True to write the ARM standard alt, lat, lon variables.
+            False will not write these variables.
+
+        """
+        # delayed import to avoid circular import
+        from ..io.grid_io import write_grid
+
+        write_grid(
+            filename,
+            self,
+            format=format,
+            arm_time_variables=arm_time_variables,
+            arm_alt_lat_lon_variables=arm_alt_lat_lon_variables,
+        )
 
     @property
     def metadata(self):
@@ -366,6 +425,7 @@ class Xradar:
         self.init_gate_x_y_z()
         self.init_gate_longitude_latitude()
         self.init_gate_alt()
+        self.init_rays_per_sweep()
 
         # Extra methods needed for compatibility
         self.rays_are_indexed = None
@@ -774,6 +834,9 @@ class Xradar:
                 data=np.mean(self.altitude["data"]) + self.gate_z["data"]
             )
 
+    # Alias matching pyart.core.Radar's attribute name.
+    init_gate_altitude = init_gate_alt
+
     def init_gate_longitude_latitude(self):
         """
         Initialize or reset the gate_longitude and gate_latitude attributes.
@@ -968,6 +1031,189 @@ class Xradar:
         else:
             return azimuths
 
+    def get_elevation(self, sweep, copy=False):
+        """
+        Return an array of elevation angles for a given sweep.
+
+        Parameters
+        ----------
+        sweep : int
+            Sweep number to retrieve data for, 0 based.
+        copy : bool, optional
+            True to return a copy of the elevations. False, the default,
+            returns a view of the elevations (when possible), changing this
+            data will change the data in the underlying Radar object.
+
+        Returns
+        -------
+        elevation : array
+            Array containing the elevation angles for a given sweep.
+
+        """
+        s = self.get_slice(sweep)
+        elevation = self.elevation["data"][s]
+        if copy:
+            return elevation.copy()
+        else:
+            return elevation
+
+    def get_gate_area(self, sweep):
+        """
+        Return the area of each gate in a sweep. Units of area will be the
+        same as those of the range variable, squared.
+
+        Assumptions:
+            1. Azimuth data is in degrees.
+
+        Parameters
+        ----------
+        sweep : int
+            Sweep number to retrieve gate locations from, 0 based.
+
+        Returns
+        -------
+        area : 2D array of size (ngates - 1, nrays - 1)
+            Array containing the area (in m * m) of each gate in the sweep.
+
+        """
+        s = self.get_slice(sweep)
+        azimuths = self.azimuth["data"][s]
+        ranges = self.range["data"]
+
+        circular_area = np.pi * ranges**2
+        annular_area = np.diff(circular_area)
+
+        az_diffs = np.diff(azimuths)
+        az_diffs[az_diffs < 0.0] += 360
+
+        d_azimuths = az_diffs / 360.0  # Fraction of a full circle
+
+        dca, daz = np.meshgrid(annular_area, d_azimuths)
+
+        area = np.abs(dca * daz)
+        return area
+
+    def init_rays_per_sweep(self):
+        """Initialize or reset the rays_per_sweep attribute."""
+        lazydic = LazyLoadDict(get_metadata("rays_per_sweep"))
+        lazydic.set_lazy("data", _rays_per_sweep_data_factory(self))
+        self.rays_per_sweep = lazydic
+
+    def info(self, level="standard", out=sys.stdout):
+        """
+        Print information on radar.
+
+        Parameters
+        ----------
+        level : {'compact', 'standard', 'full', 'c', 's', 'f'}, optional
+            Level of information on radar object to print, compact is
+            minimal information, standard more and full everything.
+        out : file-like, optional
+            Stream to direct output to, default is to print information
+            to standard out (the screen).
+
+        """
+        if level == "c":
+            level = "compact"
+        elif level == "s":
+            level = "standard"
+        elif level == "f":
+            level = "full"
+
+        if level not in ["standard", "compact", "full"]:
+            raise ValueError("invalid level parameter")
+
+        self._dic_info("altitude", level, out)
+        self._dic_info("antenna_transition", level, out)
+        self._dic_info("azimuth", level, out)
+        self._dic_info("elevation", level, out)
+
+        print("fields:", file=out)
+        for field_name, field_dic in self.fields.items():
+            self._dic_info(field_name, level, out, field_dic, 1)
+
+        self._dic_info("fixed_angle", level, out)
+
+        if self.instrument_parameters is None or not self.instrument_parameters:
+            print("instrument_parameters: None", file=out)
+        else:
+            print("instrument_parameters:", file=out)
+            for name, dic in self.instrument_parameters.items():
+                self._dic_info(name, level, out, dic, 1)
+
+        self._dic_info("latitude", level, out)
+        self._dic_info("longitude", level, out)
+
+        print("nsweeps:", self.nsweeps, file=out)
+        print("ngates:", self.ngates, file=out)
+        print("nrays:", self.nrays, file=out)
+
+        self._dic_info("range", level, out)
+        print("scan_type:", self.scan_type, file=out)
+        self._dic_info("sweep_end_ray_index", level, out)
+        self._dic_info("sweep_mode", level, out)
+        self._dic_info("sweep_number", level, out)
+        self._dic_info("sweep_start_ray_index", level, out)
+        self._dic_info("target_scan_rate", level, out)
+        self._dic_info("time", level, out)
+
+        # always print out all metadata last
+        self._dic_info("metadata", "full", out)
+
+    def _dic_info(self, attr, level, out, dic=None, ident_level=0):
+        """Print information on a dictionary attribute."""
+        if dic is None:
+            dic = getattr(self, attr, None)
+
+        ilvl0 = "\t" * ident_level
+        ilvl1 = "\t" * (ident_level + 1)
+
+        if dic is None:
+            print(str(attr) + ": None", file=out)
+            return
+
+        # some instrument_parameters entries (e.g. root dataset attrs
+        # picked up by find_instrument_parameters) are plain scalars
+        # rather than {'data': ..., ...} dictionaries.
+        if not hasattr(dic, "items"):
+            print(ilvl0 + str(attr) + ":", dic, file=out)
+            return
+
+        # make a string summary of the data key if it exists.
+        if "data" not in dic:
+            d_str = "Missing"
+        elif not isinstance(dic["data"], np.ndarray):
+            d_str = "<not a ndarray>"
+        else:
+            data = dic["data"]
+            t = (data.dtype, data.shape)
+            d_str = "<ndarray of type: {} and shape: {}>".format(*t)
+
+        # compact, only data summary
+        if level == "compact":
+            print(ilvl0 + str(attr) + ":", d_str, file=out)
+
+        # standard, all keys, only summary for data
+        elif level == "standard":
+            print(ilvl0 + str(attr) + ":", file=out)
+            print(ilvl1 + "data:", d_str, file=out)
+            for key, val in dic.items():
+                if key == "data":
+                    continue
+                print(ilvl1 + key + ":", val, file=out)
+
+        # full, all keys, full data
+        elif level == "full":
+            print(str(attr) + ":", file=out)
+            if "data" in dic:
+                print(ilvl1 + "data:", dic["data"], file=out)
+            for key, val in dic.items():
+                if key == "data":
+                    continue
+                print(ilvl1 + key + ":", val, file=out)
+
+        return
+
     def get_projparams(self):
         projparams = self.projection.copy()
         if projparams.pop("_include_lon_0_lat_0", False):
@@ -1087,6 +1333,18 @@ def _point_altitude_data_factory(grid):
         return grid.origin_altitude["data"][0] + grid.point_z["data"]
 
     return _point_altitude_data
+
+
+def _rays_per_sweep_data_factory(radar):
+    """Return a function which returns the number of rays per sweep."""
+
+    def _rays_per_sweep_data():
+        """The function which returns the number of rays per sweep."""
+        return (
+            radar.sweep_end_ray_index["data"] - radar.sweep_start_ray_index["data"] + 1
+        )
+
+    return _rays_per_sweep_data
 
 
 def _gate_lon_lat_data_factory(radar, coordinate):

--- a/pyart/xradar/accessor.py
+++ b/pyart/xradar/accessor.py
@@ -671,9 +671,7 @@ class Xradar:
             # Georeference a version with any colliding moments dropped so
             # that those moments are left untouched in combined_sweeps.
             conflicts = [
-                var
-                for var in ("x", "y", "z")
-                if var in self.combined_sweeps.data_vars
+                var for var in ("x", "y", "z") if var in self.combined_sweeps.data_vars
             ]
             if conflicts:
                 georeferenced = self.combined_sweeps.drop_vars(

--- a/tests/correct/test_correct_bias.py
+++ b/tests/correct/test_correct_bias.py
@@ -50,6 +50,33 @@ def test_calc_zdr_offset():
     assert_almost_equal(results["profile_reflectivity"][15], 14.37, decimal=2)
 
 
+def test_calc_zdr_offset_xradar():
+    xd = pytest.importorskip("xradar")
+
+    xsapr_test_file = DATASETS.fetch("sgpxsaprcfrvptI4.a1.20200205.100827.nc")
+    ds = pyart.io.read(xsapr_test_file)
+    gatefilter = pyart.filters.GateFilter(ds)
+    gatefilter.exclude_below("cross_correlation_ratio_hv", 0.995)
+    gatefilter.exclude_above("cross_correlation_ratio_hv", 1)
+    gatefilter.exclude_below("reflectivity", 10)
+    gatefilter.exclude_above("reflectivity", 30)
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = "tmp_xsapr_zdr.nc"
+        pyart.io.write_cfradial(tmpfile, ds)
+        dtree = xd.io.open_cfradial1_datatree(tmpfile, optional=False)
+        xradar_obj = pyart.xradar.Xradar(dtree)
+
+    results = pyart.correct.calc_zdr_offset(
+        xradar_obj,
+        zdr_var="differential_reflectivity",
+        gatefilter=gatefilter,
+        height_range=(1000, 3000),
+    )
+    assert_almost_equal(results["bias"], 2.69, decimal=2)
+    assert_almost_equal(results["profile_reflectivity"][15], 14.37, decimal=2)
+
+
 def test_calc_noise_floor():
     expected = [-46.25460013, -46.48371626, -46.3314618, -46.82639895, -46.76403711]
 
@@ -59,7 +86,7 @@ def test_calc_noise_floor():
 
     bad_radar = "foo"
     pytest.raises(
-        ValueError,
+        TypeError,
         pyart.correct.calc_noise_floor,
         bad_radar,
         "reflectivity_copol",
@@ -77,7 +104,7 @@ def test_range_correction():
 
     bad_radar = "foo"
     pytest.raises(
-        ValueError,
+        TypeError,
         pyart.correct.range_correction,
         bad_radar,
         "reflectivity_copol",
@@ -143,7 +170,7 @@ def test_calc_cloud_mask():
 
     bad_radar = "foo"
     pytest.raises(
-        ValueError,
+        TypeError,
         pyart.correct.calc_cloud_mask,
         bad_radar,
         "reflectivity_copol",

--- a/tests/correct/test_correct_bias.py
+++ b/tests/correct/test_correct_bias.py
@@ -54,18 +54,14 @@ def test_calc_zdr_offset_xradar():
     xd = pytest.importorskip("xradar")
 
     xsapr_test_file = DATASETS.fetch("sgpxsaprcfrvptI4.a1.20200205.100827.nc")
-    ds = pyart.io.read(xsapr_test_file)
-    gatefilter = pyart.filters.GateFilter(ds)
+    dtree = xd.io.open_cfradial1_datatree(xsapr_test_file, optional=False)
+    xradar_obj = pyart.xradar.Xradar(dtree)
+
+    gatefilter = pyart.filters.GateFilter(xradar_obj)
     gatefilter.exclude_below("cross_correlation_ratio_hv", 0.995)
     gatefilter.exclude_above("cross_correlation_ratio_hv", 1)
     gatefilter.exclude_below("reflectivity", 10)
     gatefilter.exclude_above("reflectivity", 30)
-
-    with pyart.testing.InTemporaryDirectory():
-        tmpfile = "tmp_xsapr_zdr.nc"
-        pyart.io.write_cfradial(tmpfile, ds)
-        dtree = xd.io.open_cfradial1_datatree(tmpfile, optional=False)
-        xradar_obj = pyart.xradar.Xradar(dtree)
 
     results = pyart.correct.calc_zdr_offset(
         xradar_obj,

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -511,10 +511,14 @@ def test_field_named_z_not_shadowed_by_georeference_coordinate(filename=filename
     x, y, z = radar.get_gate_x_y_z(0)
     assert z.shape == (480, 996)
 
-    # The 'z' moment must still be discoverable as a field with its
-    # original data, not the georeferenced height coordinate.
-    refreshed_fields = radar._find_fields(radar.combined_sweeps)
-    assert "z" in refreshed_fields
-    assert_allclose(refreshed_fields["z"]["data"], original_z)
-    assert "x" not in refreshed_fields
-    assert "y" not in refreshed_fields
+    # The 'z' moment must still be discoverable as a field, through the
+    # public field-access surface, with its original data -- not the
+    # georeferenced height coordinate.
+    assert "z" in radar.fields
+    assert "x" not in radar.fields
+    assert "y" not in radar.fields
+    assert_allclose(radar.fields["z"]["data"], original_z)
+    for sweep in range(radar.nsweeps):
+        assert_allclose(radar.get_field(sweep, "z"), original_z[radar.get_slice(sweep)])
+    with pytest.raises(KeyError):
+        radar.get_field(0, "x")

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -258,3 +258,33 @@ def test_grid_xradar():
     grid = pyart.map.grid_from_radars([radar], **COMMON_MAP_TO_GRID_ARGS)
     assert (10, 9, 3) == (grid.nx, grid.ny, grid.nz)
     assert_allclose(np.min(grid.fields["DBZ"]["data"]), -1.3201784)
+
+
+def test_to_pyart_radar_passes_radar_through():
+    radar = pyart.testing.make_target_radar()
+    result = pyart.xradar.to_pyart_radar(radar)
+    assert result is radar
+
+
+def test_to_pyart_radar_passes_xradar_through():
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    xradar_obj = pyart.xradar.Xradar(dtree)
+    result = pyart.xradar.to_pyart_radar(xradar_obj)
+    assert result is xradar_obj
+
+
+def test_to_pyart_radar_wraps_datatree():
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    result = pyart.xradar.to_pyart_radar(dtree)
+    assert isinstance(result, pyart.xradar.Xradar)
+
+
+def test_to_pyart_radar_raises_typeerror_on_unsupported_type():
+    with pytest.raises(TypeError):
+        pyart.xradar.to_pyart_radar({"not": "a radar"})

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -288,3 +288,38 @@ def test_to_pyart_radar_wraps_datatree():
 def test_to_pyart_radar_raises_typeerror_on_unsupported_type():
     with pytest.raises(TypeError):
         pyart.xradar.to_pyart_radar({"not": "a radar"})
+
+
+def test_field_named_z_not_shadowed_by_georeference_coordinate(filename=filename):
+    # Regression test for GH #1765: a moment named 'z' (as GAMIC stores
+    # reflectivity) must not be dropped/overwritten by the Cartesian height
+    # coordinate that xradar.georeference() adds when Xradar computes gate
+    # locations.
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    for sweep in dtree.match("sweep_*"):
+        if "DBZ" in dtree[sweep].ds:
+            dtree[sweep].ds = dtree[sweep].ds.rename({"DBZ": "z"})
+
+    radar = pyart.xradar.Xradar(dtree)
+
+    assert "z" in radar.fields
+    # Coordinates must not leak into fields just because their dims match.
+    assert "x" not in radar.fields
+    assert "y" not in radar.fields
+    original_z = radar.fields["z"]["data"].copy()
+
+    # Trigger the internal xradar.georeference() call used to compute gate
+    # locations.
+    x, y, z = radar.get_gate_x_y_z(0)
+    assert z.shape == (480, 996)
+
+    # The 'z' moment must still be discoverable as a field with its
+    # original data, not the georeferenced height coordinate.
+    refreshed_fields = radar._find_fields(radar.combined_sweeps)
+    assert "z" in refreshed_fields
+    assert_allclose(refreshed_fields["z"]["data"], original_z)
+    assert "x" not in refreshed_fields
+    assert "y" not in refreshed_fields

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -1,4 +1,7 @@
+import io
+
 import numpy as np
+import pyproj
 import pytest
 import xarray as xr
 import xradar as xd
@@ -288,6 +291,133 @@ def test_to_pyart_radar_wraps_datatree():
 def test_to_pyart_radar_raises_typeerror_on_unsupported_type():
     with pytest.raises(TypeError):
         pyart.xradar.to_pyart_radar({"not": "a radar"})
+
+
+def test_get_elevation(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+    elevations = radar.get_elevation(0)
+    s = radar.get_slice(0)
+    assert elevations.shape == (480,)
+    assert_allclose(elevations, radar.elevation["data"][s])
+    # copy=True should return an equal but distinct array
+    elevations_copy = radar.get_elevation(0, copy=True)
+    assert elevations_copy is not radar.elevation["data"][s]
+    assert_allclose(elevations_copy, elevations)
+
+
+def test_get_gate_area(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+    area = radar.get_gate_area(0)
+    nrays_sweep = radar.get_slice(0).stop - radar.get_slice(0).start
+    assert area.shape == (nrays_sweep - 1, radar.ngates - 1)
+    assert np.all(area > 0)
+
+    # locked known value for the first gate area of sweep 0
+    assert_allclose(area[0, 0], 441.78647, rtol=1e-5)
+
+
+def test_info(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+
+    out = io.StringIO()
+    radar.info(level="compact", out=out)
+    compact_output = out.getvalue()
+    assert "DBZ:" in compact_output
+    assert "nsweeps: 9" in compact_output
+    assert "nrays:" in compact_output
+
+    out = io.StringIO()
+    radar.info(level="standard", out=out)
+    standard_output = out.getvalue()
+    assert "DBZ:" in standard_output
+    assert "nsweeps: 9" in standard_output
+    assert "ngates: 996" in standard_output
+    assert "sweep_mode:" in standard_output
+
+    with pytest.raises(ValueError):
+        radar.info(level="invalid")
+
+
+def test_rays_per_sweep(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+    rays_per_sweep = radar.rays_per_sweep
+    assert "data" in rays_per_sweep
+    expected = (
+        radar.sweep_end_ray_index["data"] - radar.sweep_start_ray_index["data"] + 1
+    )
+    assert_allclose(rays_per_sweep["data"], expected)
+    assert rays_per_sweep["data"].shape == (radar.nsweeps,)
+
+    # init_rays_per_sweep should reset the attribute
+    radar.init_rays_per_sweep()
+    assert_allclose(radar.rays_per_sweep["data"], expected)
+
+
+def test_init_gate_altitude_alias(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+    radar.init_gate_altitude()
+    assert_allclose(
+        radar.gate_altitude["data"], radar.altitude["data"] + radar.gate_z["data"]
+    )
+
+
+def test_xgrid_projection_proj():
+    grid = pyart.testing.make_target_grid()
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = "tmp_grid_proj.nc"
+        pyart.io.write_grid(tmpfile, grid)
+        grid_ds = xr.open_dataset(tmpfile, decode_times=False)
+        xgrid = pyart.xradar.Xgrid(grid_ds)
+
+        # default pyart_aeqd projection cannot be turned into a Proj
+        with pytest.raises(ValueError):
+            xgrid.projection_proj
+
+        xgrid.projection["proj"] = "aeqd"
+        proj = xgrid.projection_proj
+        assert isinstance(proj, pyproj.Proj)
+        grid_ds.close()
+
+
+def test_xgrid_write_roundtrip():
+    grid = pyart.testing.make_target_grid()
+
+    with pyart.testing.InTemporaryDirectory():
+        tmpfile = "tmp_grid_source.nc"
+        pyart.io.write_grid(tmpfile, grid)
+        grid_ds = xr.open_dataset(tmpfile, decode_times=False)
+        xgrid = pyart.xradar.Xgrid(grid_ds)
+
+        out_file = "tmp_grid_written.nc"
+        xgrid.write(out_file)
+
+        grid_read = pyart.io.read_grid(out_file)
+        assert_allclose(
+            grid_read.fields["reflectivity"]["data"],
+            xgrid.fields["reflectivity"]["data"],
+        )
+        grid_ds.close()
 
 
 def test_field_named_z_not_shadowed_by_georeference_coordinate(filename=filename):

--- a/tests/xradar/test_accessor.py
+++ b/tests/xradar/test_accessor.py
@@ -420,6 +420,71 @@ def test_xgrid_write_roundtrip():
         grid_ds.close()
 
 
+def test_optional_platform_scan_attrs_default_to_none(filename=filename):
+    # None of these variables are present in this fixture file, so the
+    # attributes must exist (no AttributeError) and be None, matching
+    # Radar's behavior for optional attrs absent from the source file.
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+    radar = pyart.xradar.Xradar(dtree)
+
+    optional_attrs = [
+        "antenna_transition",
+        "rays_are_indexed",
+        "ray_angle_res",
+        "target_scan_rate",
+        "scan_rate",
+        "altitude_agl",
+        "rotation",
+        "tilt",
+        "roll",
+        "drift",
+        "heading",
+        "pitch",
+        "georefs_applied",
+        "radar_calibration",
+    ]
+    for attr in optional_attrs:
+        assert hasattr(radar, attr)
+        assert getattr(radar, attr) is None
+
+
+def test_optional_platform_scan_attrs_populated_when_present(filename=filename):
+    dtree = xd.io.open_cfradial1_datatree(
+        filename,
+        optional=False,
+    )
+
+    # Inject a scan-rate variable (per-ray) into each sweep dataset with
+    # known values and attributes.
+    scan_rate_attrs = {"units": "degrees/second", "long_name": "antenna scan rate"}
+    heading_attrs = {"units": "degrees", "long_name": "platform heading"}
+    for sweep in dtree.match("sweep_*"):
+        sweep_ds = dtree[sweep].to_dataset()
+        n = sweep_ds.sizes["azimuth"]
+        sweep_ds["scan_rate"] = (("azimuth",), np.full(n, 5.0, dtype="float64"))
+        sweep_ds["scan_rate"].attrs = scan_rate_attrs
+        sweep_ds["heading"] = (("azimuth",), np.full(n, 45.0, dtype="float64"))
+        sweep_ds["heading"].attrs = heading_attrs
+        dtree[sweep].ds = sweep_ds
+
+    radar = pyart.xradar.Xradar(dtree)
+
+    assert radar.scan_rate is not None
+    assert radar.scan_rate["data"].shape == (radar.nrays,)
+    assert_allclose(radar.scan_rate["data"], 5.0)
+    assert radar.scan_rate["units"] == "degrees/second"
+    assert radar.scan_rate["long_name"] == "antenna scan rate"
+
+    assert radar.heading is not None
+    assert radar.heading["data"].shape == (radar.nrays,)
+    assert_allclose(radar.heading["data"], 45.0)
+    assert radar.heading["units"] == "degrees"
+    assert radar.heading["long_name"] == "platform heading"
+
+
 def test_field_named_z_not_shadowed_by_georeference_coordinate(filename=filename):
     # Regression test for GH #1765: a moment named 'z' (as GAMIC stores
     # reflectivity) must not be dropped/overwritten by the Cartesian height


### PR DESCRIPTION
Continues roadmap Highest-Priority #3 (xarray/xradar integration). Closes #1765.

- Adds public `pyart.xradar.to_pyart_radar()` and uses it in `correct.bias_and_noise`, so `calc_cloud_mask`/`calc_noise_floor`/`range_correction`/`calc_zdr_offset` accept xradar DataTrees and `Xradar` objects. **API note:** invalid `radar` arguments to these functions now raise `TypeError` (was `ValueError`).
- Fixes #1765: moments named `z`/`x`/`y` (e.g. GAMIC reflectivity) are no longer shadowed or dropped by georeference coordinates.
- Adds missing `Radar` parity members on `Xradar`: `get_elevation`, `get_gate_area`, `info`, `rays_per_sweep`/`init_rays_per_sweep`, `init_gate_altitude` alias (the roadmap names `radar.info` explicitly).
- Optional platform/scan attributes (`scan_rate`, `rotation`, `tilt`, `antenna_transition`, `radar_calibration`, etc.) are now looked up in the DataTree when present instead of hardcoded `None`/`AttributeError`; `None` when absent, never fabricated.
- `Xradar` fields are now `np.ma.MaskedArray` (NaN-masked), matching `Radar` and fixing `despeckle_field` and other mask-dependent algorithms.
- RHI scans no longer collapse to one ray per sweep in `_combine_sweeps` and `add_field` (dedup key follows scan type); collision-path georeferencing is cached.
- `Xgrid` gains `projection_proj` and `write`.

Known limitation (pre-existing, not addressed here): some real RHI files (e.g. DOW8 samples in open_radar_data) still fail in `_combine_sweeps` via a separate dimension-mismatch path; follow-up issue to come.

Tests: `tests/xradar/test_accessor.py` + `tests/correct/test_correct_bias.py` = 34 passed. A companion test-matrix PR (stacked on this one) adds a Radar-vs-Xradar equality suite.
