### PR TITLE
DOC: xradar-first user guide, API reference, and gallery examples

### DIFF
--- a/doc/source/API/index.rst
+++ b/doc/source/API/index.rst
@@ -31,4 +31,5 @@ Documentation is broken down by directory and module.
    util
    bridge
    testing
+   xradar
    _debug_info

--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -10,6 +10,7 @@ We also have a collection of installation, and contribution instructions listed 
    :maxdepth: 1
 
    overview
+   xradar_integration
    pyart_2_0
    INSTALL
    setting_up_an_environment

--- a/doc/source/userguide/overview.rst
+++ b/doc/source/userguide/overview.rst
@@ -1,3 +1,5 @@
+.. _overview:
+
 Why Py-ART?
 ===========
 
@@ -25,20 +27,35 @@ xradar vs. Legacy Radar Data Structures
 
 Py-ART represents a significant advancement over legacy radar data structures, particularly with its adoption of **xarray** through the `xradar` extension. Here's how Py-ART (with xradar) compares to older approaches:
 
-+----------------------------+----------------------------------+---------------------------------+
-| **Feature**                | **Legacy Radar Data Structures** | **Py-ART with xradar**          |
-+============================+==================================+=================================+
-| **Data Representation**    | Custom object with dictionaries  | xarray-based, standardized      |
-+----------------------------+----------------------------------+---------------------------------+
-| **Metadata Handling**      | Based on cfradial1 standards.    | Based on cfradial2 standards    |
-+----------------------------+----------------------------------+---------------------------------+
-| **Performance**            | Limited scalability              | Optimized for large datasets    |
-+----------------------------+----------------------------------+---------------------------------+
-| **Multi-Dimensional Data** | Limited support                  | Native support via xarray       |
-+----------------------------+----------------------------------+---------------------------------+
-| **Interoperability**       | Minimal, package-by-package      | Full integration with PyData    |
-|                            |                                  | ecosystem                       |
-+----------------------------+----------------------------------+---------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 35 45
+
+   * - **Feature**
+     - **Legacy** (``pyart.io.read`` -> :class:`~pyart.core.Radar`)
+     - **xradar-first** (``xd.io.open_*_datatree`` ->
+       ``tree.pyart.to_radar()`` -> :class:`~pyart.xradar.Xradar`)
+   * - Data Representation
+     - Custom object with dictionaries
+     - xarray/xradar ``DataTree`` under the hood, wrapped to duck-type
+       ``Radar``
+   * - Metadata Handling
+     - Based on cfradial1 conventions
+     - Based on cfradial2/FM301 conventions (via xradar)
+   * - Format coverage
+     - Py-ART's own readers (CfRadial, NEXRAD, Sigmet, MDV, ...)
+     - Growing set of xradar readers; new format support is expected to
+       land in xradar first, see :ref:`xradar_integration`
+   * - Missing-data handling
+     - ``numpy.ma.MaskedArray`` fields
+     - Also ``numpy.ma.MaskedArray`` fields (NaN-masked on load)
+   * - Interoperability
+     - Minimal, package-by-package
+     - Full integration with the PyData/xarray ecosystem
+
+Not every :class:`~pyart.core.Radar` attribute/method has an
+:class:`~pyart.xradar.Xradar` equivalent yet -- see the supported-API table
+in :ref:`xradar_integration` for exactly what has been ported and verified.
 
 The adoption of xarray in Py-ART allows for more intuitive and efficient handling of radar data, especially for large-scale or multi-dimensional datasets. It also aligns Py-ART with modern data science practices, ensuring long-term sustainability and usability.
 

--- a/doc/source/userguide/pyart_2_0.rst
+++ b/doc/source/userguide/pyart_2_0.rst
@@ -1,3 +1,5 @@
+.. _pyart_2_0:
+
 ==========
 Py-ART 2.0
 ==========
@@ -13,30 +15,10 @@ The Py-ART 2.0 release candidate can be installed directly from github - this is
 
 Input/Output (IO)
 =================
-We now offer the option to use xradar for IO, with the following interface (a typical gridding workflow is shown below):
-
-.. code-block:: python
-
-    import xradar as xd
-    import pyart
-
-    # Access sample cfradial1 data from Py-ART and read using xradar
-    filename = get_test_data("swx_20120520_0641.nc")
-    tree = xd.io.open_cfradial1_datatree(filename)
-
-    # Add the associated pyart methods - ensuring compatibility with Py-ART functionality
-    radar = tree.pyart.to_radar()
-
-    # Grid using 11 vertical levels, and 101 horizontal grid cells at a resolution on 1 km
-    grid = pyart.map.grid_from_radars(
-        (radar,),
-        grid_shape=(11, 101, 101),
-        grid_limits=(
-            (0.0, 10_000),
-            (-50_000.0, 50_000.0),
-            (-50_000, 50_000.0),
-        ),
-    )
+We now offer the option to use xradar for IO. See :ref:`xradar_integration`
+for the full xradar-first reading guide, the supported-API table for
+:class:`pyart.xradar.Xradar`/:class:`pyart.xradar.Xgrid`, and a worked
+gridding example.
 
 Correct
 =======

--- a/doc/source/userguide/xradar_integration.rst
+++ b/doc/source/userguide/xradar_integration.rst
@@ -1,0 +1,234 @@
+.. _xradar_integration:
+
+=================================
+Reading Data: xradar and Py-ART
+=================================
+
+This page answers the question new users ask first: **which IO path do I
+use, and what works on the object it gives me?**
+
+Reading data in Py-ART today
+=============================
+
+The recommended path for reading radar data is **xradar-first**: open the
+file with `xradar <https://docs.openradarscience.org/projects/xradar/en/stable/>`_
+into an xarray ``DataTree``, then attach Py-ART's ``pyart`` accessor to get
+a :class:`pyart.xradar.Xradar` object that behaves like a
+:class:`pyart.core.Radar` for the purposes of running Py-ART algorithms,
+correction routines, and displays.
+
+.. code-block:: python
+
+    import xradar as xd
+    import pyart
+
+    # Access sample cfradial1 data from Py-ART and read using xradar
+    filename = pyart.testing.get_test_data("swx_20120520_0641.nc")
+    tree = xd.io.open_cfradial1_datatree(filename)
+
+    # Attach the Py-ART accessor -- ``radar`` now exposes Radar-like
+    # attributes/methods (fields, azimuth, elevation, get_elevation, ...)
+    radar = tree.pyart.to_radar()
+
+xradar ships ``open_*_datatree`` readers for CfRadial1, CfRadial2/FM301,
+ODIM_H5, Furuno, Iris/Sigmet, NEXRAD Level 2, and others -- see the
+`xradar documentation <https://docs.openradarscience.org/projects/xradar/en/stable/>`_
+for the full list. Any algorithm in Py-ART that accepts a ``radar``
+argument can be handed the resulting :class:`pyart.xradar.Xradar` object
+directly, in place of a :class:`pyart.core.Radar`. Code that needs to
+accept either interchangeably (for example, a helper function) can
+normalize the input with :func:`pyart.xradar.to_pyart_radar`, which
+returns a :class:`~pyart.core.Radar` or :class:`~pyart.xradar.Xradar`
+unchanged and wraps a bare ``xarray.DataTree`` for you:
+
+.. code-block:: python
+
+    import pyart
+
+    radar = pyart.xradar.to_pyart_radar(tree)  # Radar, Xradar, or DataTree in
+
+When to use ``pyart.io.read`` instead
+--------------------------------------
+
+Py-ART's built-in readers (:func:`pyart.io.read` and friends, e.g.
+:func:`pyart.io.read_cfradial`, :func:`pyart.io.read_nexrad_archive`) remain
+available and return a classic :class:`pyart.core.Radar`. Reach for them
+when:
+
+- You need a format xradar does not (yet) read, or a Py-ART-specific reader
+  such as MDV, UF, CHL, or RSL-backed files (see :mod:`pyart.io` and
+  :mod:`pyart.aux_io`).
+- You depend on behavior specific to :class:`pyart.core.Radar` that is not
+  (yet) mirrored on :class:`pyart.xradar.Xradar` -- check the
+  :ref:`supported-API table <xradar-supported-api>` below first.
+- You are maintaining existing code and are not ready to migrate.
+
+.. code-block:: python
+
+    import pyart
+
+    radar = pyart.io.read(filename)  # returns a pyart.core.Radar
+
+Reader migration: the roadmap direction
+=========================================
+
+New radar-format IO support is expected to land in `xradar
+<https://docs.openradarscience.org/projects/xradar/en/stable/>`_ going
+forward rather than as new readers in :mod:`pyart.io`. Py-ART's own legacy
+readers will be deprecated over time as xradar's format coverage grows,
+matching "Moderate #1" of the rc3.0 roadmap
+(``roadmaps/pyart-roadmap-rc3.0.pdf``). No legacy reader is being removed
+today -- this is a direction to plan for, not an immediate break.
+
+.. _xradar-supported-api:
+
+Supported-API table
+=====================
+
+:class:`pyart.xradar.Xradar` wraps an xradar ``DataTree`` and duck-types
+:class:`pyart.core.Radar`: most attributes and methods used by Py-ART's
+correction, retrieval, mapping, and graphing subpackages work unchanged.
+The table below lists what has been verified to work, sourced from
+``pyart/xradar/accessor.py`` and the test suite in ``tests/xradar/``
+(notably ``tests/xradar/test_compat_matrix.py``, which runs the same
+algorithm against a :class:`~pyart.core.Radar` and the equivalent
+:class:`~pyart.xradar.Xradar` and asserts numerically equal results).
+
+``Xradar`` (radar-level)
+--------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Member
+     - Notes
+   * - ``fields``
+     - ``numpy.ma.MaskedArray`` per field, masked where the source
+       variable is NaN (or was already masked)
+   * - ``azimuth``, ``elevation``, ``range``, ``time``, ``fixed_angle``
+     - Standard Radar-style ``dict(data=..., **attrs)``
+   * - ``latitude``, ``longitude``, ``altitude``
+     - Populated from the DataTree root
+   * - ``sweep_number``, ``sweep_mode``, ``sweep_start_ray_index``,
+       ``sweep_end_ray_index``
+     - Derived from the combined per-sweep data
+   * - ``rays_per_sweep``
+     - Lazily derived from the sweep start/end indices
+   * - ``gate_x``/``y``/``z``, ``gate_longitude``/``latitude``,
+       ``gate_altitude``
+     - Computed the same way as on ``Radar``
+   * - ``get_elevation(sweep)``
+     - Per-sweep elevation slice
+   * - ``get_azimuth(sweep)``
+     - Per-sweep azimuth slice
+   * - ``get_gate_area(sweep)``
+     - Per-gate area, same formula as ``Radar``
+   * - ``get_gate_x_y_z``, ``get_gate_lat_lon_alt``
+     - Per-sweep gate locations, computed via ``xradar.georeference()``
+       under the hood
+   * - ``get_nyquist_vel``
+     - From ``instrument_parameters`` when present
+   * - ``info(level=...)``
+     - Same three levels as ``Radar.info``
+   * - ``add_field``, ``add_field_like``, ``add_filter``
+     - Mutates both ``self.fields`` and the underlying ``DataTree``
+       sweep datasets
+   * - ``extract_sweeps``
+     - Returns a new ``Xradar``
+   * - ``instrument_parameters``
+     - Populated from a ``radar_parameters`` subgroup and/or
+       root-level variables when present, else ``{}``
+   * - ``radar_calibration``
+     - Populated from a ``radar_calibration`` subgroup when present in
+       the DataTree, else ``None``
+   * - ``antenna_transition``, ``rays_are_indexed``, ``ray_angle_res``,
+       ``target_scan_rate``, ``scan_rate``, ``altitude_agl``,
+       ``rotation``, ``tilt``, ``roll``, ``drift``, ``heading``,
+       ``pitch``, ``georefs_applied``
+     - ``None`` when the source file has no corresponding
+       variable/group -- **never fabricated**. Populated when present.
+   * - ``scan_type``
+     - ``"ppi"`` by default, or pass ``scan_type="rhi"`` to
+       ``tree.pyart.to_radar(scan_type="rhi")`` -- RHI sweeps are
+       combined on elevation rather than azimuth
+
+``Xgrid`` (grid-level)
+------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Member
+     - Notes
+   * - ``fields``, ``x``/``y``/``z``, ``origin_latitude`` etc.
+     - Same shape and layout as ``pyart.core.Grid``
+   * - ``get_point_longitude_latitude``, ``add_field``, ``to_xarray``
+     - Same as ``Grid``
+   * - ``projection_proj``
+     - ``pyproj.Proj`` built from the ``projection`` attrs; raises
+       ``ValueError`` for the ``pyart_aeqd`` projection (no
+       ``pyproj.Proj`` equivalent) and
+       :class:`~pyart.exceptions.MissingOptionalDependency` if
+       ``pyproj`` is not installed
+   * - ``write(filename)``
+     - Writes the grid via :func:`pyart.io.grid_io.write_grid`
+
+Known caveats
+==============
+
+- **Fields are masked, not filled.** ``Xradar.fields[name]["data"]`` is a
+  ``numpy.ma.MaskedArray``; any NaN in the source variable (xarray's
+  decoded ``_FillValue``) is masked, mirroring how :class:`pyart.core.Radar`
+  masks missing gates.
+- **RHI sweeps are supported** by passing ``scan_type="rhi"`` to
+  ``tree.pyart.to_radar()``; internally rays are combined per-sweep on
+  elevation (which varies per ray in an RHI) instead of azimuth (which is
+  ~constant across an RHI sweep).
+- **``radar_calibration``** is populated only when the source DataTree has a
+  ``radar_calibration`` child group (mirroring how ``instrument_parameters``
+  is sourced from a ``radar_parameters`` subgroup); otherwise it is ``None``,
+  matching :class:`~pyart.core.Radar`'s handling of files that lack this
+  information.
+- **Comparing a file read both ways is not bit-for-bit.** ``pyart.io.read``
+  and xradar's ``open_*_datatree`` readers can disagree on ray bookkeeping
+  for messy real-world files (e.g. which ray straddling the 0/360 azimuth
+  wrap belongs to which sweep); this is a property of two independent
+  parsers, not an ``Xradar`` accessor defect. See
+  ``tests/xradar/test_compat_matrix.py`` for how the compatibility test
+  suite works around this to get an apples-to-apples numerical comparison.
+
+Worked example
+================
+
+.. code-block:: python
+
+    import xradar as xd
+    import pyart
+
+    filename = pyart.testing.get_test_data("swx_20120520_0641.nc")
+    tree = xd.io.open_cfradial1_datatree(filename)
+    radar = tree.pyart.to_radar()
+
+    # Grid using 11 vertical levels, and 101 horizontal grid cells at a
+    # resolution of 1 km -- pyart.map works directly on the Xradar object
+    grid = pyart.map.grid_from_radars(
+        (radar,),
+        grid_shape=(11, 101, 101),
+        grid_limits=(
+            (0.0, 10_000),
+            (-50_000.0, 50_000.0),
+            (-50_000, 50_000.0),
+        ),
+    )
+
+More end-to-end examples are in the example gallery:
+
+- :ref:`sphx_glr_examples_xradar_plot_xradar.py`
+- :ref:`sphx_glr_examples_xradar_plot_grid_xradar.py`
+- :ref:`sphx_glr_examples_xradar_plot_dealias_xradar.py`
+- :ref:`sphx_glr_examples_xradar_plot_rhi_xradar.py`
+
+See also :ref:`pyart_2_0` for the rest of the Py-ART 2.0 API changes, and
+:ref:`overview` for how the ``Radar``/xradar data models compare.

--- a/examples/xradar/plot_dealias_xradar.py
+++ b/examples/xradar/plot_dealias_xradar.py
@@ -10,7 +10,6 @@ An example which uses xradar and Py-ART to dealias radial velocities.
 # Author: Max Grover (mgrover@anl.gov)
 # License: BSD 3 clause
 
-
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import xradar as xd
@@ -24,6 +23,11 @@ tree = xd.io.open_cfradial1_datatree(filename)
 
 # Give the tree Py-ART radar methods
 radar = tree.pyart.to_radar()
+
+# Inspect the resulting object -- it behaves like a Py-ART Radar object, and
+# its fields are numpy masked arrays, so algorithms like the region-based
+# dealiasing routine below work with it directly
+radar.info("compact")
 
 # Determine the nyquist velocity using the maximum radial velocity from the first sweep
 nyq = radar["sweep_0"]["mean_doppler_velocity"].max().values

--- a/examples/xradar/plot_grid_xradar.py
+++ b/examples/xradar/plot_grid_xradar.py
@@ -10,7 +10,6 @@ An example which uses xradar and Py-ART to grid a PPI file.
 # Author: Max Grover (mgrover@anl.gov)
 # License: BSD 3 clause
 
-
 import xradar as xd
 
 import pyart
@@ -22,6 +21,10 @@ tree = xd.io.open_cfradial1_datatree(filename)
 
 # Give the tree Py-ART radar methods
 radar = tree.pyart.to_radar()
+
+# Inspect the resulting object -- fields on an Xradar-wrapped radar are
+# numpy masked arrays, same as a Radar object
+radar.info("compact")
 
 # Grid using 11 vertical levels, and 101 horizontal grid cells at a resolution on 1 km
 grid = pyart.map.grid_from_radars(

--- a/examples/xradar/plot_rhi_xradar.py
+++ b/examples/xradar/plot_rhi_xradar.py
@@ -1,0 +1,83 @@
+"""
+====================================
+Plot an RHI Using Xradar and Py-ART
+====================================
+
+An example which uses xradar and Py-ART to create a range height indicator
+(RHI) plot and run a Py-ART algorithm on an RHI volume wrapped by ``Xradar``.
+
+Since ``open_radar_data`` does not currently ship an RHI file that reads
+cleanly through xradar/Py-ART, this example builds a synthetic RHI volume
+with :func:`pyart.testing.make_empty_rhi_radar`, round-trips it through
+CfRadial to obtain an xradar ``DataTree``, and wraps it with ``Xradar``.
+
+"""
+
+# Author: Py-ART developers
+# License: BSD 3 clause
+
+import tempfile
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xradar as xd
+
+import pyart
+
+# Build a synthetic RHI Radar object and add a reflectivity field
+radar = pyart.testing.make_empty_rhi_radar(ngates=100, rays_per_sweep=40, nsweeps=3)
+nrays = 40 * 3
+ramp = np.linspace(0, 4 * np.pi, nrays)[:, None]
+data = (20 + 15 * np.sin(ramp) * np.ones((nrays, 100))).astype("float32")
+data = np.ma.masked_array(data, mask=False)
+# Mask the far gates on every ray so despeckle_field has real gaps to work with
+data.mask[:, -5:] = True
+radar.fields = {"reflectivity": pyart.config.get_metadata("reflectivity")}
+radar.fields["reflectivity"]["data"] = data
+radar.fields["reflectivity"]["_FillValue"] = pyart.config.get_fillvalue()
+
+# Write to CfRadial and read it back in with xradar, since there is no direct
+# in-memory Radar -> DataTree conversion
+with tempfile.TemporaryDirectory() as tmp_dir:
+    filename = str(Path(tmp_dir) / "synthetic_rhi.nc")
+    pyart.io.write_cfradial(filename, radar)
+    tree = xd.io.open_cfradial1_datatree(filename)
+
+# Give the tree Py-ART radar methods
+rhi = tree.pyart.to_radar(scan_type="rhi")
+
+# Fields on an Xradar-wrapped radar are numpy masked arrays, just like Radar
+print(type(rhi.fields["reflectivity"]["data"]))
+
+# ``info`` works the same as it does on a Radar object
+rhi.info("compact")
+
+##########################################
+# **Run an algorithm on the RHI volume**
+# Despeckle the reflectivity field to remove small, isolated regions of data.
+# Any Py-ART algorithm accepting a ``Radar`` also accepts an ``Xradar``
+# instance directly -- use :func:`pyart.xradar.to_pyart_radar` only when a
+# function needs the coercion made explicit.
+gatefilter = pyart.correct.despeckle_field(rhi, "reflectivity", size=10)
+
+# Plot the RHI, before and after despeckling
+display = pyart.graph.RadarDisplay(rhi)
+fig = plt.figure(figsize=(10, 4))
+
+ax1 = fig.add_subplot(121)
+display.plot_rhi(
+    "reflectivity", 0, vmin=-8, vmax=64, cmap="ChaseSpectral", ax=ax1, title="Raw"
+)
+
+ax2 = fig.add_subplot(122)
+display.plot_rhi(
+    "reflectivity",
+    0,
+    vmin=-8,
+    vmax=64,
+    cmap="ChaseSpectral",
+    gatefilter=gatefilter,
+    ax=ax2,
+    title="Despeckled",
+)

--- a/examples/xradar/plot_xradar.py
+++ b/examples/xradar/plot_xradar.py
@@ -10,7 +10,6 @@ An example which uses xradar and Py-ART to create a PPI plot of a Cfradial file.
 # Author: Max Grover (mgrover@anl.gov)
 # License: BSD 3 clause
 
-
 import xradar as xd
 
 import pyart
@@ -23,8 +22,15 @@ tree = xd.io.open_cfradial1_datatree(filename)
 # Give the tree Py-ART radar methods
 radar = tree.pyart.to_radar()
 
+# Inspect the resulting object -- it behaves like a Py-ART Radar, and its
+# fields are numpy masked arrays just like a Radar read directly from disk
+radar.info("compact")
+
 # Plot the Reflectivity Field (corrected_reflectivity_horizontal)
 display = pyart.graph.RadarMapDisplay(radar)
 display.plot_ppi(
     "corrected_reflectivity_horizontal", cmap="ChaseSpectral", vmin=-20, vmax=70
 )
+
+# If a function needs a "plain" pyart.core.Radar instead of this Xradar
+# wrapper, use pyart.xradar.to_pyart_radar to coerce it explicitly.


### PR DESCRIPTION
Closes #1778 (docs restructure for the xradar-first IO path). Best merged after #1873, whose features it documents.

- New `doc/source/userguide/xradar_integration.rst`: which IO path to use today, a supported-API table for `Xradar`/`Xgrid` with caveats, and the reader-migration direction from roadmap Moderate-Priority #1; `pyart_2_0.rst` and `overview.rst` deduplicated/updated; toctree wired.
- `pyart.xradar` added to the API reference (`doc/source/API/index.rst`) with an autosummary-ready module docstring.
- Gallery: the three existing `examples/xradar/` scripts updated (`radar.info`, masked-array notes); new `plot_rhi_xradar.py` demonstrating RHI end to end (synthetic data, labeled as such).

Validation: every code snippet and example executed locally (all exit 0); docutils structural check clean; full sphinx-gallery build left to the docs CI job.
